### PR TITLE
fix(backend): set content-type when sending ilp-packets to peer

### DIFF
--- a/packages/backend/src/connector/core/middleware/ilp-packet.ts
+++ b/packages/backend/src/connector/core/middleware/ilp-packet.ts
@@ -18,7 +18,7 @@ import { Readable } from 'stream'
 import { HttpContext, HttpMiddleware, ILPMiddleware } from '../rafiki'
 import getRawBody from 'raw-body'
 
-const CONTENT_TYPE = 'application/octet-stream'
+export const CONTENT_TYPE = 'application/octet-stream'
 
 export interface IlpPacketMiddlewareOptions {
   getRawBody?: (req: Readable) => Promise<Buffer>

--- a/packages/backend/src/connector/core/services/client.ts
+++ b/packages/backend/src/connector/core/services/client.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from 'axios'
 import { Errors } from 'ilp-packet'
+import { CONTENT_TYPE } from '../middleware/ilp-packet'
 import { OutgoingAccount } from '../rafiki'
 
 export async function sendToPeer(
@@ -13,7 +14,10 @@ export async function sendToPeer(
   }
   const res = await client.post<Buffer>(http.outgoing.endpoint, prepare, {
     responseType: 'arraybuffer',
-    headers: { Authorization: `Bearer ${http.outgoing.authToken}` }
+    headers: {
+      Authorization: `Bearer ${http.outgoing.authToken}`,
+      'Content-Type': CONTENT_TYPE
+    }
   })
   return res.data
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- set content-type to `application/octet-stream` when sending to peer

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

The content-type is expected to be set to `application/octet-stream` when receiving ilp-packets. This wasn't being set and caused sending to fail.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
