### PR TITLE
fix(backend): check that outgoing payment quote is unused

### DIFF
--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -413,6 +413,20 @@ describe('OutgoingPaymentService', (): void => {
       ).resolves.toEqual(OutgoingPaymentError.UnknownQuote)
     })
 
+    it('fails to create on "consumed" quote', async () => {
+      const { quote } = await createOutgoingPayment(deps, {
+        paymentPointerId,
+        receiver,
+        validDestination: false
+      })
+      await expect(
+        outgoingPaymentService.create({
+          paymentPointerId,
+          quoteId: quote.id
+        })
+      ).resolves.toEqual(OutgoingPaymentError.InvalidQuote)
+    })
+
     it('fails to create on invalid quote payment pointer', async () => {
       const quote = await createQuote(deps, {
         paymentPointerId,

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -1,5 +1,9 @@
 import assert from 'assert'
-import { ForeignKeyViolationError, TransactionOrKnex } from 'objection'
+import {
+  ForeignKeyViolationError,
+  TransactionOrKnex,
+  UniqueViolationError
+} from 'objection'
 
 import { BaseService } from '../../../shared/baseService'
 import {
@@ -148,7 +152,11 @@ async function createOutgoingPayment(
       return await addSentAmount(deps, payment, BigInt(0))
     })
   } catch (err) {
-    if (err instanceof ForeignKeyViolationError) {
+    if (err instanceof UniqueViolationError) {
+      if (err.constraint === 'outgoingPayments_pkey') {
+        return OutgoingPaymentError.InvalidQuote
+      }
+    } else if (err instanceof ForeignKeyViolationError) {
       if (err.constraint === 'outgoingpayments_id_foreign') {
         return OutgoingPaymentError.UnknownQuote
       } else if (


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- A quote can only be used for a single outgoing payment. This is enforced by using the quote id (uuid) as the outgoing payment id. This PR makes `outgoingPaymentService.create` return `OutgoingPaymentError.InvalidQuote` if there is already an existing outgoing payment with the specified `quoteId`.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #471 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
