### PR TITLE
chore(backend): remove outgoing payment approval

### DIFF
--- a/docs/transaction-api.md
+++ b/docs/transaction-api.md
@@ -24,7 +24,7 @@ After the quote ends and state advances, the lock on the payment is released.
 
 ### Authorization
 
-After quoting completes, Rafiki notifies the wallet operator to add `maxSourceAmount` of the quote from the funding wallet account owned by the payer to the payment, reserving the maximum requisite funds for the payment.
+After quoting completes, Rafiki notifies the wallet operator to add `maxSourceAmount` of the quote from the funding wallet account owned by the payer to the payment, reserving the maximum requisite funds for the payment attempt.
 
 If the payment intent did not specify `autoApprove` of `true`, a client should manually approve the payment, based on the parameters of the quote, before the wallet adds payment liquidity.
 

--- a/docs/transaction-api.md
+++ b/docs/transaction-api.md
@@ -4,43 +4,41 @@
 
 ### Payment creation
 
-A user creates a payment by passing a `PaymentIntent` to `Mutation.createOutgoingPayment`. If the payment destination (the payment pointer or invoice URL) is successfully resolved, the payment is created in the `Inactive` state.
+A user creates a payment by passing a `PaymentIntent` to `Mutation.createOutgoingPayment`. If the payment destination (the payment pointer or invoice URL) is successfully resolved, the payment is created in the `Quoting` state.
 
 If the payment destination cannot be resolved, no payment is created and the query returns an error.
 
 ### Quoting
 
-To begin a payment attempt, an instance acquires a lock to setup and quote the payment, advancing it from `Inactive` to the `Ready` state.
+To begin a payment attempt, an instance acquires a lock to setup and quote the payment, advancing it from `Quoting` to the `Funding` state.
 
 First, the recipient Open Payments account or invoice is resolved. Then, the STREAM sender quotes the payment to probe the exchange rate, compute a minimum rate, and discover the path maximum packet amount.
 
 Quotes can end in 3 states:
 
-1. Success. The STREAM sender successfully established a connection to the recipient, and discovered rates and the path capacity. This advances the state to `Ready`. The parameters of the quote are persisted so they may be resumed if the payment is approved. Rafiki also assigns a deadline based on the expected validity of its slippage parameters for the user to authorize the payment.
+1. Success. The STREAM sender successfully established a connection to the recipient, and discovered rates and the path capacity. This advances the state to `Funding`. The parameters of the quote are persisted so they may be resumed if the payment is funded. Rafiki also assigns a deadline based on the expected validity of its slippage parameters for the wallet to fund the payment.
 2. Irrevocable failure. In cases such as if the payment pointer or account URL was semantically invalid, the invoice was already paid, a terminal ILP Reject was encountered, or the rate was insufficient, the payment is unlikely to ever succeed, or requires some manual intervention. These cases advance the state to `Cancelled`.
-3. Recoverable failure. In the case of some transient errors, such as if the Open Payments HTTP query failed, the quote couldn't complete within the timeout, or no external exchange rate was available, Rafiki may elect to automatically retry the quote. This returns the state to `Inactive`, but internally tracks that the quote failed and when to schedule another attempt.
+3. Recoverable failure. In the case of some transient errors, such as if the Open Payments HTTP query failed, the quote couldn't complete within the timeout, or no external exchange rate was available, Rafiki may elect to automatically retry the quote. This returns the state to `Quoting`, but internally tracks that the quote failed and when to schedule another attempt.
 
 After the quote ends and state advances, the lock on the payment is released.
 
 ### Authorization
 
-If the payment intent did not specify `autoApprove` of `true`, a client must manually approve the payment, based on the parameters of the quote, before Rafiki may execute it.
+After quoting completes, Rafiki notifies the wallet operator to add `maxSourceAmount` of the quote from the funding wallet account owned by the payer to the payment, reserving the maximum requisite funds for the payment.
+
+If the payment intent did not specify `autoApprove` of `true`, a client should manually approve the payment, based on the parameters of the quote, before the wallet adds payment liquidity.
 
 This step is necessary so the end user can precisely know the maximum amount of source units that will leave their account. Typically, the payment application will present these parameters in the user interface before the user elects to approve the payment. This step is particularly important for invoices, to prevent an unbounded sum from leaving the user's account. During this step, the user may also be presented with additional information about the payment, such as details of the payment recipient, or how much is expected to be delivered.
 
 Authorization ends in two possible states:
 
-1. Approval. If the user approves the payment before its approval deadline, or `autoApprove` was `true`, the state advances to `Funding`.
+1. Approval. If the user approves the payment before its funding deadline, or `autoApprove` was `true`, the wallet funds the payment and the state advances to `Sending`.
 
-   In this case, Rafiki creates a new Interledger account.
-
-   Then, Rafiki notifies the wallet operator to transfer `maxSourceAmount` of the quote from the funding account owned by the payer to the new account, reserving the maximum requisite funds for the payment.
-
-2. Cancellation. If the user explicitly cancels the quote, or the approval deadline is exceeded, the state advances to `Cancelled`. In the latter case, too much time has elapsed for the enforced exchange rate to remain accurate.
+2. Cancellation. If the user explicitly cancels the quote, or the funding deadline is exceeded, the state advances to `Cancelled`. In the latter case, too much time has elapsed for the enforced exchange rate to remain accurate.
 
 ### Payment execution
 
-An instance acquires a lock on a payment with an `Funding` state and advances it to `Sending`. The STREAM will use the quote parameters acquired during the `Inactive` state.
+An instance acquires a lock on a payment with a `Funding` state and advances it to `Sending`. The STREAM will use the quote parameters acquired during the `Quoting` state.
 
 The instance connects to the Interledger account it created via ILP-over-HTTP, and sends the payment with STREAM.
 
@@ -68,12 +66,12 @@ A payment in the `Cancelled` state may be explicitly retried ("requoted") by the
 
 The intent must include `invoiceUrl` xor (`paymentPointer` and `amountToSend`).
 
-| Name             | Optional | Type      | Description                                                                                                                                                                                                                                                                                         |
-| :--------------- | :------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `paymentPointer` | Yes      | `String`  | Payment pointer or URL of the destination Open Payments or SPSP account. Requires `amountToSend`.                                                                                                                                                                                                   |
-| `invoiceUrl`     | Yes      | `String`  | URL of an Open Payments invoice, for a fixed-delivery payment.                                                                                                                                                                                                                                      |
-| `amountToSend`   | Yes      | `String`  | Fixed amount to send to the recipient, in base units of the sending asset. Requires `paymentPointer`.                                                                                                                                                                                               |
-| `autoApprove`    | No       | `Boolean` | If `false`, require manual approval after the quote is complete. If `true`, automatically activates and begins execution of the payment after the quote. Note: this should only be used for fixed-source amount payments. Paying invoices without any manual review could send an unbounded amount. |
+| Name             | Optional | Type      | Description                                                                                                                                                                                                                                                                           |
+| :--------------- | :------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `paymentPointer` | Yes      | `String`  | Payment pointer or URL of the destination Open Payments or SPSP account. Requires `amountToSend`.                                                                                                                                                                                     |
+| `invoiceUrl`     | Yes      | `String`  | URL of an Open Payments invoice, for a fixed-delivery payment.                                                                                                                                                                                                                        |
+| `amountToSend`   | Yes      | `String`  | Fixed amount to send to the recipient, in base units of the sending asset. Requires `paymentPointer`.                                                                                                                                                                                 |
+| `autoApprove`    | No       | `Boolean` | If `false`, require manual approval after the quote is complete. If `true`, the wallet may automatically fund the payment after the quote. Note: this should only be used for fixed-source amount payments. Paying invoices without any manual review could send an unbounded amount. |
 
 ### `OutgoingPayment`
 
@@ -110,11 +108,10 @@ The intent must include `invoiceUrl` xor (`paymentPointer` and `amountToSend`).
 
 ### `PaymentState`
 
-- `INACTIVE`: Initial state. In this state, an empty payment account is generated, and the payment is automatically resolved & quoted. On success, transition to `Ready`. On failure, transition to `Cancelled`.
-- `READY`: Awaiting user approval. Approval is automatic if `intent.autoApprove` is set. Once approved, transitions to `Funding`.
-- `FUNDING`: Money from the user's main account is moved to the payment account to reserve it. On success, transition to `Sending`.
+- `QUOTING`: Initial state. In this state, an empty payment account is generated, and the payment is automatically resolved & quoted. On success, transition to `FUNDING`. On failure, transition to `Cancelled`.
+- `FUNDING`: Awaiting the wallet to add payment liquidity. If `intent.autoApprove` is not set, the wallet gets user approval before reserving money from the user's wallet account. On success, transition to `Sending`.
 - `SENDING`: Stream payment from the payment account to the destination.
-- `CANCELLED`: The payment failed. (Though some money may have been delivered). Requoting transitions to `Inactive`.
+- `CANCELLED`: The payment failed. (Though some money may have been delivered). Requoting transitions to `Quoting`.
 - `COMPLETED`: Successful completion.
 
 ### `PaymentType`

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1486,39 +1486,6 @@
             "deprecationReason": null
           },
           {
-            "name": "approveOutgoingPayment",
-            "description": "Approve a Ready payment's quote.",
-            "args": [
-              {
-                "name": "paymentId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "OutgoingPaymentResponse",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "requoteOutgoingPayment",
             "description": "Requote a Cancelled payment.",
             "args": [
@@ -1553,7 +1520,7 @@
           },
           {
             "name": "cancelOutgoingPayment",
-            "description": "Cancel a Ready payment.",
+            "description": "Cancel a Funding payment.",
             "args": [
               {
                 "name": "paymentId",
@@ -2773,14 +2740,8 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "INACTIVE",
-            "description": "Will transition to READY when quote is complete",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "READY",
-            "description": "Quote ready; awaiting user approval (FUNDING) or refusal (CANCELLED)",
+            "name": "QUOTING",
+            "description": "Will transition to FUNDING when quote is complete",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -2798,7 +2759,7 @@
           },
           {
             "name": "CANCELLED",
-            "description": "Payment aborted; can be requoted to INACTIVE",
+            "description": "Payment aborted; can be requoted to QUOTING",
             "isDeprecated": false,
             "deprecationReason": null
           },

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -197,11 +197,9 @@ export type LiquidityMutationResponse = MutationResponse & {
 export type Mutation = {
   __typename?: 'Mutation';
   createOutgoingPayment: OutgoingPaymentResponse;
-  /** Approve a Ready payment's quote. */
-  approveOutgoingPayment: OutgoingPaymentResponse;
   /** Requote a Cancelled payment. */
   requoteOutgoingPayment: OutgoingPaymentResponse;
-  /** Cancel a Ready payment. */
+  /** Cancel a Funding payment. */
   cancelOutgoingPayment: OutgoingPaymentResponse;
   createAccount: CreateAccountMutationResponse;
   /** Create peer */
@@ -229,11 +227,6 @@ export type Mutation = {
 
 export type MutationCreateOutgoingPaymentArgs = {
   input: CreateOutgoingPaymentInput;
-};
-
-
-export type MutationApproveOutgoingPaymentArgs = {
-  paymentId: Scalars['String'];
 };
 
 
@@ -391,15 +384,13 @@ export type PaymentQuote = {
 };
 
 export enum PaymentState {
-  /** Will transition to READY when quote is complete */
-  Inactive = 'INACTIVE',
-  /** Quote ready; awaiting user approval (FUNDING) or refusal (CANCELLED) */
-  Ready = 'READY',
+  /** Will transition to FUNDING when quote is complete */
+  Quoting = 'QUOTING',
   /** Will transition to SENDING once payment funds are reserved */
   Funding = 'FUNDING',
   /** Paying, will transition to COMPLETED on success */
   Sending = 'SENDING',
-  /** Payment aborted; can be requoted to INACTIVE */
+  /** Payment aborted; can be requoted to QUOTING */
   Cancelled = 'CANCELLED',
   /** Successfuly completion */
   Completed = 'COMPLETED'
@@ -746,7 +737,6 @@ export type LiquidityMutationResponseResolvers<ContextType = any, ParentType ext
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCreateOutgoingPaymentArgs, 'input'>>;
-  approveOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationApproveOutgoingPaymentArgs, 'paymentId'>>;
   requoteOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationRequoteOutgoingPaymentArgs, 'paymentId'>>;
   cancelOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCancelOutgoingPaymentArgs, 'paymentId'>>;
   createAccount?: Resolver<ResolversTypes['CreateAccountMutationResponse'], ParentType, ContextType, RequireFields<MutationCreateAccountArgs, 'input'>>;

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -4,7 +4,6 @@ import { getAccountInvoices, getPageInfo } from './invoice'
 import {
   getOutgoingPayment,
   createOutgoingPayment,
-  approveOutgoingPayment,
   requoteOutgoingPayment,
   cancelOutgoingPayment,
   getOutcome,
@@ -56,7 +55,6 @@ export const resolvers: Resolvers = {
   Mutation: {
     createAccount,
     createOutgoingPayment,
-    approveOutgoingPayment,
     requoteOutgoingPayment,
     cancelOutgoingPayment,
     createPeer: createPeer,

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -84,7 +84,7 @@ describe('OutgoingPayment Resolvers', (): void => {
         asset: randomAsset()
       })
       payment = await OutgoingPaymentModel.query(knex).insertAndFetch({
-        state: PaymentState.Inactive,
+        state: PaymentState.Quoting,
         intent: {
           paymentPointer: 'http://wallet2.example/paymentpointer/bob',
           amountToSend: BigInt(123),
@@ -288,7 +288,7 @@ describe('OutgoingPayment Resolvers', (): void => {
       expect(query.code).toBe('200')
       expect(query.success).toBe(true)
       expect(query.payment?.id).toBe(payment.id)
-      expect(query.payment?.state).toBe(SchemaPaymentState.Inactive)
+      expect(query.payment?.state).toBe(SchemaPaymentState.Quoting)
     })
 
     test('400', async (): Promise<void> => {
@@ -430,74 +430,6 @@ describe('OutgoingPayment Resolvers', (): void => {
     })
   })
 
-  describe(`Mutation.approveOutgoingPayment`, (): void => {
-    test('200', async (): Promise<void> => {
-      const spy = jest
-        .spyOn(outgoingPaymentService, 'approve')
-        .mockImplementation(async (id: string) => {
-          expect(id).toBe(payment.id)
-          return payment
-        })
-      const query = await appContainer.apolloClient
-        .query({
-          query: gql`
-            mutation ApproveOutgoingPayment($paymentId: String!) {
-              approveOutgoingPayment(paymentId: $paymentId) {
-                code
-                success
-                message
-                payment {
-                  id
-                }
-              }
-            }
-          `,
-          variables: { paymentId: payment.id }
-        })
-        .then(
-          (query): OutgoingPaymentResponse => query.data?.approveOutgoingPayment
-        )
-      expect(spy).toHaveBeenCalledTimes(1)
-      expect(query.code).toBe('200')
-      expect(query.success).toBe(true)
-      expect(query.message).toBeNull()
-      expect(query.payment?.id).toBe(payment.id)
-    })
-
-    test('500', async (): Promise<void> => {
-      const spy = jest
-        .spyOn(outgoingPaymentService, 'approve')
-        .mockImplementation(async (id: string) => {
-          expect(id).toBe(payment.id)
-          throw new Error('fail')
-        })
-      const query = await appContainer.apolloClient
-        .query({
-          query: gql`
-            mutation ApproveOutgoingPayment($paymentId: String!) {
-              approveOutgoingPayment(paymentId: $paymentId) {
-                code
-                success
-                message
-                payment {
-                  id
-                }
-              }
-            }
-          `,
-          variables: { paymentId: payment.id }
-        })
-        .then(
-          (query): OutgoingPaymentResponse => query.data?.approveOutgoingPayment
-        )
-      expect(spy).toHaveBeenCalledTimes(1)
-      expect(query.code).toBe('500')
-      expect(query.success).toBe(false)
-      expect(query.message).toBe('fail')
-      expect(query.payment).toBeNull()
-    })
-  })
-
   describe(`Mutation.cancelOutgoingPayment`, (): void => {
     test('200', async (): Promise<void> => {
       const spy = jest
@@ -580,7 +512,7 @@ describe('OutgoingPayment Resolvers', (): void => {
         for (let i = 0; i < 50; i++) {
           outgoingPayments.push(
             await OutgoingPaymentModel.query(knex).insertAndFetch({
-              state: PaymentState.Inactive,
+              state: PaymentState.Quoting,
               intent: {
                 paymentPointer: 'http://wallet2.example/paymentpointer/bob',
                 amountToSend: BigInt(123),

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -119,28 +119,6 @@ export const requoteOutgoingPayment: MutationResolvers<ApolloContext>['requoteOu
     }))
 }
 
-export const approveOutgoingPayment: MutationResolvers<ApolloContext>['approveOutgoingPayment'] = async (
-  parent,
-  args,
-  ctx
-): ResolversTypes['OutgoingPaymentResponse'] => {
-  const outgoingPaymentService = await ctx.container.use(
-    'outgoingPaymentService'
-  )
-  return outgoingPaymentService
-    .approve(args.paymentId)
-    .then((payment: OutgoingPayment) => ({
-      code: '200',
-      success: true,
-      payment: paymentToGraphql(payment)
-    }))
-    .catch((err: Error) => ({
-      code: '500',
-      success: false,
-      message: err.message
-    }))
-}
-
 export const cancelOutgoingPayment: MutationResolvers<ApolloContext>['cancelOutgoingPayment'] = async (
   parent,
   args,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -22,11 +22,9 @@ type Mutation {
   createOutgoingPayment(
     input: CreateOutgoingPaymentInput!
   ): OutgoingPaymentResponse!
-  "Approve a Ready payment's quote."
-  approveOutgoingPayment(paymentId: String!): OutgoingPaymentResponse!
   "Requote a Cancelled payment."
   requoteOutgoingPayment(paymentId: String!): OutgoingPaymentResponse!
-  "Cancel a Ready payment."
+  "Cancel a Funding payment."
   cancelOutgoingPayment(paymentId: String!): OutgoingPaymentResponse!
 
   createAccount(input: CreateAccountInput!): CreateAccountMutationResponse!
@@ -277,15 +275,13 @@ type PaymentIntent {
 }
 
 enum PaymentState {
-  "Will transition to READY when quote is complete"
-  INACTIVE
-  "Quote ready; awaiting user approval (FUNDING) or refusal (CANCELLED)"
-  READY
+  "Will transition to FUNDING when quote is complete"
+  QUOTING
   "Will transition to SENDING once payment funds are reserved"
   FUNDING
   "Paying, will transition to COMPLETED on success"
   SENDING
-  "Payment aborted; can be requoted to INACTIVE"
+  "Payment aborted; can be requoted to QUOTING"
   CANCELLED
   "Successfuly completion"
   COMPLETED

--- a/packages/backend/src/outgoing_payment/model.ts
+++ b/packages/backend/src/outgoing_payment/model.ts
@@ -125,12 +125,9 @@ export class OutgoingPayment extends BaseModel {
 
 export enum PaymentState {
   // Initial state. In this state, an empty trustline account is generated, and the payment is automatically resolved & quoted.
-  // On success, transition to `Ready`.
+  // On success, transition to `Funding`.
   // On failure, transition to `Cancelled`.
-  Inactive = 'Inactive',
-  // Awaiting user approval. Approval is automatic if `intent.autoApprove` is set.
-  // Once approved, transitions to `Funding`.
-  Ready = 'Ready',
+  Quoting = 'Quoting',
   // Awaiting money from the user's wallet account to be deposited to the payment account to reserve it for the payment.
   // On success, transition to `Sending`.
   Funding = 'Funding',
@@ -139,7 +136,7 @@ export enum PaymentState {
   Sending = 'Sending',
 
   // The payment failed. (Though some money may have been delivered).
-  // Requoting transitions to `Inactive`.
+  // Requoting transitions to `Quoting`.
   Cancelled = 'Cancelled',
   // Successful completion.
   Completed = 'Completed'


### PR DESCRIPTION

<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Remove outgoing payment approval step. It was previous necessary when Rafiki would auto reserve in-Rafiki user funds for an outgoing payment. Now the wallet can get user approval for fixed delivery payment before adding payment liquidity (TBD #190).
- Remove Ready payment state.
- Change Inactive payment state to Quoting.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- Related to #156 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
