### PR TITLE
fix(auth): await next() calls in httpsig middleware

### DIFF
--- a/packages/auth/src/signature/service.ts
+++ b/packages/auth/src/signature/service.ts
@@ -246,6 +246,7 @@ async function tokenHttpsigMiddleware(
       ctx.body = { error: 'invalid_client' }
       return
     }
+
     verified = await verifySigAndChallenge(
       deps,
       sig,
@@ -255,7 +256,7 @@ async function tokenHttpsigMiddleware(
     )
   } else {
     // route does not need httpsig verification
-    next()
+    await next()
     return
   }
 
@@ -265,9 +266,9 @@ async function tokenHttpsigMiddleware(
       error: verified.error || 'request_denied',
       message: verified.message || null
     }
-    next()
+    await next()
     return
   }
 
-  next()
+  await next()
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Runs `await` on any `next()` calls in the middleware so that it doesn't prematurely return data.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Since the `httpsig` middleware wasn't awaiting `next()`, the AS was pretty much always sending along the wrong status before the main handler for a route executed.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
