### PR TITLE
feat(ci): add workflow for pushing rafiki-backend docker images to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+    - main
+
+name: Release Docker Image
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: yarn install --immutable --immutable-cache
+
+      - name: Build Docker Image
+        run: yarn docker build backend -t ghcr.io/${{ github.actor }}/rafiki-backend:${{ github.sha }}
+
+      - name: Login GHCR
+        # You must create a personal access token on GitHub and add it to the 
+        # repo's actions secrets named by 'GHCR_PAT' in order to use this step.
+        run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push Docker Image to GHCR
+        run: docker push ghcr.io/${{ github.actor }}/rafiki-backend:${{ github.sha }}


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- adds an actions workflow that pushes the rafiki backend docker image to github container registery. 


## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

- fixes #233 
- this workflow only works when pushed to main.
- the image gets tagged by commit sha.

## Note
Repo owner must create a personal access token and add it to the repo's actions secrets named by `GHCR_PAT` in order to this workflow work. Without a token, the workflow fails to login GHCR which is required for pushing the image. You can read the instructions from [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry) to create a personal access token with the needed scopes.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass