### PR TITLE
fix: change pnpm docs to not show -F since it does not work

### DIFF
--- a/packages/auth/Dockerfile
+++ b/packages/auth/Dockerfile
@@ -15,6 +15,6 @@ RUN pnpm fetch
 ADD . ./
 RUN pnpm install -r --offline
 
-RUN pnpm -F auth build
+RUN pnpm --filter auth build
 
 CMD ["node", "./packages/auth/dist/index.js"]

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -2,7 +2,7 @@
   "name": "auth",
   "scripts": {
     "knex": "knex",
-    "build:deps": "pnpm -F openapi build",
+    "build:deps": "pnpm --filter openapi build",
     "build": "pnpm build:deps && tsc --build tsconfig.json",
     "clean": "rm -fr dist/",
     "test": "jest --passWithNoTests --maxWorkers=50%",

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -15,6 +15,6 @@ RUN pnpm fetch
 ADD . ./
 RUN pnpm install -r --offline
 
-RUN pnpm -F backend build
+RUN pnpm --filter backend build
 
 CMD ["node", "./packages/backend/dist/index.js"]

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -22,7 +22,7 @@
 - [`openapi`](https://github.com/interledger/rafiki/tree/main/packages/openapi):
 
 ```shell
-pnpm -F openapi build
+pnpm --filter openapi build
 ```
 
 ### Testing
@@ -30,7 +30,7 @@ pnpm -F openapi build
 From the monorepo root directory:
 
 ```shell
-pnpm -F backend test
+pnpm --filter backend test
 ```
 
 ## Docker build

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,7 +4,7 @@
     "test": "jest --passWithNoTests --maxWorkers=50%",
     "knex": "knex",
     "generate": "graphql-codegen --config codegen.yml",
-    "build:deps": "pnpm -F openapi build",
+    "build:deps": "pnpm -filter openapi build",
     "build": "pnpm build:deps && tsc --build tsconfig.json && pnpm copy-files",
     "clean": "rm -fr dist/",
     "copy-files": "cp src/graphql/schema.graphql dist/graphql/",

--- a/packages/mock-account-provider/Dockerfile
+++ b/packages/mock-account-provider/Dockerfile
@@ -15,6 +15,6 @@ RUN pnpm fetch
 ADD . ./
 RUN pnpm install -r --offline
 
-RUN pnpm -F mock-account-provider build
+RUN pnpm --filter mock-account-provider build
 
 CMD ["node", "./packages/mock-account-provider/dist/index.js"]

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -5,7 +5,7 @@
 ### Building
 
 ```shell
-pnpm -F openapi build
+pnpm --filter openapi build
 ```
 
 ### Testing
@@ -13,5 +13,5 @@ pnpm -F openapi build
 From the monorepo root directory:
 
 ```shell
-pnpm -F openapi test
+pnpm --filter openapi test
 ```

--- a/packages/rates/Dockerfile
+++ b/packages/rates/Dockerfile
@@ -15,6 +15,6 @@ RUN pnpm fetch
 ADD . ./
 RUN pnpm install -r --offline
 
-RUN pnpm -F rates build
+RUN pnpm --filter rates build
 
 CMD ["node", "./packages/rates/dist/server/index.js"]


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Fixes the docs to show `--filter` instead of `-F` for pnpm since `-F` is only supported in 7.9.4 of pnpm. 
- See: https://github.com/pnpm/pnpm/commit/3ac748aab5a5e849a872c5a085715d2fb508ad37

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
