### PR TITLE
chore: auto-detect React version in .eslintrc.yml

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,3 +21,6 @@ plugins:
   - '@typescript-eslint'
 rules:
   '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]
+settings:
+  react:
+    version: "detect"

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,6 +3,7 @@
 module.exports = {
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: 'tsconfig.build.json'
     }
   },

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -3,7 +3,6 @@
 module.exports = {
   globals: {
     'ts-jest': {
-      isolatedModules: true,
       tsconfig: 'tsconfig.build.json'
     }
   },


### PR DESCRIPTION
## Changes proposed in this pull request

Adds `settings.react.version = "detect"` to `.eslintrc.yml` so the following warning will no longer be logged from `yarn lint`:

```plaintext
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .
```

## Context

Per https://github.com/yannickcr/eslint-plugin-react#configuration, eslint-plugin-react doesn't automatically auto-detect the React version used. 

## Checklist

Please pardon the lack of related issue, I figured this small of a chore didn't warrant one. But I'm happy to file one if you'd prefer! 😄 

- [ ] Related issues linked using `fixes #number`
- ~[ ] Tests added/updated~
- ~[ ] Documentation added~
- [x] Make sure that all checks pass
