### PR TITLE
fix(backend): enable Redis stringNumbers

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -90,7 +90,10 @@ export function initIocContainer(
   container.singleton('closeEmitter', async () => new EventEmitter())
   container.singleton('redis', async (deps): Promise<Redis> => {
     const config = await deps.use('config')
-    return new Redis(config.redisUrl, { tls: config.redisTls })
+    return new Redis(config.redisUrl, {
+      tls: config.redisTls,
+      stringNumbers: true
+    })
   })
   container.singleton('streamServer', async (deps) => {
     const config = await deps.use('config')

--- a/packages/backend/src/session/service.test.ts
+++ b/packages/backend/src/session/service.test.ts
@@ -54,7 +54,7 @@ describe('Session Key Service', (): void => {
     test('Session expires', async (): Promise<void> => {
       const session = await sessionService.create()
       const ttl = await redis.pttl(session.key)
-      expect(ttl).toBeGreaterThan(0)
+      expect(Number(ttl)).toBeGreaterThan(0)
     })
   })
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes the following:
```
local-peer-backend-1  | {"level":40,"time":1668111855459,"pid":1,"hostname":"1cdf891dad52","service":"ConnectorService","totalReceived":2000,"err":null,"err2":null,"msg":"error incrementing stream totalReceived"}
```
See:
https://luin.github.io/ioredis/interfaces/CommonRedisOptions.html#stringNumbers
https://github.com/interledger/rafiki/blob/0c5fd38295bb7c8e5a6a4cda690b2477e834483a/packages/backend/src/connector/core/controllers/stream.ts#L34-L55
https://github.com/interledger/rafiki/blob/0c5fd38295bb7c8e5a6a4cda690b2477e834483a/packages/backend/src/connector/core/factories/rafiki-services.ts#L57-L61

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
