### PR TITLE
fix(auth): use correct port for peer-auth instance

### DIFF
--- a/infrastructure/local/peer-docker-compose.yml
+++ b/infrastructure/local/peer-docker-compose.yml
@@ -9,12 +9,13 @@ services:
     networks:
       rafiki:
     ports:
-      - "4006:3006"
+      - "4006:4006"
     environment:
       NODE_ENV: development
       AUTH_DATABASE_URL: postgresql://peerauth:peerauth@database/peerauth
       INTROSPECTION_HTTPSIG: "false"
       BYPASS_SIGNATURE_VALIDATION: "true"
+      PORT: 4006
   peer-backend:
     image: ghcr.io/interledger/rafiki-backend:latest
     build:

--- a/infrastructure/local/peer-docker-compose.yml
+++ b/infrastructure/local/peer-docker-compose.yml
@@ -9,13 +9,13 @@ services:
     networks:
       rafiki:
     ports:
-      - "4006:4006"
+      - "4006:3006"
     environment:
       NODE_ENV: development
       AUTH_DATABASE_URL: postgresql://peerauth:peerauth@database/peerauth
       INTROSPECTION_HTTPSIG: "false"
       BYPASS_SIGNATURE_VALIDATION: "true"
-      PORT: 4006
+      AUTH_SERVER_DOMAIN: "http://localhost:4006"
   peer-backend:
     image: ghcr.io/interledger/rafiki-backend:latest
     build:
@@ -39,8 +39,8 @@ services:
       # Tigerbeetle will support DNS in future
       TIGERBEETLE_REPLICA_ADDRESSES: '["10.5.0.50:4342"]'
       NONCE_REDIS_KEY: test
-      AUTH_SERVER_GRANT_URL: http://peer-auth:4006
-      AUTH_SERVER_INTROSPECTION_URL: http://peer-auth:4006/introspect
+      AUTH_SERVER_GRANT_URL: http://peer-auth:3006
+      AUTH_SERVER_INTROSPECTION_URL: http://peer-auth:3006/introspect
       ILP_ADDRESS: test.peer
       STREAM_SECRET: BjPXtnd00G2mRQwP/8ZpwyZASOch5sUXT5o0iR5b5wU=
       ADMIN_KEY: admin

--- a/infrastructure/local/peer-docker-compose.yml
+++ b/infrastructure/local/peer-docker-compose.yml
@@ -39,8 +39,8 @@ services:
       # Tigerbeetle will support DNS in future
       TIGERBEETLE_REPLICA_ADDRESSES: '["10.5.0.50:4342"]'
       NONCE_REDIS_KEY: test
-      AUTH_SERVER_GRANT_URL: http://peer-auth:3006
-      AUTH_SERVER_INTROSPECTION_URL: http://peer-auth:3006/introspect
+      AUTH_SERVER_GRANT_URL: http://peer-auth:4006
+      AUTH_SERVER_INTROSPECTION_URL: http://peer-auth:4006/introspect
       ILP_ADDRESS: test.peer
       STREAM_SECRET: BjPXtnd00G2mRQwP/8ZpwyZASOch5sUXT5o0iR5b5wU=
       ADMIN_KEY: admin

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -32,7 +32,10 @@ export const Config = {
     'http://localhost:3300'
   ),
   identityServerSecret: envString('IDENTITY_SERVER_SECRET', 'replace-me'),
-  authServerDomain: envString('AUTH_SERVER_DOMAIN', 'http://localhost:3006'), // TODO: replace this with whatever frontend port ends up being
+  authServerDomain: envString(
+    'AUTH_SERVER_DOMAIN',
+    `http://localhost:${envInt('PORT', 3006)}`
+  ), // TODO: replace this with whatever frontend port ends up being
   waitTimeSeconds: envInt('WAIT_SECONDS', 5),
   cookieKey: envString('COOKIE_KEY', crypto.randomBytes(32).toString('hex')),
   accessTokenExpirySeconds: envInt('ACCESS_TOKEN_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes

--- a/packages/auth/src/grant/routes.ts
+++ b/packages/auth/src/grant/routes.ts
@@ -408,7 +408,7 @@ function createGrantBody({
       access_token: {
         value: grant.continueToken
       },
-      uri: domain + `continue/${grant.continueId}`
+      uri: domain + `/continue/${grant.continueId}`
     }
   }
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds a missing `/` to the `continue` field in a grant response.
- Updates the port used by the `peer-auth` container to use 4006.
- Updates the default domain config to use the configured port.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
