### PR TITLE
fix(ci): support autolabelling pull requests from forks

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,9 +15,12 @@ on:
 
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v3
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@
 
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Changed `pull_request` to `pull_request_target` for labeling pull requests coming from forks.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #277.
- Current labeler workflow fails when a pull request comes from a fork as you can see from [this PR](https://github.com/interledger/rafiki/pull/250).
- `pull_request_target` workflow trigger additionally gives PR author write permissions compared to `pull_request` trigger. It provides the workflow to tag pull requests coming from forks in this scenario, which is not possible with the `pull_request` trigger.
- Github states that misuse of `pull_request_target` may lead to insecure situations, check [this article](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for information. Unless the workflow contains malicious code apart from the labeler action - which is a whole nother security issue -, it doesn't pose a vulnerability.
- [Labeler action](https://github.com/marketplace/actions/labeler) already uses `pull_request_target` trigger at the examples in readme, so the solution in this PR would be good to go.
- I tested this workflow on my fork and [it worked out](https://github.com/omertoast/rafiki/pull/3) as expected.
- You can check [this really long thread](https://github.com/actions/labeler/issues/12) for additional information.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number `
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
