### PR TITLE
chore: quote expiration cannot be set past the receiver's expiration

### DIFF
--- a/packages/backend/src/open_payments/client/service.test.ts
+++ b/packages/backend/src/open_payments/client/service.test.ts
@@ -77,7 +77,9 @@ describe('Open Payments Client Service', (): void => {
             incomingAmount: undefined,
             receivedAmount: undefined,
             ilpAddress: expect.any(String),
-            sharedSecret: expect.any(Buffer)
+            sharedSecret: expect.any(Buffer),
+            expiresAt:
+              urlPath === INCOMING_PAYMENT_PATH ? expect.any(Date) : undefined
           })
           expect(local).not.toEqual(scope.isDone())
         })
@@ -137,7 +139,8 @@ describe('Open Payments Client Service', (): void => {
               incomingAmount: incomingPayment.incomingAmount,
               receivedAmount: incomingPayment.receivedAmount,
               ilpAddress: expect.any(String),
-              sharedSecret: expect.any(Buffer)
+              sharedSecret: expect.any(Buffer),
+              expiresAt: incomingPayment.expiresAt
             })
           }
         )

--- a/packages/backend/src/open_payments/client/service.ts
+++ b/packages/backend/src/open_payments/client/service.ts
@@ -54,7 +54,7 @@ export class Receiver extends ConnectionBase {
     connection: ConnectionJSON,
     private readonly incomingAmountValue?: bigint,
     private readonly receivedAmountValue?: bigint,
-    private readonly expiresAtValue?: Date
+    public readonly expiresAt?: Date
   ) {
     super(
       connection.ilpAddress,
@@ -89,13 +89,6 @@ export class Receiver extends ConnectionBase {
         assetCode: this.assetCode,
         assetScale: this.assetScale
       }
-    }
-    return undefined
-  }
-
-  public get expiresAt(): Date | undefined {
-    if (this.expiresAtValue !== undefined) {
-      return this.expiresAtValue
     }
     return undefined
   }

--- a/packages/backend/src/open_payments/client/service.ts
+++ b/packages/backend/src/open_payments/client/service.ts
@@ -31,10 +31,10 @@ export class Receiver extends ConnectionBase {
     if (typeof incomingPayment.ilpStreamConnection !== 'object') {
       return undefined
     }
-    if (
-      incomingPayment.expiresAt &&
-      new Date(incomingPayment.expiresAt).getTime() <= Date.now()
-    ) {
+    const expiryDate = incomingPayment.expiresAt
+      ? new Date(incomingPayment.expiresAt)
+      : undefined
+    if (expiryDate && expiryDate.getTime() <= Date.now()) {
       return undefined
     }
     const receivedAmount = parseAmount(incomingPayment.receivedAmount)
@@ -45,14 +45,16 @@ export class Receiver extends ConnectionBase {
     return new this(
       incomingPayment.ilpStreamConnection,
       incomingAmount?.value,
-      receivedAmount.value
+      receivedAmount.value,
+      expiryDate
     )
   }
 
   private constructor(
     connection: ConnectionJSON,
     private readonly incomingAmountValue?: bigint,
-    private readonly receivedAmountValue?: bigint
+    private readonly receivedAmountValue?: bigint,
+    private readonly expiresAtValue?: Date
   ) {
     super(
       connection.ilpAddress,
@@ -87,6 +89,13 @@ export class Receiver extends ConnectionBase {
         assetCode: this.assetCode,
         assetScale: this.assetScale
       }
+    }
+    return undefined
+  }
+
+  public get expiresAt(): Date | undefined {
+    if (this.expiresAtValue !== undefined) {
+      return this.expiresAtValue
     }
     return undefined
   }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- In cases where the receiver is an incoming payment it wouldn't make sense for the quotation's expiration to be set past the expiration date of the incoming payment.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- Fixes #593

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
