### PR TITLE
fix(auth): test that client info is passed along when interaction is started

### DIFF
--- a/packages/auth/src/grant/routes.test.ts
+++ b/packages/auth/src/grant/routes.test.ts
@@ -295,6 +295,10 @@ describe('Grant Routes', (): void => {
             headers: {
               Accept: 'application/json',
               'Content-Type': 'application/json'
+            },
+            query: {
+              clientName: 'Test Client',
+              clientUri: 'https://example.com'
             }
           },
           { id: grant.interactId, nonce: grant.interactNonce }
@@ -309,9 +313,8 @@ describe('Grant Routes', (): void => {
         ).resolves.toBeUndefined()
 
         redirectUrl.searchParams.set('nonce', grant.interactNonce as string)
-        // TODO: make sure display params get passed through; not passing them now to fix tests for demo
-        redirectUrl.searchParams.set('clientName', 'undefined')
-        redirectUrl.searchParams.set('clientUri', 'undefined')
+        redirectUrl.searchParams.set('clientName', 'Test Client')
+        redirectUrl.searchParams.set('clientUri', 'https://example.com')
 
         expect(ctx.status).toBe(302)
         expect(redirectSpy).toHaveBeenCalledWith(redirectUrl.toString())

--- a/packages/auth/src/tests/context.ts
+++ b/packages/auth/src/tests/context.ts
@@ -31,6 +31,7 @@ export function createContext(
   )
   const ctx = koa.createContext(req, res)
   ctx.params = params
+  ctx.query = reqOpts.query
   ctx.session = { ...req.session }
   ctx.closeEmitter = new EventEmitter()
   ctx.container = container


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Tests that `clientName` and `clientUri` are passed in the redirect that's made when an interaction is started.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Closes #842.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
