### PR TITLE
chore: add a ci status check to end of workflows

### DIFF
--- a/.github/workflows/lint_test_build.yml
+++ b/.github/workflows/lint_test_build.yml
@@ -7,7 +7,7 @@ on:
       - opened
       - synchronize
 
-name: PR checks
+name: PR Checks
 
 jobs:
   checkout:
@@ -119,6 +119,8 @@ jobs:
       - backend
       - frontend
       - rates
+      - auth
+      - openapi
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -130,3 +132,11 @@ jobs:
           key: yarn-deps-${{ hashFiles('yarn.lock') }}
       - run: yarn install --immutable --immutable-cache
       - run: yarn build
+
+  all_pr_checks_passed:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - run: echo 'PR Checks Passed'
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - opened
       - synchronize
 
-name: Sanity check
+name: Sanity Check
 
 jobs:
   build:


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds a check at the end of the PR Checks which can then be used in the brand protection rules to enforce that all PR Checks must pass before merging. 
- Requires auth and openapi to succeed before performing the build
- closes #422

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->


## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
