### PR TITLE
chore(backend): use asset id as liquidity account id

### DIFF
--- a/packages/backend/src/accounting/accounts.ts
+++ b/packages/backend/src/accounting/accounts.ts
@@ -6,7 +6,7 @@ import {
 
 import { ServiceDependencies } from './service'
 import { CreateAccountError } from './errors'
-import { AccountIdOptions, getAccountId } from './utils'
+import { AccountId, toTigerbeetleId } from './utils'
 
 const ACCOUNT_RESERVED = Buffer.alloc(48)
 
@@ -20,7 +20,8 @@ export enum AccountType {
   Debit = 'Debit' // credits_must_not_exceed_debits
 }
 
-export type CreateAccountOptions = AccountIdOptions & {
+export interface CreateAccountOptions {
+  id: AccountId
   type: AccountType
   unit: number
 }
@@ -31,7 +32,7 @@ export async function createAccounts(
 ): Promise<void> {
   const errors = await deps.tigerbeetle.createAccounts(
     accounts.map((account) => ({
-      id: getAccountId(account),
+      id: toTigerbeetleId(account.id),
       user_data: BigInt(0),
       reserved: ACCOUNT_RESERVED,
       unit: account.unit,
@@ -56,10 +57,10 @@ export async function createAccounts(
 
 export async function getAccounts(
   deps: ServiceDependencies,
-  accounts: AccountIdOptions[]
+  accountIds: AccountId[]
 ): Promise<Account[]> {
   return await deps.tigerbeetle.lookupAccounts(
-    accounts.map((account) => getAccountId(account))
+    accountIds.map((id) => toTigerbeetleId(id))
   )
 }
 

--- a/packages/backend/src/accounting/errors.ts
+++ b/packages/backend/src/accounting/errors.ts
@@ -3,7 +3,7 @@ import {
   CreateTransferError as CreateTransferErrorCode
 } from 'tigerbeetle-node'
 
-import { AccountIdOptions } from './utils'
+import { AccountId } from './utils'
 
 export class CreateAccountError extends Error {
   constructor(public code: number) {
@@ -57,8 +57,8 @@ export class BalanceTransferError extends Error {
 }
 
 export class UnknownAccountError extends Error {
-  constructor(account: AccountIdOptions) {
-    super('Account not found. account=' + JSON.stringify(account))
+  constructor(accountId: AccountId) {
+    super('Account not found. account=' + accountId)
     this.name = 'UnknownAccountError'
   }
 }

--- a/packages/backend/src/accounting/service.test.ts
+++ b/packages/backend/src/accounting/service.test.ts
@@ -5,12 +5,7 @@ import { StartedTestContainer } from 'testcontainers'
 import { CreateAccountError as CreateTbAccountError } from 'tigerbeetle-node'
 import { v4 as uuid } from 'uuid'
 
-import {
-  AccountingService,
-  AccountOptions,
-  Deposit,
-  Withdrawal
-} from './service'
+import { AccountingService, Account, Deposit, Withdrawal } from './service'
 import { CreateAccountError, TransferError, isTransferError } from './errors'
 import { createTestApp, TestContainer } from '../tests/app'
 import { resetGraphileDb } from '../tests/graphileDb'
@@ -82,18 +77,16 @@ describe('Accounting Service', (): void => {
 
   describe('Create Account', (): void => {
     test('Can create an account', async (): Promise<void> => {
-      const options: AccountOptions = {
+      const account: Account = {
         id: uuid(),
         asset: {
           id: uuid(),
           unit: newUnit()
         }
       }
-      const account = await accountingService.createAccount(options)
-      expect(account).toEqual({
-        ...options,
-        balance: BigInt(0)
-      })
+      await expect(accountingService.createAccount(account)).resolves.toEqual(
+        account
+      )
       await expect(accountingService.getBalance(account.id)).resolves.toEqual(
         BigInt(0)
       )
@@ -216,7 +209,7 @@ describe('Accounting Service', (): void => {
       ${true}   | ${'same asset'}
       ${false}  | ${'cross-currency'}
     `('$description', ({ sameAsset }): void => {
-      let sourceAccount: AccountOptions
+      let sourceAccount: Account
       let destinationAccount: FactoryAccount
       const startingSourceBalance = BigInt(10)
       const startingDestinationLiquidity = BigInt(100)

--- a/packages/backend/src/accounting/service.test.ts
+++ b/packages/backend/src/accounting/service.test.ts
@@ -24,7 +24,7 @@ import {
   startTigerbeetleContainer,
   TIGERBEETLE_PORT
 } from '../tests/tigerbeetle'
-import { AccountFactory } from '../tests/accountFactory'
+import { AccountFactory, FactoryAccount } from '../tests/accountFactory'
 
 describe('Accounting Service', (): void => {
   let deps: IocContract<AppServices>
@@ -85,6 +85,7 @@ describe('Accounting Service', (): void => {
       const options: AccountOptions = {
         id: uuid(),
         asset: {
+          id: uuid(),
           unit: newUnit()
         }
       }
@@ -93,8 +94,8 @@ describe('Accounting Service', (): void => {
         ...options,
         balance: BigInt(0)
       })
-      await expect(accountingService.getAccount(account.id)).resolves.toEqual(
-        account
+      await expect(accountingService.getBalance(account.id)).resolves.toEqual(
+        BigInt(0)
       )
     })
 
@@ -103,6 +104,7 @@ describe('Accounting Service', (): void => {
         accountingService.createAccount({
           id: 'not a uuid',
           asset: {
+            id: uuid(),
             unit: newUnit()
           }
         })
@@ -122,27 +124,13 @@ describe('Accounting Service', (): void => {
         accountingService.createAccount({
           id: uuid(),
           asset: {
+            id: uuid(),
             unit: newUnit()
           }
         })
       ).rejects.toThrowError(
         new CreateAccountError(CreateTbAccountError.exists_with_different_unit)
       )
-    })
-  })
-
-  describe('Get Account', (): void => {
-    test('Can get an account', async (): Promise<void> => {
-      const account = await accountFactory.build()
-      await expect(accountingService.getAccount(account.id)).resolves.toEqual(
-        account
-      )
-    })
-
-    test('Returns undefined for nonexistent account', async (): Promise<void> => {
-      await expect(
-        accountingService.getAccount(uuid())
-      ).resolves.toBeUndefined()
     })
   })
 
@@ -190,56 +178,34 @@ describe('Accounting Service', (): void => {
     })
   })
 
-  describe('Create Asset Accounts', (): void => {
-    test("Can create an asset's accounts", async (): Promise<void> => {
+  describe('Create Settlement Account', (): void => {
+    test("Can create an asset's settlement account", async (): Promise<void> => {
       const unit = newUnit()
 
       await expect(
-        accountingService.getAssetLiquidityBalance(unit)
-      ).resolves.toBeUndefined()
-      await expect(
-        accountingService.getAssetSettlementBalance(unit)
+        accountingService.getSettlementBalance(unit)
       ).resolves.toBeUndefined()
 
-      await accountingService.createAssetAccounts(unit)
+      await accountingService.createSettlementAccount(unit)
 
       await expect(
-        accountingService.getAssetLiquidityBalance(unit)
-      ).resolves.toEqual(BigInt(0))
-      await expect(
-        accountingService.getAssetSettlementBalance(unit)
+        accountingService.getSettlementBalance(unit)
       ).resolves.toEqual(BigInt(0))
     })
   })
 
-  describe('Get Asset Liquidity Balance', (): void => {
-    test("Can retrieve an asset liquidity' balance", async (): Promise<void> => {
+  describe('Get Settlement Balance', (): void => {
+    test("Can retrieve an asset's settlement account balance", async (): Promise<void> => {
       const unit = newUnit()
-      await accountingService.createAssetAccounts(unit)
+      await accountingService.createSettlementAccount(unit)
       await expect(
-        accountingService.getAssetLiquidityBalance(unit)
+        accountingService.getSettlementBalance(unit)
       ).resolves.toEqual(BigInt(0))
     })
 
     test('Returns undefined for nonexistent account', async (): Promise<void> => {
       await expect(
-        accountingService.getAssetLiquidityBalance(newUnit())
-      ).resolves.toBeUndefined()
-    })
-  })
-
-  describe('Get Asset Settlement Balance', (): void => {
-    test("Can retrieve an asset accounts' balance", async (): Promise<void> => {
-      const unit = newUnit()
-      await accountingService.createAssetAccounts(unit)
-      await expect(
-        accountingService.getAssetSettlementBalance(unit)
-      ).resolves.toEqual(BigInt(0))
-    })
-
-    test('Returns undefined for nonexistent account', async (): Promise<void> => {
-      await expect(
-        accountingService.getAssetSettlementBalance(newUnit())
+        accountingService.getSettlementBalance(newUnit())
       ).resolves.toBeUndefined()
     })
   })
@@ -251,7 +217,7 @@ describe('Accounting Service', (): void => {
       ${false}  | ${'cross-currency'}
     `('$description', ({ sameAsset }): void => {
       let sourceAccount: AccountOptions
-      let destinationAccount: AccountOptions
+      let destinationAccount: FactoryAccount
       const startingSourceBalance = BigInt(10)
       const startingDestinationLiquidity = BigInt(100)
 
@@ -266,9 +232,7 @@ describe('Accounting Service', (): void => {
           await expect(
             accountingService.createDeposit({
               id: uuid(),
-              asset: {
-                unit: destinationAccount.asset.unit
-              },
+              account: destinationAccount.asset,
               amount: startingDestinationLiquidity
             })
           ).resolves.toBeUndefined()
@@ -304,9 +268,7 @@ describe('Accounting Service', (): void => {
 
             if (sameAsset) {
               await expect(
-                accountingService.getAssetLiquidityBalance(
-                  sourceAccount.asset.unit
-                )
+                accountingService.getBalance(sourceAccount.asset.id)
               ).resolves.toEqual(
                 sourceAmount < destinationAmount
                   ? startingDestinationLiquidity - amountDiff
@@ -314,15 +276,11 @@ describe('Accounting Service', (): void => {
               )
             } else {
               await expect(
-                accountingService.getAssetLiquidityBalance(
-                  sourceAccount.asset.unit
-                )
+                accountingService.getBalance(sourceAccount.asset.id)
               ).resolves.toEqual(BigInt(0))
 
               await expect(
-                accountingService.getAssetLiquidityBalance(
-                  destinationAccount.asset.unit
-                )
+                accountingService.getBalance(destinationAccount.asset.id)
               ).resolves.toEqual(
                 startingDestinationLiquidity - destinationAmount
               )
@@ -348,9 +306,7 @@ describe('Accounting Service', (): void => {
 
             if (sameAsset) {
               await expect(
-                accountingService.getAssetLiquidityBalance(
-                  sourceAccount.asset.unit
-                )
+                accountingService.getBalance(sourceAccount.asset.id)
               ).resolves.toEqual(
                 commit
                   ? startingDestinationLiquidity - amountDiff
@@ -358,15 +314,11 @@ describe('Accounting Service', (): void => {
               )
             } else {
               await expect(
-                accountingService.getAssetLiquidityBalance(
-                  sourceAccount.asset.unit
-                )
+                accountingService.getBalance(sourceAccount.asset.id)
               ).resolves.toEqual(commit ? sourceAmount : BigInt(0))
 
               await expect(
-                accountingService.getAssetLiquidityBalance(
-                  destinationAccount.asset.unit
-                )
+                accountingService.getBalance(destinationAccount.asset.id)
               ).resolves.toEqual(
                 commit
                   ? startingDestinationLiquidity - destinationAmount
@@ -480,41 +432,22 @@ describe('Accounting Service', (): void => {
     })
   })
 
-  describe.each`
-    asset    | description
-    ${true}  | ${'Asset Liquidity'}
-    ${false} | ${'Account'}
-  `(`Create $description Deposit`, (asset): void => {
+  describe('Create deposit', (): void => {
     let deposit: Deposit
-    let unit: number
 
     beforeEach(
       async (): Promise<void> => {
         const account = await accountFactory.build()
-        unit = account.asset.unit
-        const id = uuid()
-        const amount = BigInt(10)
-        if (asset) {
-          deposit = {
-            id,
-            asset: { unit },
-            amount
-          }
-          await expect(
-            accountingService.getAssetLiquidityBalance(unit)
-          ).resolves.toEqual(BigInt(0))
-        } else {
-          deposit = {
-            id,
-            accountId: account.id,
-            amount
-          }
-          await expect(
-            accountingService.getBalance(account.id)
-          ).resolves.toEqual(BigInt(0))
+        deposit = {
+          id: uuid(),
+          account,
+          amount: BigInt(10)
         }
+        await expect(accountingService.getBalance(account.id)).resolves.toEqual(
+          BigInt(0)
+        )
         await expect(
-          accountingService.getAssetSettlementBalance(unit)
+          accountingService.getSettlementBalance(account.asset.unit)
         ).resolves.toEqual(BigInt(0))
       }
     )
@@ -523,17 +456,11 @@ describe('Accounting Service', (): void => {
       await expect(
         accountingService.createDeposit(deposit)
       ).resolves.toBeUndefined()
-      if (deposit.accountId) {
-        await expect(
-          accountingService.getBalance(deposit.accountId)
-        ).resolves.toEqual(deposit.amount)
-      } else {
-        await expect(
-          accountingService.getAssetLiquidityBalance(unit)
-        ).resolves.toEqual(deposit.amount)
-      }
       await expect(
-        accountingService.getAssetSettlementBalance(unit)
+        accountingService.getBalance(deposit.account.id)
+      ).resolves.toEqual(deposit.amount)
+      await expect(
+        accountingService.getSettlementBalance(deposit.account.asset.unit)
       ).resolves.toEqual(deposit.amount)
     })
 
@@ -560,15 +487,9 @@ describe('Accounting Service', (): void => {
     })
 
     test('Cannot deposit to unknown account', async (): Promise<void> => {
-      if (deposit.asset) {
-        deposit.asset.unit = newUnit()
-      } else {
-        deposit.accountId = uuid()
-      }
+      deposit.account.id = uuid()
       await expect(accountingService.createDeposit(deposit)).resolves.toEqual(
-        asset
-          ? TransferError.UnknownSourceAccount
-          : TransferError.UnknownDestinationAccount
+        TransferError.UnknownDestinationAccount
       )
     })
 
@@ -587,52 +508,26 @@ describe('Accounting Service', (): void => {
     })
   })
 
-  describe.each`
-    asset    | description
-    ${true}  | ${'Asset Liquidity'}
-    ${false} | ${'Account'}
-  `(`$description Withdrawal`, (asset): void => {
+  describe('Withdrawal', (): void => {
     let withdrawal: Withdrawal
-    let unit: number
     const startingBalance = BigInt(10)
+
     beforeEach(
       async (): Promise<void> => {
         const account = await accountFactory.build({
-          balance: asset ? BigInt(0) : startingBalance
+          balance: startingBalance
         })
-        unit = account.asset.unit
-        const id = uuid()
-        const amount = BigInt(1)
-        if (asset) {
-          withdrawal = {
-            id,
-            asset: { unit },
-            amount,
-            timeout
-          }
-          await expect(
-            accountingService.createDeposit({
-              id: uuid(),
-              asset: { unit },
-              amount: startingBalance
-            })
-          ).resolves.toBeUndefined()
-          await expect(
-            accountingService.getAssetLiquidityBalance(unit)
-          ).resolves.toEqual(startingBalance)
-        } else {
-          withdrawal = {
-            id,
-            accountId: account.id,
-            amount,
-            timeout
-          }
-          await expect(
-            accountingService.getBalance(account.id)
-          ).resolves.toEqual(startingBalance)
+        withdrawal = {
+          id: uuid(),
+          account,
+          amount: BigInt(1),
+          timeout
         }
+        await expect(accountingService.getBalance(account.id)).resolves.toEqual(
+          startingBalance
+        )
         await expect(
-          accountingService.getAssetSettlementBalance(unit)
+          accountingService.getSettlementBalance(account.asset.unit)
         ).resolves.toEqual(startingBalance)
       }
     )
@@ -642,17 +537,11 @@ describe('Accounting Service', (): void => {
         await expect(
           accountingService.createWithdrawal(withdrawal)
         ).resolves.toBeUndefined()
-        if (withdrawal.accountId) {
-          await expect(
-            accountingService.getBalance(withdrawal.accountId)
-          ).resolves.toEqual(startingBalance - withdrawal.amount)
-        } else {
-          await expect(
-            accountingService.getAssetLiquidityBalance(unit)
-          ).resolves.toEqual(startingBalance - withdrawal.amount)
-        }
         await expect(
-          accountingService.getAssetSettlementBalance(unit)
+          accountingService.getBalance(withdrawal.account.id)
+        ).resolves.toEqual(startingBalance - withdrawal.amount)
+        await expect(
+          accountingService.getSettlementBalance(withdrawal.account.asset.unit)
         ).resolves.toEqual(startingBalance)
       })
 
@@ -679,13 +568,7 @@ describe('Accounting Service', (): void => {
       })
 
       test('Cannot withdraw from unknown account', async (): Promise<void> => {
-        if (withdrawal.accountId) {
-          withdrawal.accountId = uuid()
-        } else {
-          withdrawal.asset = {
-            unit: newUnit()
-          }
-        }
+        withdrawal.account.id = uuid()
         await expect(
           accountingService.createWithdrawal(withdrawal)
         ).resolves.toEqual(TransferError.UnknownSourceAccount)
@@ -726,17 +609,11 @@ describe('Accounting Service', (): void => {
         await expect(
           accountingService.commitWithdrawal(withdrawal.id)
         ).resolves.toBeUndefined()
-        if (withdrawal.accountId) {
-          await expect(
-            accountingService.getBalance(withdrawal.accountId)
-          ).resolves.toEqual(startingBalance - withdrawal.amount)
-        } else {
-          await expect(
-            accountingService.getAssetLiquidityBalance(unit)
-          ).resolves.toEqual(startingBalance - withdrawal.amount)
-        }
         await expect(
-          accountingService.getAssetSettlementBalance(unit)
+          accountingService.getBalance(withdrawal.account.id)
+        ).resolves.toEqual(startingBalance - withdrawal.amount)
+        await expect(
+          accountingService.getSettlementBalance(withdrawal.account.asset.unit)
         ).resolves.toEqual(startingBalance - withdrawal.amount)
       })
 
@@ -799,17 +676,11 @@ describe('Accounting Service', (): void => {
         await expect(
           accountingService.rollbackWithdrawal(withdrawal.id)
         ).resolves.toBeUndefined()
-        if (withdrawal.accountId) {
-          await expect(
-            accountingService.getBalance(withdrawal.accountId)
-          ).resolves.toEqual(startingBalance)
-        } else {
-          await expect(
-            accountingService.getAssetLiquidityBalance(unit)
-          ).resolves.toEqual(startingBalance)
-        }
         await expect(
-          accountingService.getAssetSettlementBalance(unit)
+          accountingService.getBalance(withdrawal.account.id)
+        ).resolves.toEqual(startingBalance)
+        await expect(
+          accountingService.getSettlementBalance(withdrawal.account.asset.unit)
         ).resolves.toEqual(startingBalance)
       })
 

--- a/packages/backend/src/accounting/service.ts
+++ b/packages/backend/src/accounting/service.ts
@@ -25,6 +25,18 @@ import {
 import { BaseService } from '../shared/baseService'
 import { validateId } from '../shared/utils'
 
+// Model classes that have a corresponding Tigerbeetle liquidity
+// account SHOULD implement this Account interface and call
+// createAccount for each model instance.
+// The Tigerbeetle account id will be the model id.
+// Such models include:
+//   ../asset/model
+//   ../open_payments/account/model
+//   ../open_payments/invoice/model
+//   ../outgoing_payment/model
+//   ../peer/model
+// Asset settlement Tigerbeetle accounts are the only exception.
+// Their account id is the corresponding asset's unit value.
 export interface Account {
   id: string
   asset: {

--- a/packages/backend/src/accounting/service.ts
+++ b/packages/backend/src/accounting/service.ts
@@ -27,18 +27,15 @@ import { validateId } from '../shared/utils'
 
 export interface Account {
   id: string
-  balance: bigint
   asset: {
     id: string
     unit: number
   }
 }
 
-export type AccountOptions = Omit<Account, 'balance'>
-
 export interface Deposit {
   id: string
-  account: AccountOptions
+  account: Account
   amount: bigint
 }
 
@@ -47,8 +44,8 @@ export interface Withdrawal extends Deposit {
 }
 
 export interface TransferOptions {
-  sourceAccount: AccountOptions
-  destinationAccount: AccountOptions
+  sourceAccount: Account
+  destinationAccount: Account
   sourceAmount: bigint
   destinationAmount?: bigint
   timeout: bigint // nano-seconds
@@ -60,7 +57,7 @@ export interface Transaction {
 }
 
 export interface AccountingService {
-  createAccount(options: AccountOptions): Promise<Account>
+  createAccount(account: Account): Promise<Account>
   createSettlementAccount(unit: number): Promise<void>
   getBalance(id: string): Promise<bigint | undefined>
   getTotalSent(id: string): Promise<bigint | undefined>
@@ -107,23 +104,20 @@ export function createAccountingService({
 
 export async function createAccount(
   deps: ServiceDependencies,
-  options: AccountOptions
+  account: Account
 ): Promise<Account> {
-  if (!validateId(options.id)) {
+  if (!validateId(account.id)) {
     throw new Error('unable to create account, invalid id')
   }
 
   await createAccounts(deps, [
     {
-      id: options.id,
+      id: account.id,
       type: AccountType.Credit,
-      unit: options.asset.unit
+      unit: account.asset.unit
     }
   ])
-  return {
-    ...options,
-    balance: BigInt(0)
-  }
+  return account
 }
 
 export async function createSettlementAccount(

--- a/packages/backend/src/accounting/transfers.ts
+++ b/packages/backend/src/accounting/transfers.ts
@@ -14,7 +14,7 @@ import {
   TransferError
 } from './errors'
 import { ServiceDependencies } from './service'
-import { AccountIdOptions, getAccountId, uuidToBigInt } from './utils'
+import { AccountId, toTigerbeetleId } from './utils'
 
 const TRANSFER_RESERVED = Buffer.alloc(32)
 
@@ -25,8 +25,8 @@ type TransfersError = {
 
 export interface CreateTransferOptions {
   id?: string
-  sourceAccount: AccountIdOptions
-  destinationAccount: AccountIdOptions
+  sourceAccountId: AccountId
+  destinationAccountId: AccountId
   amount: bigint
   timeout?: bigint // nano-seconds
 }
@@ -49,9 +49,9 @@ export async function createTransfers(
       flags |= TransferFlags.linked
     }
     tbTransfers.push({
-      id: uuidToBigInt(transfers[i].id || uuid()),
-      debit_account_id: getAccountId(transfer.sourceAccount),
-      credit_account_id: getAccountId(transfer.destinationAccount),
+      id: toTigerbeetleId(transfers[i].id || uuid()),
+      debit_account_id: toTigerbeetleId(transfer.sourceAccountId),
+      credit_account_id: toTigerbeetleId(transfer.destinationAccountId),
       amount: transfer.amount,
       user_data: BigInt(0),
       reserved: TRANSFER_RESERVED,
@@ -104,7 +104,7 @@ export async function commitTransfers(
     deps,
     commits: transferIds.map((id, idx) => {
       return {
-        id: uuidToBigInt(id),
+        id: toTigerbeetleId(id),
         flags: idx < transferIds.length - 1 ? 0 | CommitFlags.linked : 0,
         reserved: TRANSFER_RESERVED,
         code: 0,
@@ -123,7 +123,7 @@ export async function rollbackTransfers(
     commits: transferIds.map((id, idx) => {
       const flags = idx < transferIds.length - 1 ? 0 | CommitFlags.linked : 0
       return {
-        id: uuidToBigInt(id),
+        id: toTigerbeetleId(id),
         flags: flags | CommitFlags.reject,
         reserved: TRANSFER_RESERVED,
         code: 0,

--- a/packages/backend/src/accounting/utils.ts
+++ b/packages/backend/src/accounting/utils.ts
@@ -1,40 +1,15 @@
-const ASSET_ACCOUNTS_RESERVED = 8
+import assert from 'assert'
 
-export enum AssetAccount {
-  Liquidity = 1,
-  Settlement
-}
+import { validateId } from '../shared/utils'
 
-export interface AccountId {
-  id: string
-  asset?: {
-    unit: number
-    account?: never
+export type AccountId = string | number
+
+export function toTigerbeetleId(id: AccountId): bigint {
+  if (typeof id === 'number') {
+    return BigInt(id)
   }
-}
-
-interface AssetAccountId {
-  id?: never
-  asset: {
-    unit: number
-    account: AssetAccount
-  }
-}
-
-export type AccountIdOptions = AccountId | AssetAccountId
-
-const isAssetAccount = (o: AccountIdOptions): o is AssetAccountId =>
-  !!o.asset?.account
-
-function getAssetAccountId(unit: number, type: AssetAccount): bigint {
-  return BigInt(unit * ASSET_ACCOUNTS_RESERVED + type)
-}
-
-export function getAccountId(options: AccountIdOptions): bigint {
-  if (isAssetAccount(options)) {
-    return getAssetAccountId(options.asset.unit, options.asset.account)
-  }
-  return uuidToBigInt(options.id)
+  assert.ok(validateId(id))
+  return uuidToBigInt(id)
 }
 
 export function uuidToBigInt(id: string): bigint {

--- a/packages/backend/src/asset/model.ts
+++ b/packages/backend/src/asset/model.ts
@@ -10,4 +10,8 @@ export class Asset extends BaseModel {
 
   // TigerBeetle account 2 byte unit field representing account's asset
   public readonly unit!: number
+
+  public get asset(): Asset {
+    return this
+  }
 }

--- a/packages/backend/src/asset/model.ts
+++ b/packages/backend/src/asset/model.ts
@@ -1,6 +1,7 @@
+import { Account } from '../accounting/service'
 import { BaseModel } from '../shared/baseModel'
 
-export class Asset extends BaseModel {
+export class Asset extends BaseModel implements Account {
   public static get tableName(): string {
     return 'assets'
   }

--- a/packages/backend/src/asset/service.test.ts
+++ b/packages/backend/src/asset/service.test.ts
@@ -84,20 +84,17 @@ describe('Asset Service', (): void => {
       const unit = 1
 
       await expect(
-        accountingService.getAssetLiquidityBalance(unit)
-      ).resolves.toBeUndefined()
-      await expect(
-        accountingService.getAssetSettlementBalance(unit)
+        accountingService.getSettlementBalance(unit)
       ).resolves.toBeUndefined()
 
       const asset = await assetService.getOrCreate(randomAsset())
       expect(asset.unit).toEqual(unit)
 
+      await expect(accountingService.getBalance(asset.id)).resolves.toEqual(
+        BigInt(0)
+      )
       await expect(
-        accountingService.getAssetLiquidityBalance(unit)
-      ).resolves.toEqual(BigInt(0))
-      await expect(
-        accountingService.getAssetSettlementBalance(unit)
+        accountingService.getSettlementBalance(unit)
       ).resolves.toEqual(BigInt(0))
     })
 

--- a/packages/backend/src/asset/service.ts
+++ b/packages/backend/src/asset/service.ts
@@ -65,7 +65,8 @@ async function getOrCreateAsset(
         code,
         scale
       })
-      await deps.accountingService.createAssetAccounts(asset.unit)
+      await deps.accountingService.createAccount(asset)
+      await deps.accountingService.createSettlementAccount(asset.unit)
 
       return asset
     })

--- a/packages/backend/src/connector/core/factories/account.ts
+++ b/packages/backend/src/connector/core/factories/account.ts
@@ -10,7 +10,12 @@ const assetScale = Faker.datatype.number(6)
 
 const accountAttrs = {
   id: Faker.datatype.uuid,
-  asset: { code: assetCode, scale: assetScale, unit: Faker.datatype.number() },
+  asset: {
+    id: Faker.datatype.uuid(),
+    code: assetCode,
+    scale: assetScale,
+    unit: Faker.datatype.number()
+  },
   balance: 0n
 }
 

--- a/packages/backend/src/connector/core/rafiki.ts
+++ b/packages/backend/src/connector/core/rafiki.ts
@@ -14,22 +14,22 @@ import {
 import { createTokenAuthMiddleware } from './middleware'
 import { RatesService } from '../../rates/service'
 import { TransferError } from '../../accounting/errors'
-import { AccountOptions, Transaction } from '../../accounting/service'
+import { Account, Transaction } from '../../accounting/service'
 import { AssetOptions } from '../../asset/service'
 import { AccountService } from '../../open_payments/account/service'
 import { InvoiceService } from '../../open_payments/invoice/service'
 import { PeerService } from '../../peer/service'
 
-type Account = AccountOptions & {
+type RafikiAccount = Account & {
   asset: AssetOptions
 }
 
-export type IncomingAccount = Account & {
+export type IncomingAccount = RafikiAccount & {
   maxPacketAmount?: bigint
   staticIlpAddress?: string
 }
 
-export type OutgoingAccount = Account & {
+export type OutgoingAccount = RafikiAccount & {
   http?: {
     outgoing: {
       authToken: string

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -25,7 +25,7 @@ export const addPeerLiquidity: MutationResolvers<ApolloContext>['addPeerLiquidit
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createDeposit({
       id: args.input.id,
-      accountId: peer.id,
+      account: peer,
       amount: args.input.amount
     })
     if (error) {
@@ -69,9 +69,7 @@ export const addAssetLiquidity: MutationResolvers<ApolloContext>['addAssetLiquid
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createDeposit({
       id: args.input.id,
-      asset: {
-        unit: asset.unit
-      },
+      account: asset,
       amount: args.input.amount
     })
     if (error) {
@@ -115,7 +113,7 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createWithdrawal({
       id: args.input.id,
-      accountId: peer.id,
+      account: peer,
       amount: args.input.amount,
       timeout: BigInt(60e9) // 1 minute
     })
@@ -160,9 +158,7 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createWithdrawal({
       id: args.input.id,
-      asset: {
-        unit: asset.unit
-      },
+      account: asset,
       amount: args.input.amount,
       timeout: BigInt(60e9) // 1 minute
     })
@@ -214,7 +210,7 @@ export const createAccountWithdrawal: MutationResolvers<ApolloContext>['createAc
     }
     const error = await accountingService.createWithdrawal({
       id,
-      accountId: account.id,
+      account: account,
       amount,
       timeout: BigInt(60e9) // 1 minute
     })

--- a/packages/backend/src/open_payments/account/model.ts
+++ b/packages/backend/src/open_payments/account/model.ts
@@ -1,9 +1,10 @@
 import { Model } from 'objection'
 
+import { Account as BaseAccount } from '../../accounting/service'
 import { Asset } from '../../asset/model'
 import { BaseModel } from '../../shared/baseModel'
 
-export class Account extends BaseModel {
+export class Account extends BaseModel implements BaseAccount {
   public static get tableName(): string {
     return 'accounts'
   }

--- a/packages/backend/src/open_payments/account/service.test.ts
+++ b/packages/backend/src/open_payments/account/service.test.ts
@@ -66,13 +66,9 @@ describe('Open Payments Account Service', (): void => {
       const account = await accountService.create({ asset: randomAsset() })
 
       const accountingService = await deps.use('accountingService')
-      await expect(accountingService.getAccount(account.id)).resolves.toEqual({
-        id: account.id,
-        asset: {
-          unit: account.asset.unit
-        },
-        balance: BigInt(0)
-      })
+      await expect(accountingService.getBalance(account.id)).resolves.toEqual(
+        BigInt(0)
+      )
     })
   })
 })

--- a/packages/backend/src/open_payments/invoice/model.ts
+++ b/packages/backend/src/open_payments/invoice/model.ts
@@ -1,5 +1,6 @@
 import { Model } from 'objection'
 import { Account } from '../account/model'
+import { Asset } from '../../asset/model'
 import { BaseModel } from '../../shared/baseModel'
 
 export class Invoice extends BaseModel {
@@ -29,4 +30,8 @@ export class Invoice extends BaseModel {
   public processAt!: Date | null
 
   public webhookAttempts!: number
+
+  public get asset(): Asset {
+    return this.account.asset
+  }
 }

--- a/packages/backend/src/open_payments/invoice/model.ts
+++ b/packages/backend/src/open_payments/invoice/model.ts
@@ -1,9 +1,10 @@
 import { Model } from 'objection'
 import { Account } from '../account/model'
+import { Account as BaseAccount } from '../../accounting/service'
 import { Asset } from '../../asset/model'
 import { BaseModel } from '../../shared/baseModel'
 
-export class Invoice extends BaseModel {
+export class Invoice extends BaseModel implements BaseAccount {
   public static get tableName(): string {
     return 'invoices'
   }

--- a/packages/backend/src/open_payments/invoice/service.test.ts
+++ b/packages/backend/src/open_payments/invoice/service.test.ts
@@ -112,13 +112,9 @@ describe('Invoice Service', (): void => {
         expiresAt: new Date(Date.now() + 30_000),
         amount: BigInt(123)
       })
-      await expect(accountingService.getAccount(invoice.id)).resolves.toEqual({
-        id: invoice.id,
-        asset: {
-          unit: invoice.account.asset.unit
-        },
-        balance: BigInt(0)
-      })
+      await expect(accountingService.getBalance(invoice.id)).resolves.toEqual(
+        BigInt(0)
+      )
     })
 
     test('Cannot create invoice for nonexistent account', async (): Promise<void> => {
@@ -155,7 +151,7 @@ describe('Invoice Service', (): void => {
       await expect(
         accountingService.createDeposit({
           id: uuid(),
-          accountId: invoice.id,
+          account: invoice,
           amount: invoice.amount - BigInt(1)
         })
       ).resolves.toBeUndefined()
@@ -170,7 +166,7 @@ describe('Invoice Service', (): void => {
       await expect(
         accountingService.createDeposit({
           id: uuid(),
-          accountId: invoice.id,
+          account: invoice,
           amount: invoice.amount
         })
       ).resolves.toBeUndefined()
@@ -211,7 +207,7 @@ describe('Invoice Service', (): void => {
         await expect(
           accountingService.createDeposit({
             id: uuid(),
-            accountId: invoice.id,
+            account: invoice,
             amount: BigInt(1)
           })
         ).resolves.toBeUndefined()
@@ -258,7 +254,7 @@ describe('Invoice Service', (): void => {
             await expect(
               accountingService.createDeposit({
                 id: uuid(),
-                accountId: invoice.id,
+                account: invoice,
                 amount: amountReceived
               })
             ).resolves.toBeUndefined()

--- a/packages/backend/src/outgoing_payment/ilp_plugin.ts
+++ b/packages/backend/src/outgoing_payment/ilp_plugin.ts
@@ -1,4 +1,4 @@
-import { AccountOptions } from '../accounting/service'
+import { Account } from '../accounting/service'
 
 // Maybe @interledger/pay should export this interface.
 export interface IlpPlugin {
@@ -37,6 +37,6 @@ export class OutgoingIlpPlugin implements IlpPlugin {
 }
 
 export interface IlpPluginOptions {
-  sourceAccount: AccountOptions
+  sourceAccount: Account
   unfulfillable?: boolean
 }

--- a/packages/backend/src/outgoing_payment/lifecycle.ts
+++ b/packages/backend/src/outgoing_payment/lifecycle.ts
@@ -162,7 +162,7 @@ export async function handleFunding(
     if (status === 200) {
       const error = await deps.accountingService.createDeposit({
         id: payment.webhookId,
-        accountId: payment.id,
+        account: payment,
         amount: payment.quote.maxSourceAmount
       })
       if (error) {
@@ -355,7 +355,7 @@ export async function handleCancelledOrCompleted(
   if (balance) {
     const error = await deps.accountingService.createWithdrawal({
       id: payment.webhookId,
-      accountId: payment.id,
+      account: payment,
       amount: balance,
       timeout: BigInt(deps.webhookService.timeout) * BigInt(1e6) // ms -> ns
     })

--- a/packages/backend/src/outgoing_payment/model.ts
+++ b/packages/backend/src/outgoing_payment/model.ts
@@ -2,6 +2,7 @@ import { Pojo, Model, ModelOptions, QueryContext } from 'objection'
 import * as Pay from '@interledger/pay'
 import { v4 as uuid } from 'uuid'
 
+import { Account as BaseAccount } from '../accounting/service'
 import { Asset } from '../asset/model'
 import { Account } from '../open_payments/account/model'
 import { BaseModel } from '../shared/baseModel'
@@ -21,7 +22,7 @@ export type PaymentIntent = {
   autoApprove: boolean
 }
 
-export class OutgoingPayment extends BaseModel {
+export class OutgoingPayment extends BaseModel implements BaseAccount {
   public static readonly tableName = 'outgoingPayments'
 
   public state!: PaymentState

--- a/packages/backend/src/outgoing_payment/model.ts
+++ b/packages/backend/src/outgoing_payment/model.ts
@@ -1,6 +1,8 @@
 import { Pojo, Model, ModelOptions, QueryContext } from 'objection'
 import * as Pay from '@interledger/pay'
 import { v4 as uuid } from 'uuid'
+
+import { Asset } from '../asset/model'
 import { Account } from '../open_payments/account/model'
 import { BaseModel } from '../shared/baseModel'
 
@@ -53,6 +55,10 @@ export class OutgoingPayment extends BaseModel {
     scale: number
     code: string
     url?: string
+  }
+
+  public get asset(): Asset {
+    return this.account.asset
   }
 
   static relationMappings = {

--- a/packages/backend/src/outgoing_payment/service.test.ts
+++ b/packages/backend/src/outgoing_payment/service.test.ts
@@ -116,7 +116,7 @@ describe('OutgoingPaymentService', (): void => {
     await expect(
       accountingService.createDeposit({
         id: uuid(),
-        accountId: invoice.id,
+        account: invoice,
         amount
       })
     ).resolves.toBeUndefined()
@@ -212,9 +212,7 @@ describe('OutgoingPaymentService', (): void => {
       await expect(
         accountingService.createDeposit({
           id: uuid(),
-          asset: {
-            unit: destinationAccount.asset.unit
-          },
+          account: destinationAccount.asset,
           amount: BigInt(123)
         })
       ).resolves.toBeUndefined()

--- a/packages/backend/src/peer/model.ts
+++ b/packages/backend/src/peer/model.ts
@@ -1,9 +1,10 @@
 import { Model, Pojo } from 'objection'
+import { Account } from '../accounting/service'
 import { Asset } from '../asset/model'
 import { HttpToken } from '../httpToken/model'
 import { BaseModel } from '../shared/baseModel'
 
-export class Peer extends BaseModel {
+export class Peer extends BaseModel implements Account {
   public static get tableName(): string {
     return 'peers'
   }

--- a/packages/backend/src/peer/service.test.ts
+++ b/packages/backend/src/peer/service.test.ts
@@ -18,7 +18,6 @@ import { Pagination } from '../shared/pagination'
 import { randomAsset } from '../tests/asset'
 import { PeerFactory } from '../tests/peerFactory'
 import { truncateTables } from '../tests/tableManager'
-import { Asset } from '../asset/model'
 
 describe('Peer Service', (): void => {
   let deps: IocContract<AppServices>
@@ -131,14 +130,9 @@ describe('Peer Service', (): void => {
       const accountingService = await deps.use('accountingService')
       const peer = await peerService.create(options)
       assert.ok(!isPeerError(peer))
-      const assetService = await deps.use('assetService')
-      await expect(accountingService.getAccount(peer.id)).resolves.toEqual({
-        id: peer.id,
-        asset: {
-          unit: ((await assetService.get(options.asset)) as Asset).unit
-        },
-        balance: BigInt(0)
-      })
+      await expect(accountingService.getBalance(peer.id)).resolves.toEqual(
+        BigInt(0)
+      )
     })
 
     test('Auto-creates corresponding asset', async (): Promise<void> => {

--- a/packages/backend/src/tests/accountFactory.ts
+++ b/packages/backend/src/tests/accountFactory.ts
@@ -11,29 +11,55 @@ type BuildOptions = Partial<AccountOptions> & {
   balance?: bigint
 }
 
+export type FactoryAccount = Omit<Account, 'asset'> & {
+  asset: {
+    id: string
+    unit: number
+    asset: {
+      id: string
+      unit: number
+    }
+  }
+}
+
 export class AccountFactory {
   public constructor(
     private accounts: AccountingService,
     private unitGenerator: () => number = randomUnit
   ) {}
 
-  public async build(options: BuildOptions = {}): Promise<Account> {
+  public async build(options: BuildOptions = {}): Promise<FactoryAccount> {
+    const assetId = options.asset?.id || uuid()
     const unit = options.asset?.unit || this.unitGenerator()
-    await this.accounts.createAssetAccounts(unit)
+    const asset = {
+      id: assetId,
+      unit,
+      asset: {
+        id: assetId,
+        unit
+      }
+    }
+    if (!options.asset) {
+      await this.accounts.createSettlementAccount(asset.unit)
+      await this.accounts.createAccount(asset)
+    }
     const accountOptions: AccountOptions = {
       id: options.id || uuid(),
-      asset: { unit }
+      asset
     }
     const account = await this.accounts.createAccount(accountOptions)
 
     if (options.balance) {
       await this.accounts.createDeposit({
         id: uuid(),
-        accountId: account.id,
+        account,
         amount: options.balance
       })
     }
 
-    return account
+    return {
+      ...account,
+      asset
+    }
   }
 }

--- a/packages/backend/src/tests/accountFactory.ts
+++ b/packages/backend/src/tests/accountFactory.ts
@@ -1,13 +1,9 @@
 import { v4 as uuid } from 'uuid'
 
-import {
-  AccountingService,
-  Account,
-  AccountOptions
-} from '../accounting/service'
+import { AccountingService, Account } from '../accounting/service'
 import { randomUnit } from './asset'
 
-type BuildOptions = Partial<AccountOptions> & {
+type BuildOptions = Partial<Account> & {
   balance?: bigint
 }
 
@@ -43,11 +39,11 @@ export class AccountFactory {
       await this.accounts.createSettlementAccount(asset.unit)
       await this.accounts.createAccount(asset)
     }
-    const accountOptions: AccountOptions = {
+    const account = {
       id: options.id || uuid(),
       asset
     }
-    const account = await this.accounts.createAccount(accountOptions)
+    await this.accounts.createAccount(account)
 
     if (options.balance) {
       await this.accounts.createDeposit({
@@ -57,9 +53,6 @@ export class AccountFactory {
       })
     }
 
-    return {
-      ...account,
-      asset
-    }
+    return account
   }
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Use asset id as liquidity account id.
- Use asset unit as settlement account id.
- Do not look up Tigerbeetle account before deposit or withdrawal.
- Remove unused `accountingService.getAccount()`

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #215 
- progress towards #225 (which will benefit from polymorphic account models)

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
