### PR TITLE
feat(map): display account transactions

### DIFF
--- a/packages/mock-account-provider/app/lib/requesters.ts
+++ b/packages/mock-account-provider/app/lib/requesters.ts
@@ -2,7 +2,8 @@ import { gql } from '@apollo/client'
 import type {
   CreatePeerMutationResponse,
   LiquidityMutationResponse,
-  CreatePaymentPointerMutationResponse
+  CreatePaymentPointerMutationResponse,
+  PaymentPointer
 } from '../../generated/graphql'
 import { apolloClient } from './apolloClient'
 
@@ -148,5 +149,92 @@ export async function createPaymentPointer(
         throw new Error('Data was empty')
       }
       return data.createPaymentPointer
+    })
+}
+
+export async function getPaymentPointerPayments(
+  paymentPointerId: string
+  // TODO: pagination
+): Promise<PaymentPointer> {
+  const query = gql`
+    query PaymentPointer($id: String!) {
+      paymentPointer(id: $id) {
+        incomingPayments {
+          edges {
+            node {
+              id
+              state
+              expiresAt
+              incomingAmount {
+                value
+              }
+              receivedAmount {
+                value
+                assetCode
+                assetScale
+              }
+              description
+              externalRef
+              createdAt
+            }
+            cursor
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+            hasPreviousPage
+            startCursor
+          }
+        }
+        outgoingPayments {
+          edges {
+            node {
+              id
+              state
+              error
+              sendAmount {
+                value
+                assetCode
+                assetScale
+              }
+              receiveAmount {
+                value
+                assetCode
+                assetScale
+              }
+              receiver
+              description
+              externalRef
+              sentAmount {
+                value
+                assetCode
+                assetScale
+              }
+              createdAt
+            }
+            cursor
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+            hasPreviousPage
+            startCursor
+          }
+        }
+      }
+    }
+  `
+  return apolloClient
+    .query({
+      query,
+      variables: {
+        id: paymentPointerId
+      }
+    })
+    .then(({ data }): PaymentPointer => {
+      if (!data.paymentPointer) {
+        throw new Error('Data was empty')
+      }
+      return data.paymentPointer
     })
 }

--- a/packages/mock-account-provider/app/lib/transactions.server.ts
+++ b/packages/mock-account-provider/app/lib/transactions.server.ts
@@ -1,0 +1,72 @@
+import { mockAccounts } from './accounts.server'
+import { getPaymentPointerPayments } from './requesters'
+
+export interface Amount {
+  value: bigint
+  assetCode: string
+  assetScale: number
+}
+
+export type IncomingPayment = {
+  id: string
+  description: string
+  externalRef: string
+  incomingAmountValue: string
+  receivedAmountValue: string
+  assetCode: string
+  assetScale: number
+  state: string
+  createdAt: string
+}
+
+export type OutgoingPayment = {
+  id: string
+  receiver: string
+  description: string
+  externalRef: string
+  sendAmountValue: string
+  sentAmountValue: string
+  receiveAmount: Amount
+  assetCode: string
+  assetScale: number
+  state: string
+  createdAt: string
+}
+
+export async function getAccountTransactions(
+  accountId: string
+): Promise<Array<IncomingPayment | OutgoingPayment>> {
+  const account = await mockAccounts.get(accountId)
+  const { incomingPayments, outgoingPayments } =
+    await getPaymentPointerPayments(account.paymentPointerID)
+  const transactions = incomingPayments.edges.map(({ node }) => {
+    return {
+      id: node.id,
+      description: node.description,
+      externalRef: node.externalRef,
+      incomingAmountValue: node.incomingAmount.value,
+      receivedAmountValue: node.receivedAmount.value,
+      assetCode: node.receivedAmount.assetCode,
+      assetScale: node.receivedAmount.assetScale,
+      state: node.state,
+      createdAt: node.createdAt
+    }
+  })
+  return transactions.concat(
+    outgoingPayments.edges.map(({ node }) => {
+      return {
+        id: node.id,
+        receiver: node.receiver,
+        description: node.description,
+        externalRef: node.externalRef,
+        sendAmountValue: node.sendAmount.value,
+        sentAmountValue: node.sentAmount.value,
+        receiveAmount: node.receiveAmount,
+        assetCode: node.sendAmount.assetCode,
+        assetScale: node.sendAmount.assetScale,
+        state: node.state,
+        createdAt: node.createdAt
+      }
+    })
+  )
+}

--- a/packages/mock-account-provider/app/lib/transactions.server.ts
+++ b/packages/mock-account-provider/app/lib/transactions.server.ts
@@ -7,30 +7,31 @@ export interface Amount {
   assetScale: number
 }
 
-export type IncomingPayment = {
-  id: string
-  description: string
-  externalRef: string
-  incomingAmountValue: string
-  receivedAmountValue: string
-  assetCode: string
-  assetScale: number
-  state: string
-  createdAt: string
+export enum TransactionType {
+  IncomingPayment = 'Incoming Payment',
+  OutgoingPayment = 'Outgoing Payment'
 }
 
-export type OutgoingPayment = {
+interface Transaction {
   id: string
-  receiver: string
   description: string
   externalRef: string
-  sendAmountValue: string
-  sentAmountValue: string
-  receiveAmount: Amount
+  createdAt: string
+  amountValue: string
   assetCode: string
   assetScale: number
   state: string
-  createdAt: string
+  type: TransactionType
+}
+
+export interface IncomingPayment extends Transaction {
+  incomingAmountValue: string
+}
+
+export interface OutgoingPayment extends Transaction {
+  receiver: string
+  sendAmountValue: string
+  receiveAmount: Amount
 }
 
 export async function getAccountTransactions(
@@ -45,11 +46,12 @@ export async function getAccountTransactions(
       description: node.description,
       externalRef: node.externalRef,
       incomingAmountValue: node.incomingAmount.value,
-      receivedAmountValue: node.receivedAmount.value,
+      amountValue: node.receivedAmount.value,
       assetCode: node.receivedAmount.assetCode,
       assetScale: node.receivedAmount.assetScale,
       state: node.state,
-      createdAt: node.createdAt
+      createdAt: node.createdAt,
+      type: TransactionType.IncomingPayment
     }
   })
   return transactions.concat(
@@ -60,12 +62,13 @@ export async function getAccountTransactions(
         description: node.description,
         externalRef: node.externalRef,
         sendAmountValue: node.sendAmount.value,
-        sentAmountValue: node.sentAmount.value,
+        amountValue: node.sentAmount.value,
         receiveAmount: node.receiveAmount,
         assetCode: node.sendAmount.assetCode,
         assetScale: node.sendAmount.assetScale,
         state: node.state,
-        createdAt: node.createdAt
+        createdAt: node.createdAt,
+        type: TransactionType.OutgoingPayment
       }
     })
   )

--- a/packages/mock-account-provider/app/routes/accounts.$accountId.tsx
+++ b/packages/mock-account-provider/app/routes/accounts.$accountId.tsx
@@ -28,11 +28,9 @@ export default function Transactions() {
         {transactions.map((trx) => (
           <tr key={trx.id}>
             <td>{trx.createdAt}</td>
-            <td>{trx.sendAmountValue ? 'Outgoing' : 'Incoming'}</td>
+            <td>{trx.type}</td>
             <td>
-              {(
-                Number(trx.sendAmountValue ?? trx.incomingAmountValue) / 100
-              ).toFixed(trx.assetScale)}{' '}
+              {(Number(trx.amountValue) / 100).toFixed(trx.assetScale)}{' '}
               {trx.assetCode}
             </td>
             <td>{trx.description}</td>

--- a/packages/mock-account-provider/app/routes/accounts.$accountId.tsx
+++ b/packages/mock-account-provider/app/routes/accounts.$accountId.tsx
@@ -1,0 +1,48 @@
+import { json } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import { getAccountTransactions } from '../lib/transactions.server'
+import tableStyle from '../styles/table.css'
+
+type LoaderData = {
+  transactions: Awaited<ReturnType<typeof getAccountTransactions>>
+}
+
+export const loader = async ({ params }) => {
+  return json<LoaderData>({
+    transactions: await getAccountTransactions(params.accountId)
+  })
+}
+
+export default function Transactions() {
+  const { transactions } = useLoaderData() as LoaderData
+  return (
+    <main>
+      <h1>Transactions</h1>
+      <table>
+        <tr>
+          <th>Date</th>
+          <th>Type</th>
+          <th>Amount</th>
+          <th>Description</th>
+        </tr>
+        {transactions.map((trx) => (
+          <tr key={trx.id}>
+            <td>{trx.createdAt}</td>
+            <td>{trx.sendAmountValue ? 'Outgoing' : 'Incoming'}</td>
+            <td>
+              {(
+                Number(trx.sendAmountValue ?? trx.incomingAmountValue) / 100
+              ).toFixed(trx.assetScale)}{' '}
+              {trx.assetCode}
+            </td>
+            <td>{trx.description}</td>
+          </tr>
+        ))}
+      </table>
+    </main>
+  )
+}
+
+export function links() {
+  return [{ rel: 'stylesheet', href: tableStyle }]
+}

--- a/packages/mock-account-provider/app/routes/index.tsx
+++ b/packages/mock-account-provider/app/routes/index.tsx
@@ -1,5 +1,5 @@
 import { json } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
+import { Link, useLoaderData } from '@remix-run/react'
 import { getAccountsWithBalance } from '../lib/balances.server'
 import tableStyle from '../styles/table.css'
 
@@ -28,7 +28,9 @@ export default function Accounts() {
         {accountsWithBalance.map((acc, i) => (
           <tr key={acc.id}>
             <td>{i + 1}</td>
-            <td>{acc.name}</td>
+            <td>
+              <Link to={`/accounts/${acc.id}`}>{acc.name}</Link>
+            </td>
             <td>{acc.paymentPointer}</td>
             <td>
               {(Number(acc.balance) / 100).toFixed(acc.assetScale)}{' '}

--- a/packages/mock-account-provider/app/routes/webhooks.ts
+++ b/packages/mock-account-provider/app/routes/webhooks.ts
@@ -1,6 +1,7 @@
 import type { ActionArgs } from '@remix-run/node'
 import { json } from '@remix-run/node'
 import { mockAccounts } from '~/lib/accounts.server'
+import type { Amount } from '~/lib/transactions.server'
 import { gql } from '@apollo/client'
 import type { LiquidityMutationResponse } from '../../generated/graphql'
 import { apolloClient } from '~/lib/apolloClient'
@@ -19,11 +20,6 @@ export interface WebHook {
   data: Record<string, unknown>
 }
 
-export interface Amount {
-  value: bigint
-  assetCode: string
-  assetScale: number
-}
 export interface AmountJSON {
   value: string
   assetCode: string


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- add `/accounts/{accountId}` page with incoming and outgoing account transactions to mock account provider
- as is, payments are queried via the admin api and not stored by the mock account provider (which makes it difficult to pre-seed transactions...)

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #717

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
