### PR TITLE
feat(auth): use ctx.throw, add 40X responses to idp spec

### DIFF
--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -127,9 +127,8 @@ describe('Access Token Routes', (): void => {
         access_token: v4(),
         resource_server: 'test'
       }
-      await expect(accessTokenRoutes.introspect(ctx)).resolves.toBeUndefined()
-      expect(ctx.status).toBe(404)
-      expect(ctx.body).toMatchObject({
+      await expect(accessTokenRoutes.introspect(ctx)).rejects.toMatchObject({
+        status: 404,
         error: 'invalid_request',
         message: 'token not found'
       })
@@ -353,7 +352,9 @@ describe('Access Token Routes', (): void => {
       managementId = v4()
       const ctx = createContext(
         {
-          headers: { Accept: 'application/json' }
+          headers: { Accept: 'application/json' },
+          method: 'POST',
+          url: `/token/${managementId}`
         },
         { id: managementId }
       )

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -44,12 +44,10 @@ async function introspectToken(
   if (introspectionResult) {
     ctx.body = introspectionToBody(introspectionResult)
   } else {
-    ctx.status = 404
-    ctx.body = {
+    ctx.throw(404, {
       error: 'invalid_request',
       message: 'token not found'
-    }
-    return
+    })
   }
 }
 
@@ -93,7 +91,6 @@ async function rotateToken(
       }
     }
   } else {
-    ctx.status = 404
-    return ctx.throw(ctx.status, result.error.message)
+    ctx.throw(404, { message: result.error.message })
   }
 }

--- a/packages/auth/src/grant/routes.test.ts
+++ b/packages/auth/src/grant/routes.test.ts
@@ -313,10 +313,10 @@ describe('Grant Routes', (): void => {
 
       ctx.request.body = { ...BASE_GRANT_REQUEST, interact: undefined }
 
-      await expect(grantRoutes.create(ctx)).rejects.toHaveProperty(
-        'status',
-        400
-      )
+      await expect(grantRoutes.create(ctx)).rejects.toMatchObject({
+        status: 400,
+        error: 'interaction_required'
+      })
 
       scope.isDone()
     })

--- a/packages/auth/src/openapi/id-provider.yaml
+++ b/packages/auth/src/openapi/id-provider.yaml
@@ -37,6 +37,8 @@ paths:
               schema:
                 type: string
               description: Interaction id
+        '401':
+          description: Unauthorized
       operationId: get-interact
       parameters:
         - schema:
@@ -71,6 +73,8 @@ paths:
               schema:
                 type: string
               description: Client finish endpoint
+        '401':
+          description: Unauthorized
       description: "To finish the user interaction for grant approval, this endpoint redirects the user to the client's finish url."
       parameters:
         - schema:
@@ -100,6 +104,8 @@ paths:
                 properties:
                   access:
                     $ref: ./schemas.yaml#/components/schemas/access
+        '401':
+          description: Unauthorized
         '404':
           description: Not Found
       operationId: get-grant
@@ -127,6 +133,8 @@ paths:
       responses:
         '202':
           description: Accepted
+        '400':
+          description: Not Found
         '401':
           description: Unauthorized
         '404':


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds 40X responses to the endpoints the AS extends for interactions
- Uses `ctx.throw` for all known errors.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
In order to surface certain errors properly, the needed to be reflected in the spec so that they wouldn't be swallowed by the validator.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
