### PR TITLE
fix(auth): do not check for content-digest in signature if body is empty

### DIFF
--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -79,6 +79,7 @@ async function rotateToken(
   deps: ServiceDependencies,
   ctx: AppContext
 ): Promise<void> {
+  // TODO: verify Authorization: GNAP ${accessToken} contains correct token value
   const { id: managementId } = ctx.params
   const result = await deps.accessTokenService.rotate(managementId)
   if (result.success == true) {

--- a/packages/auth/src/signature/middleware.test.ts
+++ b/packages/auth/src/signature/middleware.test.ts
@@ -70,36 +70,6 @@ describe('Signature Service', (): void => {
       ).resolves.toBe(true)
     })
 
-    // test('can construct a challenge from signature input', (): void => {
-    //   const sigInputHeader =
-    //     'sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type" "authorization");created=1618884473;keyid="gnap-key"'
-    //   const ctx = createContext(
-    //     {
-    //       headers: {
-    //         'Content-Type': 'application/json',
-    //         'Content-Digest': 'sha-256=:test-hash:',
-    //         'Content-Length': '1234',
-    //         'Signature-Input': sigInputHeader,
-    //         Authorization: 'GNAP test-access-token'
-    //       },
-    //       method: 'GET',
-    //       url: '/test'
-    //     },
-    //     {},
-    //     deps
-    //   )
-
-    //   ctx.request.body = { foo: 'bar' }
-
-    //   const challenge = sigInputToChallenge(sigInputHeader, ctx)
-    //   expect(challenge).toEqual(
-    //     `"@method": GET\n"@target-uri": /test\n"content-digest": sha-256=:test-hash:\n"content-length": 1234\n"content-type": application/json\n"authorization": GNAP test-access-token\n"@signature-params": ${sigInputHeader.replace(
-    //       'sig1=',
-    //       ''
-    //     )}`
-    //   )
-    // })
-
     test.each`
       title                                 | withAuthorization | withRequestBody
       ${''}                                 | ${true}           | ${true}

--- a/packages/auth/src/signature/middleware.test.ts
+++ b/packages/auth/src/signature/middleware.test.ts
@@ -70,35 +70,89 @@ describe('Signature Service', (): void => {
       ).resolves.toBe(true)
     })
 
-    test('can construct a challenge from signature input', (): void => {
-      const sigInputHeader =
-        'sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type" "authorization");created=1618884473;keyid="gnap-key"'
-      const ctx = createContext(
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Digest': 'sha-256=:test-hash:',
-            'Content-Length': '1234',
-            'Signature-Input': sigInputHeader,
-            Authorization: 'GNAP test-access-token'
-          },
-          method: 'GET',
-          url: '/test'
-        },
-        {},
-        deps
-      )
+    // test('can construct a challenge from signature input', (): void => {
+    //   const sigInputHeader =
+    //     'sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type" "authorization");created=1618884473;keyid="gnap-key"'
+    //   const ctx = createContext(
+    //     {
+    //       headers: {
+    //         'Content-Type': 'application/json',
+    //         'Content-Digest': 'sha-256=:test-hash:',
+    //         'Content-Length': '1234',
+    //         'Signature-Input': sigInputHeader,
+    //         Authorization: 'GNAP test-access-token'
+    //       },
+    //       method: 'GET',
+    //       url: '/test'
+    //     },
+    //     {},
+    //     deps
+    //   )
 
-      ctx.request.body = { foo: 'bar' }
+    //   ctx.request.body = { foo: 'bar' }
 
-      const challenge = sigInputToChallenge(sigInputHeader, ctx)
-      expect(challenge).toEqual(
-        `"@method": GET\n"@target-uri": /test\n"content-digest": sha-256=:test-hash:\n"content-length": 1234\n"content-type": application/json\n"authorization": GNAP test-access-token\n"@signature-params": ${sigInputHeader.replace(
+    //   const challenge = sigInputToChallenge(sigInputHeader, ctx)
+    //   expect(challenge).toEqual(
+    //     `"@method": GET\n"@target-uri": /test\n"content-digest": sha-256=:test-hash:\n"content-length": 1234\n"content-type": application/json\n"authorization": GNAP test-access-token\n"@signature-params": ${sigInputHeader.replace(
+    //       'sig1=',
+    //       ''
+    //     )}`
+    //   )
+    // })
+
+    test.each`
+      title                                 | withAuthorization | withRequestBody
+      ${''}                                 | ${true}           | ${true}
+      ${' without an authorization header'} | ${false}          | ${true}
+      ${' without a request body'}          | ${true}           | ${false}
+    `(
+      'can construct a challenge from signature input$title',
+      ({ withAuthorization, withRequestBody }): void => {
+        let sigInputHeader = 'sig1=("@method" "@target-uri" "content-type"'
+
+        const headers = {
+          'Content-Type': 'application/json'
+        }
+        let expectedChallenge = `"@method": GET\n"@target-uri": /test\n"content-type": application/json\n`
+
+        if (withRequestBody) {
+          sigInputHeader += ' "content-digest" "content-length"'
+          headers['Content-Digest'] = 'sha-256=:test-hash:'
+          headers['Content-Length'] = '1234'
+          expectedChallenge +=
+            '"content-digest": sha-256=:test-hash:\n"content-length": 1234\n'
+        }
+
+        if (withAuthorization) {
+          sigInputHeader += ' "authorization"'
+          headers['Authorization'] = 'GNAP test-access-token'
+          expectedChallenge += '"authorization": GNAP test-access-token\n'
+        }
+
+        sigInputHeader += ');created=1618884473;keyid="gnap-key"'
+        headers['Signature-Input'] = sigInputHeader
+        expectedChallenge += `"@signature-params": ${sigInputHeader.replace(
           'sig1=',
           ''
         )}`
-      )
-    })
+
+        const ctx = createContext(
+          {
+            headers,
+            method: 'GET',
+            url: '/test'
+          },
+          {},
+          deps
+        )
+
+        ctx.request.body = withRequestBody ? { foo: 'bar' } : {}
+
+        const challenge = sigInputToChallenge(sigInputHeader, ctx)
+
+        expect(challenge).toEqual(expectedChallenge)
+      }
+    )
 
     test.each`
       title                                                                               | sigInputHeader

--- a/packages/auth/src/signature/middleware.ts
+++ b/packages/auth/src/signature/middleware.ts
@@ -80,7 +80,7 @@ function validateSigInputComponents(
   return !(
     !sigInputComponents.includes('@method') ||
     !sigInputComponents.includes('@target-uri') ||
-    (ctx.request.body && !sigInputComponents.includes('content-digest')) ||
+    ((ctx.request.body && Object.keys(ctx.request.body).length > 0) && !sigInputComponents.includes('content-digest')) ||
     (ctx.headers['authorization'] &&
       !sigInputComponents.includes('authorization'))
   )

--- a/packages/auth/src/signature/middleware.ts
+++ b/packages/auth/src/signature/middleware.ts
@@ -80,7 +80,9 @@ function validateSigInputComponents(
   return !(
     !sigInputComponents.includes('@method') ||
     !sigInputComponents.includes('@target-uri') ||
-    ((ctx.request.body && Object.keys(ctx.request.body).length > 0) && !sigInputComponents.includes('content-digest')) ||
+    (ctx.request.body &&
+      Object.keys(ctx.request.body).length > 0 &&
+      !sigInputComponents.includes('content-digest')) ||
     (ctx.headers['authorization'] &&
       !sigInputComponents.includes('authorization'))
   )


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Don't check for `Content-Digest` if the body object is empty.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Even if a body was not provided in the request, koa will default to an empty object.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
