### PR TITLE
feat(auth): match dereferenced name with spec name

### DIFF
--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -306,7 +306,7 @@ describe('Access Token Routes', (): void => {
         {
           headers: { Accept: 'application/json' }
         },
-        { managementId }
+        { id: managementId }
       )
 
       await expect(accessTokenRoutes.rotate(ctx)).rejects.toMatchObject({
@@ -322,7 +322,7 @@ describe('Access Token Routes', (): void => {
           url: `/token/${token.id}`,
           method: 'POST'
         },
-        { managementId }
+        { id: managementId }
       )
 
       await accessTokenRoutes.rotate(ctx)
@@ -353,7 +353,7 @@ describe('Access Token Routes', (): void => {
           url: `/token/${token.id}`,
           method: 'POST'
         },
-        { managementId }
+        { id: managementId }
       )
 
       await token.$query(trx).patch({ expiresIn: -1 })

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -69,7 +69,8 @@ async function revokeToken(
 ): Promise<void> {
   //TODO: verify accessToken with httpsig method
 
-  await deps.accessTokenService.revoke(ctx.params['id'])
+  const { id } = ctx.params
+  await deps.accessTokenService.revoke(id)
   ctx.status = 204
 }
 
@@ -78,9 +79,8 @@ async function rotateToken(
   ctx: AppContext
 ): Promise<void> {
   //TODO: verify accessToken with httpsig method
-  const result = await deps.accessTokenService.rotate(
-    ctx.params['managementId']
-  )
+  const { id: managementId } = ctx.params
+  const result = await deps.accessTokenService.rotate(managementId)
   if (result.success == true) {
     ctx.status = 200
     ctx.body = {

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -69,8 +69,8 @@ async function revokeToken(
 ): Promise<void> {
   //TODO: verify accessToken with httpsig method
 
-  const { id } = ctx.params
-  await deps.accessTokenService.revoke(id)
+  const { id: managementId } = ctx.params
+  await deps.accessTokenService.revoke(managementId)
   ctx.status = 204
 }
 

--- a/packages/auth/src/grant/routes.test.ts
+++ b/packages/auth/src/grant/routes.test.ts
@@ -1035,7 +1035,7 @@ describe('Grant Routes', (): void => {
           }
         },
         {
-          continueId: grant.continueId
+          id: grant.continueId
         }
       )
 
@@ -1060,7 +1060,7 @@ describe('Grant Routes', (): void => {
           }
         },
         {
-          continueId: grant.continueId
+          id: grant.continueId
         }
       )
 

--- a/packages/auth/src/grant/routes.test.ts
+++ b/packages/auth/src/grant/routes.test.ts
@@ -960,7 +960,7 @@ describe('Grant Routes', (): void => {
           method: 'POST'
         },
         {
-          continueId: grant.continueId
+          id: grant.continueId
         }
       )
 
@@ -1005,7 +1005,7 @@ describe('Grant Routes', (): void => {
           }
         },
         {
-          continueId: v4()
+          id: v4()
         }
       )
 
@@ -1082,7 +1082,7 @@ describe('Grant Routes', (): void => {
           }
         },
         {
-          continueId: grant.continueId
+          id: grant.continueId
         }
       )
 

--- a/packages/auth/src/grant/routes.ts
+++ b/packages/auth/src/grant/routes.ts
@@ -248,7 +248,7 @@ async function continueGrant(
   ctx: AppContext
 ): Promise<void> {
   // TODO: httpsig validation
-  const { continueId } = ctx.params
+  const { id: continueId } = ctx.params
   const continueToken = (ctx.headers['authorization'] as string)?.split(
     'GNAP '
   )[1]


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Modifies the implementation of `continueGrant` to look for a parameter named `id` instead of `continueId`

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- During debugging it was noticed that the parameter value of the `continueGrant` method was not being found
- At runtime, the property name is `id` (which matches the spec) but the function was expecting it to be named `continueId`

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
