### PR TITLE
chore: pin redis to specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pnpm --filter auth test
 pnpm --filter open-api test
 
 # run all tests
-pnpm -r --workspace-concurrency=2 test
+pnpm -r --workspace-concurrency=1 test
 
 # format and lint code:
 pnpm format

--- a/infrastructure/local/docker-compose.yml
+++ b/infrastructure/local/docker-compose.yml
@@ -110,7 +110,7 @@ services:
         DATA_FILE=/var/lib/tigerbeetle/cluster_0000000000_replica_000.tigerbeetle
         /opt/beta-beetle/tigerbeetle start --cluster="0" --replica="0" --directory=/var/lib/tigerbeetle --addresses=0.0.0.0:4342
   redis:
-    image: 'redis:5' # use latest official postgres version
+    image: 'redis:7'
     restart: unless-stopped
     networks:
       rafiki:

--- a/packages/auth/docker-compose.yml
+++ b/packages/auth/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password
   redis:
-    image: "redis:5" # use latest official postgres version
+    image: "redis:7"
     restart: unless-stopped
     ports:
       - "6379:6379"

--- a/packages/backend/docker-compose.yml
+++ b/packages/backend/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password
   redis:
-    image: "redis:5" # use latest official postgres version
+    image: "redis:7"
     restart: unless-stopped
     ports:
       - "6379:6379"

--- a/packages/backend/jest.setup.js
+++ b/packages/backend/jest.setup.js
@@ -133,7 +133,7 @@ module.exports = async (globalConfig) => {
 
   const setupRedis = async () => {
     if (!process.env.REDIS_URL) {
-      const redisContainer = await new GenericContainer('redis')
+      const redisContainer = await new GenericContainer('redis:7')
         .withExposedPorts(REDIS_PORT)
         .start()
 


### PR DESCRIPTION
## Changes proposed in this pull request
Pin redis to a spefic version. 

## Context
Rafiki seems to use some new features, so some tests fails if the local machine has an older version of redis. 