### PR TITLE
feat(MAP): support for incoming payment expiry webhook

### DIFF
--- a/docs/transaction-api.md
+++ b/docs/transaction-api.md
@@ -87,7 +87,7 @@ Credit `paymentPointer.received` to the wallet balance for `paymentPointer.id`, 
 
 #### `incoming_payment.expired`
 
-Incoming payment has expired.
+Incoming payment has expired (but received some amount).
 
 Credit `incomingPayment.received` to the wallet balance for `incomingPayment.accountId`, and call `Mutation.withdrawEventLiquidity` with the event id.
 

--- a/packages/mock-account-provider/app/lib/accounts.server.ts
+++ b/packages/mock-account-provider/app/lib/accounts.server.ts
@@ -214,13 +214,4 @@ export class AccountProvider implements AccountsServer {
   }
 }
 
-declare global {
-  let __mockAccounts: AccountsServer | undefined
-}
-
-if (!global.__mockAccounts) {
-  global.__mockAccounts = new AccountProvider()
-}
-const mockAccounts = global.__mockAccounts
-
-export { mockAccounts }
+export const mockAccounts = new AccountProvider()

--- a/packages/mock-account-provider/app/routes/webhooks.ts
+++ b/packages/mock-account-provider/app/routes/webhooks.ts
@@ -8,6 +8,7 @@ import { apolloClient } from '~/lib/apolloClient'
 
 export enum EventType {
   IncomingPaymentCompleted = 'incoming_payment.completed',
+  IncomingPaymentExpired = 'incoming_payment.expired',
   OutgoingPaymentCreated = 'outgoing_payment.created',
   OutgoingPaymentCompleted = 'outgoing_payment.completed',
   OutgoingPaymentFailed = 'outgoing_payment.failed'
@@ -36,7 +37,8 @@ export async function action({ request }: ActionArgs) {
     case EventType.OutgoingPaymentFailed:
       return handleOutgoingPaymentCompletedFailed(wh)
     case EventType.IncomingPaymentCompleted:
-      return handleIncomingPaymentCompleted(wh)
+    case EventType.IncomingPaymentExpired:
+      return handleIncomingPaymentCompletedExpired(wh)
   }
 
   return json(undefined, { status: 200 })
@@ -107,7 +109,7 @@ export async function handleOutgoingPaymentCreated(wh: WebHook) {
   return json(undefined, { status: 200 })
 }
 
-export async function handleIncomingPaymentCompleted(wh: WebHook) {
+export async function handleIncomingPaymentCompletedExpired(wh: WebHook) {
   assert.equal(wh.type, EventType.IncomingPaymentCompleted)
   const payment = wh.data['incomingPayment']
   const pp = payment['paymentPointerId'] as string

--- a/packages/mock-account-provider/app/routes/webhooks.ts
+++ b/packages/mock-account-provider/app/routes/webhooks.ts
@@ -110,7 +110,13 @@ export async function handleOutgoingPaymentCreated(wh: WebHook) {
 }
 
 export async function handleIncomingPaymentCompletedExpired(wh: WebHook) {
-  assert.equal(wh.type, EventType.IncomingPaymentCompleted)
+  if (
+    wh.type !== EventType.IncomingPaymentCompleted &&
+    wh.type !== EventType.IncomingPaymentExpired
+  ) {
+    assert.fail('invalid event type')
+  }
+
   const payment = wh.data['incomingPayment']
   const pp = payment['paymentPointerId'] as string
   const acc = await mockAccounts.getByPaymentPointer(pp)


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adding `incoming_payment.expired` webhook support for the mock account provider. As per webhook [docs](https://github.com/interledger/rafiki/blob/main/docs/transaction-api.md#incoming_paymentexpired), incoming payment expiry should be treated the same as completion on incoming payment (credit the account for the amount, call `WithdrawLiquidity` mutation)

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- Fixes #659 :
Took this issue on after a discussion with @wilsonianb in another: [one](https://github.com/interledger/rafiki/issues/649#issuecomment-1268821849)

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
