### PR TITLE
feat(backend): serve keys from payment pointer url

### DIFF
--- a/packages/backend/migrations/20220818141305_create_clients_table.js
+++ b/packages/backend/migrations/20220818141305_create_clients_table.js
@@ -6,6 +6,8 @@ exports.up = function (knex) {
     table.string('email').notNullable()
     table.string('image').notNullable()
 
+    table.string('paymentPointerUrl').notNullable()
+
     table.timestamp('createdAt').defaultTo(knex.fn.now())
     table.timestamp('updatedAt').defaultTo(knex.fn.now())
   })

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -350,6 +350,13 @@ export class App {
       (ctx: ClientKeysContext): Promise<void> => clientKeysRoutes.get(ctx)
     )
 
+    router.get(
+      PAYMENT_POINTER_PATH + '/jwks.json',
+      createPaymentPointerMiddleware(),
+      (ctx: PaymentPointerContext): Promise<void> =>
+        paymentPointerRoutes.getKeys(ctx)
+    )
+
     // Add the payment pointer query route last.
     // Otherwise it will be matched instead of other Open Payments endpoints.
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/backend/src/clientKeys/routes.test.ts
+++ b/packages/backend/src/clientKeys/routes.test.ts
@@ -19,7 +19,8 @@ const TEST_CLIENT = {
   name: faker.name.firstName(),
   uri: faker.internet.url(),
   email: faker.internet.exampleEmail(),
-  image: faker.image.avatar()
+  image: faker.image.avatar(),
+  paymentPointerUrl: faker.internet.url()
 }
 const KEY_UUID = uuid()
 const TEST_KID_PATH = '/keys/' + KEY_UUID

--- a/packages/backend/src/clientKeys/routes.ts
+++ b/packages/backend/src/clientKeys/routes.ts
@@ -40,7 +40,8 @@ export async function getKeyById(
       name: clientDetails.name,
       uri: clientDetails.uri,
       email: clientDetails.email,
-      image: clientDetails.image
+      image: clientDetails.image,
+      paymentPointerUrl: clientDetails.paymentPointerUrl
     }
   }
 }

--- a/packages/backend/src/clientKeys/service.test.ts
+++ b/packages/backend/src/clientKeys/service.test.ts
@@ -16,7 +16,8 @@ const TEST_CLIENT = {
   name: faker.name.firstName(),
   uri: faker.internet.url(),
   email: faker.internet.exampleEmail(),
-  image: faker.image.avatar()
+  image: faker.image.avatar(),
+  paymentPointerUrl: faker.internet.url()
 }
 const KEY_UUID = uuid()
 const TEST_KID_PATH = '/keys/' + KEY_UUID

--- a/packages/backend/src/clients/model.ts
+++ b/packages/backend/src/clients/model.ts
@@ -7,6 +7,8 @@ export class Client extends BaseModel {
     return 'clients'
   }
 
+  public paymentPointerUrl!: string
+
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   static relationMappings = () => ({
     keys: {

--- a/packages/backend/src/clients/service.test.ts
+++ b/packages/backend/src/clients/service.test.ts
@@ -75,6 +75,17 @@ describe('Client Key Service', (): void => {
       await expect(fetchedClient.uri).toEqual(Client.uri)
       await expect(fetchedClient.keys).toHaveLength(0)
     })
+    test('Can get client using payment pointer url (with empty keys)', async (): Promise<void> => {
+      const Client = await clientService.createClient(TEST_CLIENT)
+
+      const fetchedClient = await clientService.getClientByPaymentPointerUrl(
+        Client.paymentPointerUrl
+      )
+      await expect(fetchedClient.id).toEqual(Client.id)
+      await expect(fetchedClient.name).toEqual(Client.name)
+      await expect(fetchedClient.uri).toEqual(Client.uri)
+      await expect(fetchedClient.keys).toHaveLength(0)
+    })
   })
   describe('Manage Client Keys', (): void => {
     test('Can add a key to a client', async (): Promise<void> => {

--- a/packages/backend/src/clients/service.test.ts
+++ b/packages/backend/src/clients/service.test.ts
@@ -13,6 +13,7 @@ import { faker } from '@faker-js/faker'
 const KEY_REGISTRY_ORIGIN = 'https://openpayments.network'
 const TEST_CLIENT = {
   name: faker.name.firstName(),
+  paymentPointerUrl: faker.internet.url(),
   uri: faker.internet.url(),
   email: faker.internet.exampleEmail(),
   image: faker.image.avatar()

--- a/packages/backend/src/clients/service.ts
+++ b/packages/backend/src/clients/service.ts
@@ -6,6 +6,7 @@ import { ClientKeys } from '../clientKeys/model'
 import { JWKWithRequired } from 'auth'
 
 export interface CreateClientOptions {
+  paymentPointerUrl: string
   name: string
   uri: string
 }

--- a/packages/backend/src/clients/service.ts
+++ b/packages/backend/src/clients/service.ts
@@ -19,6 +19,7 @@ export interface AddKeyToClientOptions {
 
 export interface ClientService {
   getClient(id: string): Promise<Client | undefined>
+  getClientByPaymentPointerUrl(url: string): Promise<Client | undefined>
   createClient(options: CreateClientOptions): Promise<Client>
   addKeyToClient(options: AddKeyToClientOptions): Promise<Client>
 }
@@ -40,6 +41,8 @@ export async function createClientService({
   }
   return {
     getClient: (id) => getClient(deps, id),
+    getClientByPaymentPointerUrl: (url) =>
+      getClientByPaymentPointerUrl(deps, url),
     createClient: (options) => createClient(deps, options),
     addKeyToClient: (options) => addKeyToClient(deps, options)
   }
@@ -50,6 +53,17 @@ async function getClient(
   id: string
 ): Promise<Client | undefined> {
   const client = await Client.query(deps.knex).findById(id)
+  client.keys = await getClientKeys(deps, client.id)
+  return client
+}
+
+async function getClientByPaymentPointerUrl(
+  deps: ServiceDependencies,
+  paymentPointerUrl: string
+) {
+  const client = await Client.query(deps.knex)
+    .where('paymentPointerUrl', paymentPointerUrl)
+    .first()
   client.keys = await getClientKeys(deps, client.id)
   return client
 }

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -904,6 +904,22 @@
             "deprecationReason": null
           },
           {
+            "name": "paymentPointerUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "uri",
             "description": null,
             "args": [],
@@ -1270,6 +1286,22 @@
           },
           {
             "name": "name",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paymentPointerUrl",
             "description": null,
             "type": {
               "kind": "NON_NULL",

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -111,6 +111,7 @@ export type Client = Model & {
   image: Scalars['String'];
   keys: Array<ClientKeys>;
   name: Scalars['String'];
+  paymentPointerUrl: Scalars['String'];
   uri: Scalars['String'];
 };
 
@@ -154,6 +155,7 @@ export type CreateClientInput = {
   email: Scalars['String'];
   image: Scalars['String'];
   name: Scalars['String'];
+  paymentPointerUrl: Scalars['String'];
   uri: Scalars['String'];
 };
 
@@ -1165,6 +1167,7 @@ export type ClientResolvers<ContextType = any, ParentType extends ResolversParen
   image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   keys?: Resolver<Array<ResolversTypes['ClientKeys']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  paymentPointerUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/backend/src/graphql/resolvers/clientKeys.test.ts
+++ b/packages/backend/src/graphql/resolvers/clientKeys.test.ts
@@ -25,7 +25,8 @@ const TEST_CLIENT = {
   name: faker.name.firstName(),
   uri: faker.internet.url(),
   email: faker.internet.exampleEmail(),
-  image: faker.image.avatar()
+  image: faker.image.avatar(),
+  paymentPointerUrl: faker.internet.url()
 }
 const KEY_UUID = uuid()
 const TEST_KID_PATH = '/keys/' + KEY_UUID

--- a/packages/backend/src/graphql/resolvers/clientKeys.ts
+++ b/packages/backend/src/graphql/resolvers/clientKeys.ts
@@ -134,6 +134,7 @@ export const clientToGraphql = (client: Client): SchemaClient => ({
   uri: client.uri,
   email: client.email,
   image: client.image,
+  paymentPointerUrl: client.paymentPointerUrl,
   keys:
     client.keys != null
       ? client.keys.map((key) => ({

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -258,6 +258,7 @@ input CreateClientInput {
   uri: String!
   image: String!
   email: String!
+  paymentPointerUrl: String!
 }
 
 input AddKeyToClientInput {
@@ -534,6 +535,7 @@ type Client implements Model {
   image: String!
   email: String!
   keys: [ClientKeys!]!
+  paymentPointerUrl: String!
   createdAt: String!
 }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -205,7 +205,8 @@ export function initIocContainer(
   })
   container.singleton('paymentPointerRoutes', async (deps) => {
     return createPaymentPointerRoutes({
-      config: await deps.use('config')
+      config: await deps.use('config'),
+      clientService: await deps.use('clientService')
     })
   })
   container.singleton('clientKeysRoutes', async (deps) => {

--- a/packages/backend/src/shared/routes.test.ts
+++ b/packages/backend/src/shared/routes.test.ts
@@ -104,5 +104,3 @@ export const listTests = <Type extends BaseResponse>({
     )
   })
 }
-
-test.todo('test suite must contain at least one test')

--- a/packages/mock-account-provider/generated/graphql.ts
+++ b/packages/mock-account-provider/generated/graphql.ts
@@ -111,6 +111,7 @@ export type Client = Model & {
   image: Scalars['String'];
   keys: Array<ClientKeys>;
   name: Scalars['String'];
+  paymentPointerUrl: Scalars['String'];
   uri: Scalars['String'];
 };
 
@@ -154,6 +155,7 @@ export type CreateClientInput = {
   email: Scalars['String'];
   image: Scalars['String'];
   name: Scalars['String'];
+  paymentPointerUrl: Scalars['String'];
   uri: Scalars['String'];
 };
 
@@ -1165,6 +1167,7 @@ export type ClientResolvers<ContextType = any, ParentType extends ResolversParen
   image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   keys?: Resolver<Array<ResolversTypes['ClientKeys']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  paymentPointerUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- add `paymentPointerUrl` field to `clients` table. This is temporary as I don't want to break services that use clients, if you have a better way to link clients to payment pointers I'm open to it.
- add `getClientByPaymentPointerUrl` method to client service.
- add `getPaymentPointerKeys` method to `paymentPointerRoutes` to serve key set.
- add `/jwks.json` route.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
This is one of the first tasks for refactoring the Key Directory from v1 to v2. As the first step, I'm implementing `/jkws.json` relative path to the payment pointer URL to serve the client key set linked to the payment pointer.
 
## TODO

- [x] Link clients and payment pointers
- [x] Allow getting clients using payment pointers
- [x] Extract JWKS from the key set
- [x] Serve key set from `/jwks.json` endpoint.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
