### PR TITLE
fix(auth): use milliseconds when determining access token expiration

### DIFF
--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -202,7 +202,8 @@ describe('Access Token Routes', (): void => {
           client: TEST_CLIENT,
           jwk: testJwk
         } as ClientKey)
-      const now = new Date(new Date().getTime() + 4000 * 1000)
+      const tokenCreatedDate = new Date(token.createdAt)
+      const now = new Date(tokenCreatedDate.getTime() + 4000 * 1000)
       jest.useFakeTimers({ now })
 
       const ctx = createContext(

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -204,7 +204,7 @@ describe('Access Token Routes', (): void => {
         } as ClientKey)
       const now = new Date(new Date().getTime() + 4000 * 1000)
       jest.useFakeTimers({ now })
-      jest.setSystemTime(now)
+      // jest.setSystemTime(now)
 
       const ctx = createContext(
         {

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -204,7 +204,6 @@ describe('Access Token Routes', (): void => {
         } as ClientKey)
       const now = new Date(new Date().getTime() + 4000 * 1000)
       jest.useFakeTimers({ now })
-      // jest.setSystemTime(now)
 
       const ctx = createContext(
         {

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -202,8 +202,8 @@ describe('Access Token Routes', (): void => {
           client: TEST_CLIENT,
           jwk: testJwk
         } as ClientKey)
-      const now = new Date(new Date().getTime() + 4000)
-      jest.useFakeTimers()
+      const now = new Date(new Date().getTime() + 4000 * 1000)
+      jest.useFakeTimers({ now })
       jest.setSystemTime(now)
 
       const ctx = createContext(

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -203,7 +203,7 @@ describe('Access Token Routes', (): void => {
           jwk: testJwk
         } as ClientKey)
       const tokenCreatedDate = new Date(token.createdAt)
-      const now = new Date(tokenCreatedDate.getTime() + 4000 * 1000)
+      const now = new Date(tokenCreatedDate.getTime() + (token.expiresIn + 1) * 1000)
       jest.useFakeTimers({ now })
 
       const ctx = createContext(

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -203,7 +203,9 @@ describe('Access Token Routes', (): void => {
           jwk: testJwk
         } as ClientKey)
       const tokenCreatedDate = new Date(token.createdAt)
-      const now = new Date(tokenCreatedDate.getTime() + (token.expiresIn + 1) * 1000)
+      const now = new Date(
+        tokenCreatedDate.getTime() + (token.expiresIn + 1) * 1000
+      )
       jest.useFakeTimers({ now })
 
       const ctx = createContext(

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -167,7 +167,7 @@ describe('Access Token Service', (): void => {
 
     test('Can introspect expired token', async (): Promise<void> => {
       const tokenCreatedDate = new Date(token.createdAt)
-      const now = new Date(tokenCreatedDate.getTime() + 4000 * 1000)
+      const now = new Date(tokenCreatedDate.getTime() + (token.expiresIn + 1) * 1000)
       jest.useFakeTimers({ now })
       const introspection = await accessTokenService.introspect(token.value)
       expect(introspection).toEqual({ active: false })

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -167,8 +167,7 @@ describe('Access Token Service', (): void => {
 
     test('Can introspect expired token', async (): Promise<void> => {
       const now = new Date(new Date().getTime() + 4000 * 1000)
-      jest.useFakeTimers()
-      jest.setSystemTime(now)
+      jest.useFakeTimers({ now })
       const introspection = await accessTokenService.introspect(token.value)
       expect(introspection).toEqual({ active: false })
     })

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -166,7 +166,8 @@ describe('Access Token Service', (): void => {
     })
 
     test('Can introspect expired token', async (): Promise<void> => {
-      const now = new Date(new Date().getTime() + 4000 * 1000)
+      const tokenCreatedDate = new Date(token.createdAt)
+      const now = new Date(tokenCreatedDate.getTime() + 4000 * 1000)
       jest.useFakeTimers({ now })
       const introspection = await accessTokenService.introspect(token.value)
       expect(introspection).toEqual({ active: false })

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -167,7 +167,9 @@ describe('Access Token Service', (): void => {
 
     test('Can introspect expired token', async (): Promise<void> => {
       const tokenCreatedDate = new Date(token.createdAt)
-      const now = new Date(tokenCreatedDate.getTime() + (token.expiresIn + 1) * 1000)
+      const now = new Date(
+        tokenCreatedDate.getTime() + (token.expiresIn + 1) * 1000
+      )
       jest.useFakeTimers({ now })
       const introspection = await accessTokenService.introspect(token.value)
       expect(introspection).toEqual({ active: false })

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -166,7 +166,7 @@ describe('Access Token Service', (): void => {
     })
 
     test('Can introspect expired token', async (): Promise<void> => {
-      const now = new Date(new Date().getTime() + 4000)
+      const now = new Date(new Date().getTime() + 4000 * 1000)
       jest.useFakeTimers()
       jest.setSystemTime(now)
       const introspection = await accessTokenService.introspect(token.value)

--- a/packages/auth/src/accessToken/service.ts
+++ b/packages/auth/src/accessToken/service.ts
@@ -79,7 +79,7 @@ export async function createAccessTokenService({
 
 function isTokenExpired(token: AccessToken): boolean {
   const now = new Date(Date.now())
-  const expiresAt = token.createdAt.getTime() + (token.expiresIn * 1000)
+  const expiresAt = token.createdAt.getTime() + token.expiresIn * 1000
   return expiresAt < now.getTime()
 }
 

--- a/packages/auth/src/accessToken/service.ts
+++ b/packages/auth/src/accessToken/service.ts
@@ -79,7 +79,7 @@ export async function createAccessTokenService({
 
 function isTokenExpired(token: AccessToken): boolean {
   const now = new Date(Date.now())
-  const expiresAt = token.createdAt.getTime() + token.expiresIn
+  const expiresAt = token.createdAt.getTime() + (token.expiresIn * 1000)
   return expiresAt < now.getTime()
 }
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- When determining if an access token has expired or not, convert the bound `expiresIn` value to milliseconds.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Javascript `Date` handles time in milliseconds, GNAP handles time in seconds. Conversion is necessary.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
