### PR TITLE
fix(map): use correct AUTH_SERVER_INTROSPECTION_URL

### DIFF
--- a/infrastructure/local/docker-compose.yml
+++ b/infrastructure/local/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       TIGERBEETLE_REPLICA_ADDRESSES: '["10.5.0.50:4342"]'
       NONCE_REDIS_KEY: test
       AUTH_SERVER_GRANT_URL: http://auth:3006
-      AUTH_SERVER_INTROSPECTION_URL: http://auth:3006/auth/introspect
+      AUTH_SERVER_INTROSPECTION_URL: http://auth:3006/introspect
       ILP_ADDRESS: test.rafiki
       STREAM_SECRET: BjPXtnd00G2mRQwP/8ZpwyZASOch5sUXT5o0iR5b5wU=
       ADMIN_KEY: admin

--- a/infrastructure/local/peer-docker-compose.yml
+++ b/infrastructure/local/peer-docker-compose.yml
@@ -32,7 +32,7 @@ services:
       TIGERBEETLE_REPLICA_ADDRESSES: '["10.5.0.50:4342"]'
       NONCE_REDIS_KEY: test
       AUTH_SERVER_GRANT_URL: http://peer-auth:3006
-      AUTH_SERVER_INTROSPECTION_URL: http://peer-auth:3006/auth/introspect
+      AUTH_SERVER_INTROSPECTION_URL: http://peer-auth:3006/introspect
       ILP_ADDRESS: test.peer
       STREAM_SECRET: BjPXtnd00G2mRQwP/8ZpwyZASOch5sUXT5o0iR5b5wU=
       ADMIN_KEY: admin

--- a/packages/mock-account-provider/app/routes/keys.$keyId.ts
+++ b/packages/mock-account-provider/app/routes/keys.$keyId.ts
@@ -5,13 +5,15 @@ export function loader({ request }: LoaderArgs) {
   // TODO Fetch actual key relating to keyId
   return json(
     {
-      kid: request.url,
-      x: 'test-public-key',
-      kty: 'OKP',
-      alg: 'EdDSA',
-      crv: 'Ed25519',
-      key_ops: ['sign', 'verify'],
-      use: 'sig',
+      jwk: {
+        kid: request.url,
+        x: 'test-public-key',
+        kty: 'OKP',
+        alg: 'EdDSA',
+        crv: 'Ed25519',
+        key_ops: ['sign', 'verify'],
+        use: 'sig'
+      },
       client: {
         id: '73bc0345-f03f-4627-903c-5abb55656d15'
       }


### PR DESCRIPTION


<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- use correct `AUTH_SERVER_INTROSPECTION_URL`
- update mock-account-provider key format.
- token introspection requests are still failing due to backend not including httpsig in the request

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

- related to #574 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
