### PR TITLE
fix(backend): don't reject ConnectionClose packet

### DIFF
--- a/packages/backend/src/connector/core/middleware/account.ts
+++ b/packages/backend/src/connector/core/middleware/account.ts
@@ -51,8 +51,11 @@ export function createAccountMiddleware(serverAddress: string): ILPMiddleware {
         })
         if (incomingPayment) {
           if (
-            incomingPayment.state === IncomingPaymentState.Completed ||
-            incomingPayment.state === IncomingPaymentState.Expired
+            ctx.request.prepare.amount !== '0' &&
+            [
+              IncomingPaymentState.Completed,
+              IncomingPaymentState.Expired
+            ].includes(incomingPayment.state)
           ) {
             throw new Errors.UnreachableError('destination account is disabled')
           }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Allow a disabled (completed/expired) incoming payment to be the stream destination "outgoing" account in the connector when handling a zero-amount packet.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes https://github.com/interledger/rafiki/issues/337
- resolves:

```
local-peer-backend-1  | {"level":20,"time":1668111855568,"pid":1,"hostname":"1cdf891dad52","service":"ConnectorService","err":{"type":"UnreachableError","message":"destination account is disabled","stack":"UnreachableError: destination account is disabled\n    at getAccountByDestinationAddress (/workspace/packages/backend/dist/connector/core/middleware/account.js:38:31)\n    at async account (/workspace/packages/backend/dist/connector/core/middleware/account.js:69:33)\n    at async /workspace/packages/backend/dist/connector/core/middleware/stream-address.js:9:9\n    at async /workspace/packages/backend/dist/connector/core/middleware/error-handler.js:14:13\n    at async ilpPacket (/workspace/packages/backend/dist/connector/core/middleware/ilp-packet.js:171:9)\n    at async auth (/workspace/packages/backend/dist/connector/core/middleware/auth.js:31:9)","ilpErrorCode":"F02"},"msg":"Error thrown in incoming pipeline"}
```

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
