### PR TITLE
feat(auth): check that token value matches during rotation & revocation

### DIFF
--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -325,11 +325,33 @@ describe('Access Token Routes', (): void => {
       jestOpenAPI(openApi.authServerSpec)
     })
 
-    test('Cannot rotate nonexistent token', async (): Promise<void> => {
+    test('Cannot rotate nonexistent token management id', async (): Promise<void> => {
       managementId = v4()
       const ctx = createContext(
         {
-          headers: { Accept: 'application/json' },
+          headers: {
+            Accept: 'application/json',
+            Authorization: `GNAP ${token.value}`
+          },
+          method: 'POST',
+          url: `/token/${managementId}`
+        },
+        { id: managementId }
+      )
+
+      await expect(accessTokenRoutes.rotate(ctx)).rejects.toMatchObject({
+        status: 404,
+        message: 'token not found'
+      })
+    })
+
+    test('Cannot rotate nonexistent token', async (): Promise<void> => {
+      const ctx = createContext(
+        {
+          headers: {
+            Accept: 'application/json',
+            Authorization: `GNAP ${v4()}`
+          },
           method: 'POST',
           url: `/token/${managementId}`
         },
@@ -345,7 +367,10 @@ describe('Access Token Routes', (): void => {
     test('Can rotate token', async (): Promise<void> => {
       const ctx = createContext(
         {
-          headers: { Accept: 'application/json' },
+          headers: {
+            Accept: 'application/json',
+            Authorization: `GNAP ${token.value}`
+          },
           url: `/token/${token.id}`,
           method: 'POST'
         },
@@ -376,7 +401,10 @@ describe('Access Token Routes', (): void => {
     test('Can rotate an expired token', async (): Promise<void> => {
       const ctx = createContext(
         {
-          headers: { Accept: 'application/json' },
+          headers: {
+            Accept: 'application/json',
+            Authorization: `GNAP ${token.value}`
+          },
           url: `/token/${token.id}`,
           method: 'POST'
         },

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -238,12 +238,30 @@ describe('Access Token Routes', (): void => {
       url = `/token/${managementId}`
     })
 
-    test('Returns status 204 even if token does not exist', async (): Promise<void> => {
+    test('Returns status 204 even if management id does not exist', async (): Promise<void> => {
       managementId = v4()
       const ctx = createContext(
         {
           headers: {
-            Accept: 'application/json'
+            Accept: 'application/json',
+            Authorization: `GNAP ${token.value}`
+          },
+          url: `/token/${managementId}`,
+          method
+        },
+        { id: managementId }
+      )
+
+      await accessTokenRoutes.revoke(ctx)
+      expect(ctx.response.status).toBe(204)
+    })
+
+    test('Returns status 204 even if token does not exist', async (): Promise<void> => {
+      const ctx = createContext(
+        {
+          headers: {
+            Accept: 'application/json',
+            Authorization: `GNAP ${v4()}`
           },
           url: `/token/${managementId}`,
           method
@@ -259,7 +277,8 @@ describe('Access Token Routes', (): void => {
       const ctx = createContext(
         {
           headers: {
-            Accept: 'application/json'
+            Accept: 'application/json',
+            Authorization: `GNAP ${token.value}`
           },
           url,
           method
@@ -281,7 +300,8 @@ describe('Access Token Routes', (): void => {
       const ctx = createContext(
         {
           headers: {
-            Accept: 'application/json'
+            Accept: 'application/json',
+            Authorization: `GNAP ${token.value}`
           },
           url,
           method

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -91,8 +91,9 @@ async function revokeToken(
   deps: ServiceDependencies,
   ctx: RevokeContext
 ): Promise<void> {
+  const token = (ctx.headers['authorization'] ?? '').replace('GNAP ', '')
   const { id: managementId } = ctx.params
-  await deps.accessTokenService.revoke(managementId)
+  await deps.accessTokenService.revoke(managementId, token)
   ctx.status = 204
 }
 
@@ -100,7 +101,6 @@ async function rotateToken(
   deps: ServiceDependencies,
   ctx: RotateContext
 ): Promise<void> {
-  // TODO: verify Authorization: GNAP ${accessToken} contains correct token value
   const { id: managementId } = ctx.params
   const token = (ctx.headers['authorization'] ?? '').replace('GNAP ', '')
   const result = await deps.accessTokenService.rotate(managementId, token)

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -102,7 +102,8 @@ async function rotateToken(
 ): Promise<void> {
   // TODO: verify Authorization: GNAP ${accessToken} contains correct token value
   const { id: managementId } = ctx.params
-  const result = await deps.accessTokenService.rotate(managementId)
+  const token = ctx.headers['authorization'].replace('GNAP ', '')
+  const result = await deps.accessTokenService.rotate(managementId, token)
   if (result.success == true) {
     ctx.status = 200
     ctx.body = {

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -102,7 +102,7 @@ async function rotateToken(
 ): Promise<void> {
   // TODO: verify Authorization: GNAP ${accessToken} contains correct token value
   const { id: managementId } = ctx.params
-  const token = ctx.headers['authorization'].replace('GNAP ', '')
+  const token = (ctx.headers['authorization'] ?? '').replace('GNAP ', '')
   const result = await deps.accessTokenService.rotate(managementId, token)
   if (result.success == true) {
     ctx.status = 200

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -209,7 +209,10 @@ describe('Access Token Service', (): void => {
     })
     test('Can revoke un-expired token', async (): Promise<void> => {
       await token.$query(trx).patch({ expiresIn: 1000000 })
-      const result = await accessTokenService.revoke(token.managementId)
+      const result = await accessTokenService.revoke(
+        token.managementId,
+        token.value
+      )
       expect(result).toBeUndefined()
       await expect(
         AccessToken.query(trx).findById(token.id)
@@ -217,7 +220,10 @@ describe('Access Token Service', (): void => {
     })
     test('Can revoke even if token has already expired', async (): Promise<void> => {
       await token.$query(trx).patch({ expiresIn: -1 })
-      const result = await accessTokenService.revoke(token.managementId)
+      const result = await accessTokenService.revoke(
+        token.managementId,
+        token.value
+      )
       expect(result).toBeUndefined()
       await expect(
         AccessToken.query(trx).findById(token.id)
@@ -225,7 +231,7 @@ describe('Access Token Service', (): void => {
     })
     test('Can revoke even if token has already been revoked', async (): Promise<void> => {
       await token.$query(trx).delete()
-      const result = await accessTokenService.revoke(token.id)
+      const result = await accessTokenService.revoke(token.id, token.value)
       expect(result).toBeUndefined()
       await expect(
         AccessToken.query(trx).findById(token.id)

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -262,13 +262,19 @@ describe('Access Token Service', (): void => {
 
     test('Can rotate un-expired token', async (): Promise<void> => {
       await token.$query(trx).patch({ expiresIn: 1000000 })
-      const result = await accessTokenService.rotate(token.managementId)
+      const result = await accessTokenService.rotate(
+        token.managementId,
+        token.value
+      )
       expect(result.success).toBe(true)
       expect(result.success && result.value).not.toBe(originalTokenValue)
     })
     test('Can rotate expired token', async (): Promise<void> => {
       await token.$query(trx).patch({ expiresIn: -1 })
-      const result = await accessTokenService.rotate(token.managementId)
+      const result = await accessTokenService.rotate(
+        token.managementId,
+        token.value
+      )
       expect(result.success).toBe(true)
       const rotatedToken = await AccessToken.query(trx).findOne({
         managementId: result.success && result.managementId
@@ -276,8 +282,12 @@ describe('Access Token Service', (): void => {
       expect(rotatedToken).toBeDefined()
       expect(rotatedToken?.value).not.toBe(originalTokenValue)
     })
-    test('Cannot rotate nonexistent token', async (): Promise<void> => {
-      const result = await accessTokenService.rotate(v4())
+    test('Cannot rotate token with incorrect management id', async (): Promise<void> => {
+      const result = await accessTokenService.rotate(v4(), token.value)
+      expect(result.success).toBe(false)
+    })
+    test('Cannot rotate token with incorrect value', async (): Promise<void> => {
+      const result = await accessTokenService.rotate(token.managementId, v4())
       expect(result.success).toBe(false)
     })
   })

--- a/packages/auth/src/accessToken/service.ts
+++ b/packages/auth/src/accessToken/service.ts
@@ -14,7 +14,7 @@ export interface AccessTokenService {
   get(token: string): Promise<AccessToken>
   getByManagementId(managementId: string): Promise<AccessToken>
   introspect(token: string): Promise<Introspection | undefined>
-  revoke(id: string): Promise<void>
+  revoke(id: string, tokenValue: string): Promise<void>
   create(grantId: string, opts?: AccessTokenOpts): Promise<AccessToken>
   rotate(managementId: string, tokenValue: string): Promise<Rotation>
 }
@@ -76,7 +76,7 @@ export async function createAccessTokenService({
     getByManagementId: (managementId: string) =>
       getByManagementId(managementId),
     introspect: (token: string) => introspect(deps, token),
-    revoke: (id: string) => revoke(deps, id),
+    revoke: (id: string, tokenValue: string) => revoke(deps, id, tokenValue),
     create: (grantId: string, opts?: AccessTokenOpts) =>
       createAccessToken(deps, grantId, opts),
     rotate: (managementId: string, tokenValue: string) =>
@@ -138,9 +138,13 @@ async function introspect(
   }
 }
 
-async function revoke(deps: ServiceDependencies, id: string): Promise<void> {
+async function revoke(
+  deps: ServiceDependencies,
+  id: string,
+  tokenValue: string
+): Promise<void> {
   const token = await AccessToken.query(deps.knex).findOne({ managementId: id })
-  if (token) {
+  if (token && token.value === tokenValue) {
     await token.$query(deps.knex).delete()
   }
 }

--- a/packages/auth/src/accessToken/service.ts
+++ b/packages/auth/src/accessToken/service.ts
@@ -79,7 +79,8 @@ export async function createAccessTokenService({
     revoke: (id: string) => revoke(deps, id),
     create: (grantId: string, opts?: AccessTokenOpts) =>
       createAccessToken(deps, grantId, opts),
-    rotate: (managementId: string, tokenValue: string) => rotate(deps, managementId, tokenValue)
+    rotate: (managementId: string, tokenValue: string) =>
+      rotate(deps, managementId, tokenValue)
   }
 }
 

--- a/packages/auth/src/app.ts
+++ b/packages/auth/src/app.ts
@@ -72,7 +72,6 @@ export interface AppServices {
   knex: Promise<Knex>
   closeEmitter: Promise<EventEmitter>
   config: Promise<IAppConfig>
-  // TODO: Add GNAP-related services
   clientService: Promise<ClientService>
   grantService: Promise<GrantService>
   accessTokenRoutes: Promise<AccessTokenRoutes>
@@ -123,7 +122,6 @@ export class App {
       session(
         {
           key: 'sessionId',
-          // TODO: make this time shorter?
           maxAge: 60 * 1000,
           signed: true
         },
@@ -272,7 +270,6 @@ export class App {
     )
 
     /* Front Channel Routes */
-    // TODO: update front-channel routes to have /frontend prefix here and in openapi spec
 
     // Interaction start
     this.publicRouter.get(

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -35,7 +35,7 @@ export const Config = {
   authServerDomain: envString(
     'AUTH_SERVER_DOMAIN',
     `http://localhost:${envInt('PORT', 3006)}`
-  ), // TODO: replace this with whatever frontend port ends up being
+  ),
   waitTimeSeconds: envInt('WAIT_SECONDS', 5),
   cookieKey: envString('COOKIE_KEY', crypto.randomBytes(32).toString('hex')),
   accessTokenExpirySeconds: envInt('ACCESS_TOKEN_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes

--- a/packages/auth/src/grant/routes.test.ts
+++ b/packages/auth/src/grant/routes.test.ts
@@ -266,6 +266,7 @@ describe('Grant Routes', (): void => {
   })
 
   // TODO: validate that routes satisfy API spec
+  // https://github.com/interledger/rafiki/issues/841
   describe('interaction', (): void => {
     beforeEach(async (): Promise<void> => {
       const openApi = await deps.use('openApi')

--- a/packages/auth/src/grant/routes.ts
+++ b/packages/auth/src/grant/routes.ts
@@ -273,7 +273,6 @@ async function startInteraction(
     ctx.throw(401, { error: 'unknown_request' })
   }
 
-  // TODO: also establish session in redis with short expiry
   ctx.session.nonce = grant.interactNonce
 
   const interactionUrl = new URL(config.identityServerDomain)
@@ -286,11 +285,11 @@ async function startInteraction(
 }
 
 // TODO: allow idp to specify the reason for rejection
+// https://github.com/interledger/rafiki/issues/886
 async function handleGrantChoice(
   deps: ServiceDependencies,
   ctx: ChooseContext
 ): Promise<void> {
-  // TODO: check redis for a session
   const { id: interactId, nonce, choice } = ctx.params
   const { config, grantService } = deps
 

--- a/packages/auth/src/grant/service.ts
+++ b/packages/auth/src/grant/service.ts
@@ -139,8 +139,10 @@ async function create(
       interactId: interact ? v4() : undefined,
       interactRef: interact ? v4() : undefined,
       interactNonce: interact
-        ? crypto.randomBytes(8).toString('hex').toUpperCase()
-        : undefined, // TODO: factor out nonce generation
+        ? // TODO: factor out nonce generation
+          // https://github.com/interledger/rafiki/issues/887
+          crypto.randomBytes(8).toString('hex').toUpperCase()
+        : undefined,
       continueId: v4(),
       continueToken: crypto.randomBytes(8).toString('hex').toUpperCase()
     })

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -60,7 +60,6 @@ export function initIocContainer(
   })
 
   container.singleton('closeEmitter', async () => new EventEmitter())
-  // TODO: add redis
 
   container.singleton('openPaymentsClient', async (deps) => {
     const logger = await deps.use('logger')
@@ -161,9 +160,6 @@ export const gracefulShutdown = async (
   await app.shutdown()
   const knex = await container.use('knex')
   await knex.destroy()
-  // TODO: add redis to container
-  // const redis = await container.use('redis')
-  // await redis.disconnect()
 }
 
 export const start = async (


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Checks the token value during revocation and rotation.
- Adds some in-line issues in the comments.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Closes #832.

When rotating and revoking a token, the provided management id in the URL was used to retrieve the token, but the token value that's provided during these requests wasn't being verified against the token that was retrieved.

Also, some TODOs did not have an associated Github issue attached to them. These have been created and their URIs have been added to the original associted in-line comments.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
