### PR TITLE
663/mk/standardize op client requests

### DIFF
--- a/packages/open-payments/src/client/grant.ts
+++ b/packages/open-payments/src/client/grant.ts
@@ -1,5 +1,9 @@
 import { HttpMethod } from 'openapi'
-import { RouteDeps } from '.'
+import {
+  ResourceRequestArgs,
+  RouteDeps,
+  UnauthenticatedResourceRequestArgs
+} from '.'
 import {
   getASPath,
   InteractiveGrant,
@@ -13,21 +17,16 @@ export interface GrantRouteDeps extends RouteDeps {
   client: string
 }
 
-interface PostArgs {
-  url: string
-  accessToken: string
-}
-
 export interface GrantRoutes {
   request(
-    postArgs: Omit<PostArgs, 'accessToken'>,
+    postArgs: UnauthenticatedResourceRequestArgs,
     args: Omit<GrantRequest, 'client'>
   ): Promise<InteractiveGrant | NonInteractiveGrant>
   continue(
-    postArgs: PostArgs,
+    postArgs: ResourceRequestArgs,
     args: GrantContinuationRequest
   ): Promise<NonInteractiveGrant>
-  cancel(postArgs: PostArgs): Promise<void>
+  cancel(postArgs: ResourceRequestArgs): Promise<void>
 }
 
 export const createGrantRoutes = (deps: GrantRouteDeps): GrantRoutes => {
@@ -49,7 +48,7 @@ export const createGrantRoutes = (deps: GrantRouteDeps): GrantRoutes => {
 
   return {
     request: (
-      { url }: Omit<PostArgs, 'accessToken'>,
+      { url }: UnauthenticatedResourceRequestArgs,
       args: Omit<GrantRequest, 'client'>
     ) =>
       post(
@@ -64,7 +63,7 @@ export const createGrantRoutes = (deps: GrantRouteDeps): GrantRoutes => {
         requestGrantValidator
       ),
     continue: (
-      { url, accessToken }: PostArgs,
+      { url, accessToken }: ResourceRequestArgs,
       args: GrantContinuationRequest
     ) =>
       post(
@@ -76,7 +75,7 @@ export const createGrantRoutes = (deps: GrantRouteDeps): GrantRoutes => {
         },
         continueGrantValidator
       ),
-    cancel: ({ url, accessToken }: PostArgs) =>
+    cancel: ({ url, accessToken }: ResourceRequestArgs) =>
       deleteRequest(
         deps,
         {

--- a/packages/open-payments/src/client/ilp-stream-connection.test.ts
+++ b/packages/open-payments/src/client/ilp-stream-connection.test.ts
@@ -1,7 +1,20 @@
 import { createILPStreamConnectionRoutes } from './ilp-stream-connection'
 import { OpenAPI, HttpMethod, createOpenAPI } from 'openapi'
 import path from 'path'
-import { defaultAxiosInstance, silentLogger } from '../test/helpers'
+import {
+  defaultAxiosInstance,
+  mockILPStreamConnection,
+  silentLogger
+} from '../test/helpers'
+import * as requestors from './requests'
+
+jest.mock('./requests', () => {
+  return {
+    // https://jestjs.io/docs/jest-object#jestmockmodulename-factory-options
+    __esModule: true,
+    ...jest.requireActual('./requests')
+  }
+})
 
 describe('ilp-stream-connection', (): void => {
   let openApi: OpenAPI
@@ -15,14 +28,34 @@ describe('ilp-stream-connection', (): void => {
   const axiosInstance = defaultAxiosInstance
   const logger = silentLogger
 
-  describe('createILPStreamConnectionRoutes', (): void => {
-    test('calls createResponseValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
+  describe('routes', (): void => {
+    const ilpStreamConnection = mockILPStreamConnection()
 
-      createILPStreamConnectionRoutes({ axiosInstance, openApi, logger })
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/connections/{id}',
-        method: HttpMethod.GET
+    describe('get', (): void => {
+      test('calls get method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/connections/{id}' && method === HttpMethod.GET
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const getSpy = jest
+          .spyOn(requestors, 'get')
+          .mockResolvedValueOnce(ilpStreamConnection)
+
+        await createILPStreamConnectionRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).get({ url: ilpStreamConnection.id })
+
+        expect(getSpy).toHaveBeenCalledWith(
+          { axiosInstance, logger },
+          { url: ilpStreamConnection.id },
+          true
+        )
       })
     })
   })

--- a/packages/open-payments/src/client/ilp-stream-connection.ts
+++ b/packages/open-payments/src/client/ilp-stream-connection.ts
@@ -1,14 +1,10 @@
 import { HttpMethod } from 'openapi'
-import { RouteDeps } from '.'
+import { RouteDeps, UnauthenticatedResourceRequestArgs } from '.'
 import { getRSPath, ILPStreamConnection } from '../types'
 import { get } from './requests'
 
-interface GetArgs {
-  url: string
-}
-
 export interface ILPStreamConnectionRoutes {
-  get(args: GetArgs): Promise<ILPStreamConnection>
+  get(args: UnauthenticatedResourceRequestArgs): Promise<ILPStreamConnection>
 }
 
 export const createILPStreamConnectionRoutes = (
@@ -23,7 +19,7 @@ export const createILPStreamConnectionRoutes = (
     })
 
   return {
-    get: (args: GetArgs) =>
+    get: (args: UnauthenticatedResourceRequestArgs) =>
       get({ axiosInstance, logger }, args, getILPStreamConnectionValidator)
   }
 }

--- a/packages/open-payments/src/client/incoming-payment.test.ts
+++ b/packages/open-payments/src/client/incoming-payment.test.ts
@@ -42,7 +42,8 @@ describe('incoming-payment', (): void => {
 
   const axiosInstance = defaultAxiosInstance
   const logger = silentLogger
-  const paymentPointer = `http://localhost:1000/.well-known/pay`
+  const paymentPointer = 'http://localhost:1000/.well-known/pay'
+  const accessToken = 'accessToken'
   const openApiValidators = mockOpenApiResponseValidators()
 
   describe('getIncomingPayment', (): void => {
@@ -57,7 +58,7 @@ describe('incoming-payment', (): void => {
         { axiosInstance, logger },
         {
           url: `${paymentPointer}/incoming-payments/1`,
-          accessToken: 'accessToken'
+          accessToken
         },
         openApiValidators.successfulValidator
       )
@@ -82,7 +83,7 @@ describe('incoming-payment', (): void => {
         .get('/incoming-payments/1')
         .reply(200, incomingPayment)
 
-      await expect(() =>
+      await expect(
         getIncomingPayment(
           {
             axiosInstance,
@@ -90,7 +91,7 @@ describe('incoming-payment', (): void => {
           },
           {
             url: `${paymentPointer}/incoming-payments/1`,
-            accessToken: 'accessToken'
+            accessToken
           },
           openApiValidators.successfulValidator
         )
@@ -104,7 +105,7 @@ describe('incoming-payment', (): void => {
         .get('/incoming-payments/1')
         .reply(200, incomingPayment)
 
-      await expect(() =>
+      await expect(
         getIncomingPayment(
           {
             axiosInstance,
@@ -112,7 +113,7 @@ describe('incoming-payment', (): void => {
           },
           {
             url: `${paymentPointer}/incoming-payments/1`,
-            accessToken: 'accessToken'
+            accessToken
           },
           openApiValidators.failedValidator
         )
@@ -146,7 +147,7 @@ describe('incoming-payment', (): void => {
 
         const result = await createIncomingPayment(
           { axiosInstance, logger },
-          { paymentPointer, accessToken: 'accessToken' },
+          { paymentPointer, accessToken },
           openApiValidators.successfulValidator,
           {
             incomingAmount,
@@ -178,10 +179,10 @@ describe('incoming-payment', (): void => {
         .post('/incoming-payments')
         .reply(200, incomingPayment)
 
-      await expect(() =>
+      await expect(
         createIncomingPayment(
           { axiosInstance, logger },
-          { paymentPointer, accessToken: 'accessToken' },
+          { paymentPointer, accessToken },
           openApiValidators.successfulValidator,
           {}
         )
@@ -196,10 +197,10 @@ describe('incoming-payment', (): void => {
         .post('/incoming-payments')
         .reply(200, incomingPayment)
 
-      await expect(() =>
+      await expect(
         createIncomingPayment(
           { axiosInstance, logger },
-          { paymentPointer, accessToken: 'accessToken' },
+          { paymentPointer, accessToken },
           openApiValidators.failedValidator,
           {}
         )
@@ -222,7 +223,7 @@ describe('incoming-payment', (): void => {
         { axiosInstance, logger },
         {
           url: `${paymentPointer}/incoming-payments/${incomingPayment.id}`,
-          accessToken: 'accessToken'
+          accessToken
         },
         openApiValidators.successfulValidator
       )
@@ -241,12 +242,12 @@ describe('incoming-payment', (): void => {
         .post(`/incoming-payments/${incomingPayment.id}/complete`)
         .reply(200, incomingPayment)
 
-      await expect(() =>
+      await expect(
         completeIncomingPayment(
           { axiosInstance, logger },
           {
             url: `${paymentPointer}/incoming-payments/${incomingPayment.id}`,
-            accessToken: 'accessToken'
+            accessToken
           },
           openApiValidators.successfulValidator
         )
@@ -264,12 +265,12 @@ describe('incoming-payment', (): void => {
         .post(`/incoming-payments/${incomingPayment.id}/complete`)
         .reply(200, incomingPayment)
 
-      await expect(() =>
+      await expect(
         completeIncomingPayment(
           { axiosInstance, logger },
           {
             url: `${paymentPointer}/incoming-payments/${incomingPayment.id}`,
-            accessToken: 'accessToken'
+            accessToken
           },
           openApiValidators.failedValidator
         )
@@ -309,7 +310,7 @@ describe('incoming-payment', (): void => {
             },
             {
               paymentPointer,
-              accessToken: 'accessToken'
+              accessToken
             },
             openApiValidators.successfulValidator,
             {
@@ -352,7 +353,7 @@ describe('incoming-payment', (): void => {
             },
             {
               paymentPointer,
-              accessToken: 'accessToken'
+              accessToken
             },
             openApiValidators.successfulValidator,
             {
@@ -390,7 +391,7 @@ describe('incoming-payment', (): void => {
         .get('/incoming-payments')
         .reply(200, incomingPaymentPaginationResult)
 
-      await expect(() =>
+      await expect(
         listIncomingPayment(
           {
             axiosInstance,
@@ -398,7 +399,7 @@ describe('incoming-payment', (): void => {
           },
           {
             paymentPointer,
-            accessToken: 'accessToken'
+            accessToken
           },
           openApiValidators.successfulValidator
         )
@@ -415,10 +416,10 @@ describe('incoming-payment', (): void => {
         .get('/incoming-payments')
         .reply(200, incomingPaymentPaginationResult)
 
-      await expect(() =>
+      await expect(
         listIncomingPayment(
           { axiosInstance, logger },
-          { paymentPointer, accessToken: 'accessToken' },
+          { paymentPointer, accessToken },
           openApiValidators.failedValidator
         )
       ).rejects.toThrowError()
@@ -663,14 +664,14 @@ describe('incoming-payment', (): void => {
           openApi,
           axiosInstance,
           logger
-        }).get({ url, accessToken: 'accessToken' })
+        }).get({ url, accessToken })
 
         expect(getSpy).toHaveBeenCalledWith(
           {
             axiosInstance,
             logger
           },
-          { url, accessToken: 'accessToken' },
+          { url, accessToken },
           true
         )
       })
@@ -700,14 +701,14 @@ describe('incoming-payment', (): void => {
           openApi,
           axiosInstance,
           logger
-        }).list({ paymentPointer, accessToken: 'accessToken' })
+        }).list({ paymentPointer, accessToken })
 
         expect(getSpy).toHaveBeenCalledWith(
           {
             axiosInstance,
             logger
           },
-          { url, accessToken: 'accessToken' },
+          { url, accessToken },
           true
         )
       })
@@ -737,17 +738,14 @@ describe('incoming-payment', (): void => {
           openApi,
           axiosInstance,
           logger
-        }).create(
-          { paymentPointer, accessToken: 'accessToken' },
-          incomingPaymentCreateArgs
-        )
+        }).create({ paymentPointer, accessToken }, incomingPaymentCreateArgs)
 
         expect(postSpy).toHaveBeenCalledWith(
           {
             axiosInstance,
             logger
           },
-          { url, accessToken: 'accessToken', body: incomingPaymentCreateArgs },
+          { url, accessToken, body: incomingPaymentCreateArgs },
           true
         )
       })
@@ -774,14 +772,14 @@ describe('incoming-payment', (): void => {
           openApi,
           axiosInstance,
           logger
-        }).complete({ url: incomingPaymentUrl, accessToken: 'accessToken' })
+        }).complete({ url: incomingPaymentUrl, accessToken })
 
         expect(postSpy).toHaveBeenCalledWith(
           {
             axiosInstance,
             logger
           },
-          { url: `${incomingPaymentUrl}/complete`, accessToken: 'accessToken' },
+          { url: `${incomingPaymentUrl}/complete`, accessToken },
           true
         )
       })

--- a/packages/open-payments/src/client/incoming-payment.test.ts
+++ b/packages/open-payments/src/client/incoming-payment.test.ts
@@ -42,83 +42,21 @@ describe('incoming-payment', (): void => {
 
   const axiosInstance = defaultAxiosInstance
   const logger = silentLogger
-  const baseUrl = 'http://localhost:1000'
+  const paymentPointer = `http://localhost:1000/.well-known/pay`
   const openApiValidators = mockOpenApiResponseValidators()
-
-  describe('createIncomingPaymentRoutes', (): void => {
-    test('creates getIncomingPaymentOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createIncomingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/incoming-payments/{id}',
-        method: HttpMethod.GET
-      })
-    })
-
-    test('creates createIncomingPaymentOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createIncomingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/incoming-payments',
-        method: HttpMethod.POST
-      })
-    })
-
-    test('creates completeIncomingPaymentOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createIncomingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/incoming-payments/{id}/complete',
-        method: HttpMethod.POST
-      })
-    })
-
-    test('creates listIncomingPaymentsOpenApiValidator', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createIncomingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/incoming-payments',
-        method: HttpMethod.GET
-      })
-    })
-  })
 
   describe('getIncomingPayment', (): void => {
     test('returns incoming payment if passes validation', async (): Promise<void> => {
       const incomingPayment = mockIncomingPayment()
 
-      nock(baseUrl).get('/incoming-payments').reply(200, incomingPayment)
+      nock(paymentPointer)
+        .get('/incoming-payments/1')
+        .reply(200, incomingPayment)
 
       const result = await getIncomingPayment(
+        { axiosInstance, logger },
         {
-          axiosInstance,
-          logger
-        },
-        {
-          url: `${baseUrl}/incoming-payments`,
+          url: `${paymentPointer}/incoming-payments/1`,
           accessToken: 'accessToken'
         },
         openApiValidators.successfulValidator
@@ -140,7 +78,9 @@ describe('incoming-payment', (): void => {
         }
       })
 
-      nock(baseUrl).get('/incoming-payments').reply(200, incomingPayment)
+      nock(paymentPointer)
+        .get('/incoming-payments/1')
+        .reply(200, incomingPayment)
 
       await expect(() =>
         getIncomingPayment(
@@ -149,7 +89,7 @@ describe('incoming-payment', (): void => {
             logger
           },
           {
-            url: `${baseUrl}/incoming-payments`,
+            url: `${paymentPointer}/incoming-payments/1`,
             accessToken: 'accessToken'
           },
           openApiValidators.successfulValidator
@@ -160,7 +100,9 @@ describe('incoming-payment', (): void => {
     test('throws if incoming payment does not pass open api validation', async (): Promise<void> => {
       const incomingPayment = mockIncomingPayment()
 
-      nock(baseUrl).get('/incoming-payments').reply(200, incomingPayment)
+      nock(paymentPointer)
+        .get('/incoming-payments/1')
+        .reply(200, incomingPayment)
 
       await expect(() =>
         getIncomingPayment(
@@ -169,7 +111,7 @@ describe('incoming-payment', (): void => {
             logger
           },
           {
-            url: `${baseUrl}/incoming-payments`,
+            url: `${paymentPointer}/incoming-payments/1`,
             accessToken: 'accessToken'
           },
           openApiValidators.failedValidator
@@ -198,26 +140,20 @@ describe('incoming-payment', (): void => {
           externalRef
         })
 
-        const scope = nock(baseUrl)
+        const scope = nock(paymentPointer)
           .post('/incoming-payments')
           .reply(200, incomingPayment)
 
         const result = await createIncomingPayment(
+          { axiosInstance, logger },
+          { paymentPointer, accessToken: 'accessToken' },
+          openApiValidators.successfulValidator,
           {
-            axiosInstance,
-            logger
-          },
-          {
-            url: `${baseUrl}/incoming-payments`,
-            body: {
-              incomingAmount,
-              expiresAt,
-              description,
-              externalRef
-            },
-            accessToken: 'accessToken'
-          },
-          openApiValidators.successfulValidator
+            incomingAmount,
+            expiresAt,
+            description,
+            externalRef
+          }
         )
 
         scope.done()
@@ -238,19 +174,16 @@ describe('incoming-payment', (): void => {
         completed: false
       })
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post('/incoming-payments')
         .reply(200, incomingPayment)
 
       await expect(() =>
         createIncomingPayment(
           { axiosInstance, logger },
-          {
-            url: `${baseUrl}/incoming-payments`,
-            body: {},
-            accessToken: 'accessToken'
-          },
-          openApiValidators.successfulValidator
+          { paymentPointer, accessToken: 'accessToken' },
+          openApiValidators.successfulValidator,
+          {}
         )
       ).rejects.toThrowError()
       scope.done()
@@ -259,22 +192,16 @@ describe('incoming-payment', (): void => {
     test('throws if the created incoming payment does not pass open api validation', async (): Promise<void> => {
       const incomingPayment = mockIncomingPayment()
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post('/incoming-payments')
         .reply(200, incomingPayment)
 
       await expect(() =>
         createIncomingPayment(
-          {
-            axiosInstance,
-            logger
-          },
-          {
-            url: `${baseUrl}/incoming-payments`,
-            body: {},
-            accessToken: 'accessToken'
-          },
-          openApiValidators.failedValidator
+          { axiosInstance, logger },
+          { paymentPointer, accessToken: 'accessToken' },
+          openApiValidators.failedValidator,
+          {}
         )
       ).rejects.toThrowError()
       scope.done()
@@ -287,14 +214,14 @@ describe('incoming-payment', (): void => {
         completed: true
       })
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post(`/incoming-payments/${incomingPayment.id}/complete`)
         .reply(200, incomingPayment)
 
       const result = await completeIncomingPayment(
         { axiosInstance, logger },
         {
-          url: `${baseUrl}/incoming-payments/${incomingPayment.id}/complete`,
+          url: `${paymentPointer}/incoming-payments/${incomingPayment.id}`,
           accessToken: 'accessToken'
         },
         openApiValidators.successfulValidator
@@ -310,7 +237,7 @@ describe('incoming-payment', (): void => {
         completed: false
       })
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post(`/incoming-payments/${incomingPayment.id}/complete`)
         .reply(200, incomingPayment)
 
@@ -318,7 +245,7 @@ describe('incoming-payment', (): void => {
         completeIncomingPayment(
           { axiosInstance, logger },
           {
-            url: `${baseUrl}/incoming-payments/${incomingPayment.id}/complete`,
+            url: `${paymentPointer}/incoming-payments/${incomingPayment.id}`,
             accessToken: 'accessToken'
           },
           openApiValidators.successfulValidator
@@ -333,7 +260,7 @@ describe('incoming-payment', (): void => {
         completed: true
       })
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post(`/incoming-payments/${incomingPayment.id}/complete`)
         .reply(200, incomingPayment)
 
@@ -341,7 +268,7 @@ describe('incoming-payment', (): void => {
         completeIncomingPayment(
           { axiosInstance, logger },
           {
-            url: `${baseUrl}/incoming-payments/${incomingPayment.id}/complete`,
+            url: `${paymentPointer}/incoming-payments/${incomingPayment.id}`,
             accessToken: 'accessToken'
           },
           openApiValidators.failedValidator
@@ -353,8 +280,6 @@ describe('incoming-payment', (): void => {
   })
 
   describe('listIncomingPayment', (): void => {
-    const paymentPointer = `${baseUrl}/.well-known/pay`
-
     describe('forward pagination', (): void => {
       test.each`
         first        | cursor
@@ -718,6 +643,39 @@ describe('incoming-payment', (): void => {
   })
 
   describe('routes', (): void => {
+    describe('get', (): void => {
+      test('calls get method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/incoming-payments/{id}' && method === HttpMethod.GET
+
+        const url = `${paymentPointer}/incoming-payments/1`
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const getSpy = jest
+          .spyOn(requestors, 'get')
+          .mockResolvedValueOnce(mockIncomingPayment())
+
+        await createIncomingPaymentRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).get({ url, accessToken: 'accessToken' })
+
+        expect(getSpy).toHaveBeenCalledWith(
+          {
+            axiosInstance,
+            logger
+          },
+          { url, accessToken: 'accessToken' },
+          true
+        )
+      })
+    })
+
     describe('list', (): void => {
       test('calls get method with correct validator', async (): Promise<void> => {
         const mockResponseValidator = ({ path, method }) =>
@@ -727,7 +685,6 @@ describe('incoming-payment', (): void => {
           mockIncomingPaymentPaginationResult({
             result: [mockIncomingPayment()]
           })
-        const paymentPointer = `${baseUrl}/.well-known/pay`
         const url = `${paymentPointer}${getRSPath('/incoming-payments')}`
 
         jest
@@ -751,6 +708,80 @@ describe('incoming-payment', (): void => {
             logger
           },
           { url, accessToken: 'accessToken' },
+          true
+        )
+      })
+    })
+
+    describe('create', (): void => {
+      test('calls post method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/incoming-payments' && method === HttpMethod.POST
+
+        const url = `${paymentPointer}/incoming-payments`
+        const incomingPaymentCreateArgs = {
+          description: 'Invoice',
+          incomingAmount: { assetCode: 'USD', assetScale: 2, value: '10' }
+        }
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const postSpy = jest
+          .spyOn(requestors, 'post')
+          .mockResolvedValueOnce(mockIncomingPayment(incomingPaymentCreateArgs))
+
+        await createIncomingPaymentRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).create(
+          { paymentPointer, accessToken: 'accessToken' },
+          incomingPaymentCreateArgs
+        )
+
+        expect(postSpy).toHaveBeenCalledWith(
+          {
+            axiosInstance,
+            logger
+          },
+          { url, accessToken: 'accessToken', body: incomingPaymentCreateArgs },
+          true
+        )
+      })
+    })
+
+    describe('complete', (): void => {
+      test('calls post method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/incoming-payments/{id}/complete' &&
+          method === HttpMethod.POST
+
+        const incomingPaymentUrl = `${paymentPointer}/incoming-payments/1`
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const postSpy = jest
+          .spyOn(requestors, 'post')
+          .mockResolvedValueOnce(mockIncomingPayment({ completed: true }))
+
+        await createIncomingPaymentRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).complete({ url: incomingPaymentUrl, accessToken: 'accessToken' })
+
+        expect(postSpy).toHaveBeenCalledWith(
+          {
+            axiosInstance,
+            logger
+          },
+          { url: `${incomingPaymentUrl}/complete`, accessToken: 'accessToken' },
           true
         )
       })

--- a/packages/open-payments/src/client/incoming-payment.ts
+++ b/packages/open-payments/src/client/incoming-payment.ts
@@ -1,5 +1,10 @@
 import { HttpMethod, ResponseValidator } from 'openapi'
-import { BaseDeps, RouteDeps } from '.'
+import {
+  BaseDeps,
+  CollectionRequestArgs,
+  ResourceRequestArgs,
+  RouteDeps
+} from '.'
 import {
   IncomingPayment,
   getRSPath,
@@ -9,25 +14,15 @@ import {
 } from '../types'
 import { get, post } from './requests'
 
-interface RequestWithUrlArgs {
-  url: string
-  accessToken: string
-}
-
-interface RequestWithPaymentPointerArgs {
-  paymentPointer: string
-  accessToken: string
-}
-
 export interface IncomingPaymentRoutes {
-  get(args: RequestWithUrlArgs): Promise<IncomingPayment>
+  get(args: ResourceRequestArgs): Promise<IncomingPayment>
   create(
-    args: RequestWithPaymentPointerArgs,
+    args: CollectionRequestArgs,
     createArgs: CreateIncomingPaymentArgs
   ): Promise<IncomingPayment>
-  complete(args: RequestWithUrlArgs): Promise<IncomingPayment>
+  complete(args: ResourceRequestArgs): Promise<IncomingPayment>
   list(
-    args: RequestWithPaymentPointerArgs,
+    args: CollectionRequestArgs,
     pagination?: PaginationArgs
   ): Promise<IncomingPaymentPaginationResult>
 }
@@ -62,14 +57,14 @@ export const createIncomingPaymentRoutes = (
     })
 
   return {
-    get: (args: RequestWithUrlArgs) =>
+    get: (args: ResourceRequestArgs) =>
       getIncomingPayment(
         { axiosInstance, logger },
         args,
         getIncomingPaymentOpenApiValidator
       ),
     create: (
-      requestArgs: RequestWithPaymentPointerArgs,
+      requestArgs: CollectionRequestArgs,
       createArgs: CreateIncomingPaymentArgs
     ) =>
       createIncomingPayment(
@@ -78,13 +73,13 @@ export const createIncomingPaymentRoutes = (
         createIncomingPaymentOpenApiValidator,
         createArgs
       ),
-    complete: (args: RequestWithUrlArgs) =>
+    complete: (args: ResourceRequestArgs) =>
       completeIncomingPayment(
         { axiosInstance, logger },
         args,
         completeIncomingPaymentOpenApiValidator
       ),
-    list: (args: RequestWithPaymentPointerArgs, pagination?: PaginationArgs) =>
+    list: (args: CollectionRequestArgs, pagination?: PaginationArgs) =>
       listIncomingPayment(
         { axiosInstance, logger },
         args,
@@ -96,7 +91,7 @@ export const createIncomingPaymentRoutes = (
 
 export const getIncomingPayment = async (
   deps: BaseDeps,
-  args: RequestWithUrlArgs,
+  args: ResourceRequestArgs,
   validateOpenApiResponse: ResponseValidator<IncomingPayment>
 ) => {
   const { axiosInstance, logger } = deps
@@ -120,7 +115,7 @@ export const getIncomingPayment = async (
 
 export const createIncomingPayment = async (
   deps: BaseDeps,
-  requestArgs: RequestWithPaymentPointerArgs,
+  requestArgs: CollectionRequestArgs,
   validateOpenApiResponse: ResponseValidator<IncomingPayment>,
   createArgs: CreateIncomingPaymentArgs
 ) => {
@@ -146,7 +141,7 @@ export const createIncomingPayment = async (
 
 export const completeIncomingPayment = async (
   deps: BaseDeps,
-  args: RequestWithUrlArgs,
+  args: ResourceRequestArgs,
   validateOpenApiResponse: ResponseValidator<IncomingPayment>
 ) => {
   const { axiosInstance, logger } = deps
@@ -171,7 +166,7 @@ export const completeIncomingPayment = async (
 
 export const listIncomingPayment = async (
   deps: BaseDeps,
-  args: RequestWithPaymentPointerArgs,
+  args: CollectionRequestArgs,
   validateOpenApiResponse: ResponseValidator<IncomingPaymentPaginationResult>,
   pagination?: PaginationArgs
 ) => {

--- a/packages/open-payments/src/client/index.ts
+++ b/packages/open-payments/src/client/index.ts
@@ -45,14 +45,15 @@ export interface UnauthenticatedResourceRequestArgs {
   url: string
 }
 
-export interface ResourceRequestArgs {
-  url: string
+interface AuthenticatedRequestArgs {
   accessToken: string
 }
+export interface ResourceRequestArgs
+  extends UnauthenticatedResourceRequestArgs,
+    AuthenticatedRequestArgs {}
 
-export interface CollectionRequestArgs {
+export interface CollectionRequestArgs extends AuthenticatedRequestArgs {
   paymentPointer: string
-  accessToken: string
 }
 
 const createDeps = async (

--- a/packages/open-payments/src/client/index.ts
+++ b/packages/open-payments/src/client/index.ts
@@ -41,6 +41,20 @@ export interface RouteDeps extends BaseDeps {
   logger: Logger
 }
 
+export interface UnauthenticatedResourceRequestArgs {
+  url: string
+}
+
+export interface ResourceRequestArgs {
+  url: string
+  accessToken: string
+}
+
+export interface CollectionRequestArgs {
+  paymentPointer: string
+  accessToken: string
+}
+
 const createDeps = async (
   args: Partial<CreateAuthenticatedClientArgs>
 ): Promise<ClientDeps> => {

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -16,6 +16,15 @@ import {
 import nock from 'nock'
 import path from 'path'
 import { v4 as uuid } from 'uuid'
+import * as requestors from './requests'
+
+jest.mock('./requests', () => {
+  return {
+    // https://jestjs.io/docs/jest-object#jestmockmodulename-factory-options
+    __esModule: true,
+    ...jest.requireActual('./requests')
+  }
+})
 
 describe('outgoing-payment', (): void => {
   let openApi: OpenAPI
@@ -28,71 +37,27 @@ describe('outgoing-payment', (): void => {
 
   const axiosInstance = defaultAxiosInstance
   const logger = silentLogger
-  const baseUrl = 'http://localhost:1000'
+  const paymentPointer = `http://localhost:1000/.well-known/pay`
   const openApiValidators = mockOpenApiResponseValidators()
-
-  describe('createOutgoingPaymentRoutes', (): void => {
-    test('creates getOutgoingPaymentOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createOutgoingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/outgoing-payments/{id}',
-        method: HttpMethod.GET
-      })
-    })
-
-    test('creates listOutgoingPaymentOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createOutgoingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/outgoing-payments',
-        method: HttpMethod.GET
-      })
-    })
-
-    test('creates createOutgoingPaymentOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createOutgoingPaymentRoutes({
-        axiosInstance,
-        openApi,
-        logger
-      })
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/outgoing-payments',
-        method: HttpMethod.POST
-      })
-    })
-  })
 
   describe('getOutgoingPayment', (): void => {
     test('returns outgoing payment if passes validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment()
 
-      nock(baseUrl).get('/outgoing-payments').reply(200, outgoingPayment)
+      const scope = nock(paymentPointer)
+        .get('/outgoing-payments/1')
+        .reply(200, outgoingPayment)
 
       const result = await getOutgoingPayment(
+        { axiosInstance, logger },
         {
-          axiosInstance,
-          logger
-        },
-        {
-          url: `${baseUrl}/outgoing-payments`,
+          url: `${paymentPointer}/outgoing-payments/1`,
           accessToken: 'accessToken'
         },
         openApiValidators.successfulValidator
       )
       expect(result).toStrictEqual(outgoingPayment)
+      scope.done()
     })
 
     test('throws if outgoing payment does not pass validation', async (): Promise<void> => {
@@ -109,47 +74,45 @@ describe('outgoing-payment', (): void => {
         }
       })
 
-      nock(baseUrl).get('/outgoing-payments').reply(200, outgoingPayment)
+      const scope = nock(paymentPointer)
+        .get('/outgoing-payments/1')
+        .reply(200, outgoingPayment)
 
       await expect(() =>
         getOutgoingPayment(
+          { axiosInstance, logger },
           {
-            axiosInstance,
-            logger
-          },
-          {
-            url: `${baseUrl}/outgoing-payments`,
+            url: `${paymentPointer}/outgoing-payments/1`,
             accessToken: 'accessToken'
           },
           openApiValidators.successfulValidator
         )
       ).rejects.toThrowError()
+      scope.done()
     })
 
     test('throws if outgoing payment does not pass open api validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment()
 
-      nock(baseUrl).get('/outgoing-payments').reply(200, outgoingPayment)
+      const scope = nock(paymentPointer)
+        .get('/outgoing-payments/1')
+        .reply(200, outgoingPayment)
 
       await expect(() =>
         getOutgoingPayment(
+          { axiosInstance, logger },
           {
-            axiosInstance,
-            logger
-          },
-          {
-            url: `${baseUrl}/outgoing-payments`,
+            url: `${paymentPointer}/outgoing-payments/1`,
             accessToken: 'accessToken'
           },
           openApiValidators.failedValidator
         )
       ).rejects.toThrowError()
+      scope.done()
     })
   })
 
   describe('listOutgoingPayment', (): void => {
-    const paymentPointer = 'http://localhost:1000/.well-known/pay'
-
     describe('forward pagination', (): void => {
       test.each`
         first        | cursor
@@ -173,10 +136,7 @@ describe('outgoing-payment', (): void => {
             .reply(200, outgoingPaymentPaginationResult)
 
           const result = await listOutgoingPayments(
-            {
-              axiosInstance,
-              logger
-            },
+            { axiosInstance, logger },
             {
               paymentPointer,
               accessToken: 'accessToken'
@@ -297,7 +257,7 @@ describe('outgoing-payment', (): void => {
   })
 
   describe('createOutgoingPayment', (): void => {
-    const quoteId = `${baseUrl}/quotes/${uuid()}`
+    const quoteId = `${paymentPointer}/quotes/${uuid()}`
 
     test.each`
       description           | externalRef
@@ -312,25 +272,22 @@ describe('outgoing-payment', (): void => {
           externalRef
         })
 
-        const scope = nock(baseUrl)
+        const scope = nock(paymentPointer)
           .post('/outgoing-payments')
           .reply(200, outgoingPayment)
 
         const result = await createOutgoingPayment(
+          { axiosInstance, logger },
           {
-            axiosInstance,
-            logger
+            paymentPointer,
+            accessToken: 'accessToken'
           },
+          openApiValidators.successfulValidator,
           {
-            url: `${baseUrl}/outgoing-payments`,
-            accessToken: 'accessToken',
-            body: {
-              quoteId,
-              description,
-              externalRef
-            }
-          },
-          openApiValidators.successfulValidator
+            quoteId,
+            description,
+            externalRef
+          }
         )
         expect(result).toEqual(outgoingPayment)
         scope.done()
@@ -351,24 +308,21 @@ describe('outgoing-payment', (): void => {
         }
       })
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post('/outgoing-payments')
         .reply(200, outgoingPayment)
 
       await expect(() =>
         createOutgoingPayment(
+          { axiosInstance, logger },
           {
-            axiosInstance,
-            logger
+            paymentPointer,
+            accessToken: 'accessToken'
           },
+          openApiValidators.successfulValidator,
           {
-            url: `${baseUrl}/outgoing-payments`,
-            accessToken: 'accessToken',
-            body: {
-              quoteId: uuid()
-            }
-          },
-          openApiValidators.successfulValidator
+            quoteId: uuid()
+          }
         )
       ).rejects.toThrowError()
       scope.done()
@@ -377,7 +331,7 @@ describe('outgoing-payment', (): void => {
     test('throws if outgoing payment does not pass open api validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment()
 
-      const scope = nock(baseUrl)
+      const scope = nock(paymentPointer)
         .post('/outgoing-payments')
         .reply(200, outgoingPayment)
 
@@ -388,13 +342,13 @@ describe('outgoing-payment', (): void => {
             logger
           },
           {
-            url: `${baseUrl}/outgoing-payments`,
-            accessToken: 'accessToken',
-            body: {
-              quoteId: uuid()
-            }
+            paymentPointer,
+            accessToken: 'accessToken'
           },
-          openApiValidators.failedValidator
+          openApiValidators.failedValidator,
+          {
+            quoteId: uuid()
+          }
         )
       ).rejects.toThrowError()
       scope.done()
@@ -485,6 +439,117 @@ describe('outgoing-payment', (): void => {
       expect(() => validateOutgoingPayment(outgoingPayment)).toThrow(
         'Amount to send matches sent amount but payment failed'
       )
+    })
+  })
+
+  describe('routes', (): void => {
+    describe('get', (): void => {
+      test('calls get method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/outgoing-payments/{id}' && method === HttpMethod.GET
+
+        const url = `${paymentPointer}/outgoing-payments/1`
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const getSpy = jest
+          .spyOn(requestors, 'get')
+          .mockResolvedValueOnce(mockOutgoingPayment())
+
+        await createOutgoingPaymentRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).get({ url, accessToken: 'accessToken' })
+
+        expect(getSpy).toHaveBeenCalledWith(
+          {
+            axiosInstance,
+            logger
+          },
+          { url, accessToken: 'accessToken' },
+          true
+        )
+      })
+    })
+
+    describe('list', (): void => {
+      test('calls get method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/outgoing-payments' && method === HttpMethod.GET
+
+        const outgoingPaymentPaginationResult =
+          mockOutgoingPaymentPaginationResult({
+            result: [mockOutgoingPayment()]
+          })
+        const url = `${paymentPointer}/outgoing-payments`
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const getSpy = jest
+          .spyOn(requestors, 'get')
+          .mockResolvedValueOnce(outgoingPaymentPaginationResult)
+
+        await createOutgoingPaymentRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).list({ paymentPointer, accessToken: 'accessToken' })
+
+        expect(getSpy).toHaveBeenCalledWith(
+          {
+            axiosInstance,
+            logger
+          },
+          { url, accessToken: 'accessToken' },
+          true
+        )
+      })
+    })
+
+    describe('create', (): void => {
+      test('calls post method with correct validator', async (): Promise<void> => {
+        const mockResponseValidator = ({ path, method }) =>
+          path === '/outgoing-payments' && method === HttpMethod.POST
+
+        const url = `${paymentPointer}/outgoing-payments`
+        const outgoingPaymentCreateArgs = {
+          quoteId: uuid()
+        }
+
+        jest
+          .spyOn(openApi, 'createResponseValidator')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation(mockResponseValidator as any)
+
+        const postSpy = jest
+          .spyOn(requestors, 'post')
+          .mockResolvedValueOnce(mockOutgoingPayment(outgoingPaymentCreateArgs))
+
+        await createOutgoingPaymentRoutes({
+          openApi,
+          axiosInstance,
+          logger
+        }).create(
+          { paymentPointer, accessToken: 'accessToken' },
+          outgoingPaymentCreateArgs
+        )
+
+        expect(postSpy).toHaveBeenCalledWith(
+          {
+            axiosInstance,
+            logger
+          },
+          { url, accessToken: 'accessToken', body: outgoingPaymentCreateArgs },
+          true
+        )
+      })
     })
   })
 })

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -78,7 +78,7 @@ describe('outgoing-payment', (): void => {
         .get('/outgoing-payments/1')
         .reply(200, outgoingPayment)
 
-      await expect(() =>
+      await expect(
         getOutgoingPayment(
           { axiosInstance, logger },
           {
@@ -98,7 +98,7 @@ describe('outgoing-payment', (): void => {
         .get('/outgoing-payments/1')
         .reply(200, outgoingPayment)
 
-      await expect(() =>
+      await expect(
         getOutgoingPayment(
           { axiosInstance, logger },
           {
@@ -215,7 +215,7 @@ describe('outgoing-payment', (): void => {
         .get('/outgoing-payments')
         .reply(200, outgoingPaymentPaginationResult)
 
-      await expect(() =>
+      await expect(
         listOutgoingPayments(
           {
             axiosInstance,
@@ -239,7 +239,7 @@ describe('outgoing-payment', (): void => {
         .get('/outgoing-payments')
         .reply(200, outgoingPaymentPaginationResult)
 
-      await expect(() =>
+      await expect(
         listOutgoingPayments(
           {
             axiosInstance,
@@ -312,7 +312,7 @@ describe('outgoing-payment', (): void => {
         .post('/outgoing-payments')
         .reply(200, outgoingPayment)
 
-      await expect(() =>
+      await expect(
         createOutgoingPayment(
           { axiosInstance, logger },
           {
@@ -335,7 +335,7 @@ describe('outgoing-payment', (): void => {
         .post('/outgoing-payments')
         .reply(200, outgoingPayment)
 
-      await expect(() =>
+      await expect(
         createOutgoingPayment(
           {
             axiosInstance,

--- a/packages/open-payments/src/client/outgoing-payment.ts
+++ b/packages/open-payments/src/client/outgoing-payment.ts
@@ -1,5 +1,10 @@
 import { HttpMethod, ResponseValidator } from 'openapi'
-import { BaseDeps, RouteDeps } from '.'
+import {
+  BaseDeps,
+  CollectionRequestArgs,
+  ResourceRequestArgs,
+  RouteDeps
+} from '.'
 import {
   CreateOutgoingPaymentArgs,
   getRSPath,
@@ -9,24 +14,14 @@ import {
 } from '../types'
 import { get, post } from './requests'
 
-interface RequestWithUrlArgs {
-  url: string
-  accessToken: string
-}
-
-interface RequestWithPaymentPointerArgs {
-  paymentPointer: string
-  accessToken: string
-}
-
 export interface OutgoingPaymentRoutes {
-  get(args: RequestWithUrlArgs): Promise<OutgoingPayment>
+  get(args: ResourceRequestArgs): Promise<OutgoingPayment>
   list(
-    args: RequestWithPaymentPointerArgs,
+    args: CollectionRequestArgs,
     pagination?: PaginationArgs
   ): Promise<OutgoingPaymentPaginationResult>
   create(
-    requestArgs: RequestWithPaymentPointerArgs,
+    requestArgs: CollectionRequestArgs,
     createArgs: CreateOutgoingPaymentArgs
   ): Promise<OutgoingPayment>
 }
@@ -55,16 +50,13 @@ export const createOutgoingPaymentRoutes = (
     })
 
   return {
-    get: (requestArgs: RequestWithUrlArgs) =>
+    get: (requestArgs: ResourceRequestArgs) =>
       getOutgoingPayment(
         { axiosInstance, logger },
         requestArgs,
         getOutgoingPaymentOpenApiValidator
       ),
-    list: (
-      requestArgs: RequestWithPaymentPointerArgs,
-      pagination?: PaginationArgs
-    ) =>
+    list: (requestArgs: CollectionRequestArgs, pagination?: PaginationArgs) =>
       listOutgoingPayments(
         { axiosInstance, logger },
         requestArgs,
@@ -72,7 +64,7 @@ export const createOutgoingPaymentRoutes = (
         pagination
       ),
     create: (
-      requestArgs: RequestWithPaymentPointerArgs,
+      requestArgs: CollectionRequestArgs,
       createArgs: CreateOutgoingPaymentArgs
     ) =>
       createOutgoingPayment(
@@ -86,7 +78,7 @@ export const createOutgoingPaymentRoutes = (
 
 export const getOutgoingPayment = async (
   deps: BaseDeps,
-  requestArgs: RequestWithUrlArgs,
+  requestArgs: ResourceRequestArgs,
   validateOpenApiResponse: ResponseValidator<OutgoingPayment>
 ) => {
   const { axiosInstance, logger } = deps
@@ -110,7 +102,7 @@ export const getOutgoingPayment = async (
 
 export const createOutgoingPayment = async (
   deps: BaseDeps,
-  requestArgs: RequestWithPaymentPointerArgs,
+  requestArgs: CollectionRequestArgs,
   validateOpenApiResponse: ResponseValidator<OutgoingPayment>,
   createArgs: CreateOutgoingPaymentArgs
 ) => {
@@ -136,7 +128,7 @@ export const createOutgoingPayment = async (
 
 export const listOutgoingPayments = async (
   deps: BaseDeps,
-  requestArgs: RequestWithPaymentPointerArgs,
+  requestArgs: CollectionRequestArgs,
   validateOpenApiResponse: ResponseValidator<OutgoingPaymentPaginationResult>,
   pagination?: PaginationArgs
 ) => {

--- a/packages/open-payments/src/client/payment-pointer.ts
+++ b/packages/open-payments/src/client/payment-pointer.ts
@@ -1,15 +1,11 @@
 import { HttpMethod } from 'openapi'
-import { RouteDeps } from '.'
+import { RouteDeps, UnauthenticatedResourceRequestArgs } from '.'
 import { JWKS, PaymentPointer, getRSPath } from '../types'
 import { get } from './requests'
 
-interface GetArgs {
-  url: string
-}
-
 export interface PaymentPointerRoutes {
-  get(args: GetArgs): Promise<PaymentPointer>
-  getKeys(args: GetArgs): Promise<JWKS>
+  get(args: UnauthenticatedResourceRequestArgs): Promise<PaymentPointer>
+  getKeys(args: UnauthenticatedResourceRequestArgs): Promise<JWKS>
 }
 
 export const createPaymentPointerRoutes = (
@@ -29,9 +25,9 @@ export const createPaymentPointerRoutes = (
   })
 
   return {
-    get: (args: GetArgs) =>
+    get: (args: UnauthenticatedResourceRequestArgs) =>
       get({ axiosInstance, logger }, args, getPaymentPaymentValidator),
-    getKeys: (args: GetArgs) =>
+    getKeys: (args: UnauthenticatedResourceRequestArgs) =>
       get(
         { axiosInstance, logger },
         {

--- a/packages/open-payments/src/client/quote.test.ts
+++ b/packages/open-payments/src/client/quote.test.ts
@@ -35,29 +35,6 @@ describe('quote', (): void => {
   const paymentPointer = 'http://localhost:1000/.well-known/pay'
   const accessToken = 'accessToken'
 
-  describe('createQuoteRoutes', (): void => {
-    test('creates getQuoteOpenApiValidator  properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createQuoteRoutes({ axiosInstance, openApi, logger })
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/quotes/{id}',
-        method: HttpMethod.GET
-      })
-    })
-
-    test('creates createQuoteOpenApiValidator properly', async (): Promise<void> => {
-      jest.spyOn(openApi, 'createResponseValidator')
-
-      createQuoteRoutes({ openApi, axiosInstance, logger })
-
-      expect(openApi.createResponseValidator).toHaveBeenCalledWith({
-        path: '/quotes',
-        method: HttpMethod.POST
-      })
-    })
-  })
-
   describe('getQuote', (): void => {
     test('returns the quote if it passes open api validation', async (): Promise<void> => {
       const scope = nock(baseUrl).get(`/quotes/${quote.id}`).reply(200, quote)

--- a/packages/open-payments/src/client/quote.ts
+++ b/packages/open-payments/src/client/quote.ts
@@ -1,14 +1,10 @@
 import { HttpMethod } from 'openapi'
-import { RouteDeps } from '.'
+import { ResourceRequestArgs, RouteDeps } from '.'
 import { getRSPath, Quote } from '../types'
 import { get } from './requests'
 
-interface GetArgs {
-  url: string
-}
-
 export interface QuoteRoutes {
-  get(args: GetArgs): Promise<Quote>
+  get(args: ResourceRequestArgs): Promise<Quote>
 }
 
 export const createQuoteRoutes = (deps: RouteDeps): QuoteRoutes => {
@@ -20,7 +16,7 @@ export const createQuoteRoutes = (deps: RouteDeps): QuoteRoutes => {
   })
 
   return {
-    get: (args: GetArgs) =>
+    get: (args: ResourceRequestArgs) =>
       get({ axiosInstance, logger }, args, getQuoteValidator)
   }
 }

--- a/packages/open-payments/src/client/requests.test.ts
+++ b/packages/open-payments/src/client/requests.test.ts
@@ -2,7 +2,11 @@
 import { createAxiosInstance, deleteRequest, get, post } from './requests'
 import { generateKeyPairSync } from 'crypto'
 import nock from 'nock'
-import { mockOpenApiResponseValidators, silentLogger } from '../test/helpers'
+import {
+  mockOpenApiResponseValidators,
+  silentLogger,
+  withEnvVariableOverride
+} from '../test/helpers'
 
 describe('requests', (): void => {
   const logger = silentLogger
@@ -194,6 +198,51 @@ describe('requests', (): void => {
         )
       ).rejects.toThrow(/Failed to validate OpenApi response/)
     })
+
+    test(
+      'keeps https protocol for request if non-development environment',
+      withEnvVariableOverride(
+        { NODE_ENV: 'production' },
+        async (): Promise<void> => {
+          const httpsUrl = 'https://localhost:1000/'
+          const scope = nock(httpsUrl).get('/').reply(200)
+
+          await get(
+            { axiosInstance, logger },
+            { url: httpsUrl },
+            responseValidators.successfulValidator
+          )
+
+          expect(axiosInstance.get).toHaveBeenCalledWith(httpsUrl, {
+            headers: {}
+          })
+          scope.done()
+        }
+      )
+    )
+
+    test(
+      'uses http protocol for request if development environment',
+      withEnvVariableOverride(
+        { NODE_ENV: 'development' },
+        async (): Promise<void> => {
+          const httpsUrl = 'https://localhost:1000/'
+          const httpUrl = httpsUrl.replace('https', 'http')
+          const scope = nock(httpUrl).get('/').reply(200)
+
+          await get(
+            { axiosInstance, logger },
+            { url: httpsUrl },
+            responseValidators.successfulValidator
+          )
+
+          expect(axiosInstance.get).toHaveBeenCalledWith(httpUrl, {
+            headers: {}
+          })
+          scope.done()
+        }
+      )
+    )
   })
 
   describe('post', (): void => {
@@ -364,6 +413,51 @@ describe('requests', (): void => {
         )
       ).rejects.toThrow(/Failed to validate OpenApi response/)
     })
+
+    test(
+      'keeps https protocol for request if non-development environment',
+      withEnvVariableOverride(
+        { NODE_ENV: 'production' },
+        async (): Promise<void> => {
+          const httpsUrl = 'https://localhost:1000/'
+          const scope = nock(httpsUrl).post('/').reply(200)
+
+          await post(
+            { axiosInstance, logger },
+            { url: httpsUrl },
+            responseValidators.successfulValidator
+          )
+
+          expect(axiosInstance.post).toHaveBeenCalledWith(httpsUrl, undefined, {
+            headers: {}
+          })
+          scope.done()
+        }
+      )
+    )
+
+    test(
+      'uses http protocol for request if development environment',
+      withEnvVariableOverride(
+        { NODE_ENV: 'development' },
+        async (): Promise<void> => {
+          const httpsUrl = 'https://localhost:1000/'
+          const httpUrl = httpsUrl.replace('https', 'http')
+          const scope = nock(httpUrl).post('/').reply(200)
+
+          await post(
+            { axiosInstance, logger },
+            { url: httpsUrl },
+            responseValidators.successfulValidator
+          )
+
+          expect(axiosInstance.post).toHaveBeenCalledWith(httpUrl, undefined, {
+            headers: {}
+          })
+          scope.done()
+        }
+      )
+    )
   })
 
   describe('delete', (): void => {
@@ -501,5 +595,50 @@ describe('requests', (): void => {
         )
       ).rejects.toThrow(/Failed to validate OpenApi response/)
     })
+
+    test(
+      'keeps https protocol for request if non-development environment',
+      withEnvVariableOverride(
+        { NODE_ENV: 'production' },
+        async (): Promise<void> => {
+          const httpsUrl = 'https://localhost:1000/'
+          const scope = nock(httpsUrl).delete('/').reply(200)
+
+          await deleteRequest(
+            { axiosInstance, logger },
+            { url: httpsUrl },
+            responseValidators.successfulValidator
+          )
+
+          expect(axiosInstance.delete).toHaveBeenCalledWith(httpsUrl, {
+            headers: {}
+          })
+          scope.done()
+        }
+      )
+    )
+
+    test(
+      'uses http protocol for request if development environment',
+      withEnvVariableOverride(
+        { NODE_ENV: 'development' },
+        async (): Promise<void> => {
+          const httpsUrl = 'https://localhost:1000/'
+          const httpUrl = httpsUrl.replace('https', 'http')
+          const scope = nock(httpUrl).delete('/').reply(200)
+
+          await deleteRequest(
+            { axiosInstance, logger },
+            { url: httpsUrl },
+            responseValidators.successfulValidator
+          )
+
+          expect(axiosInstance.delete).toHaveBeenCalledWith(httpUrl, {
+            headers: {}
+          })
+          scope.done()
+        }
+      )
+    )
   })
 })

--- a/packages/open-payments/src/client/token.ts
+++ b/packages/open-payments/src/client/token.ts
@@ -1,21 +1,16 @@
 import { HttpMethod, ResponseValidator } from 'openapi'
-import { RouteDeps } from '.'
+import { ResourceRequestArgs, RouteDeps } from '.'
 import { getASPath, AccessToken } from '../types'
 import { deleteRequest, post } from './requests'
 
-interface TokenRequestArgs {
-  url: string
-  accessToken: string
-}
-
 export interface TokenRoutes {
-  rotate(args: TokenRequestArgs): Promise<AccessToken>
-  revoke(args: TokenRequestArgs): Promise<void>
+  rotate(args: ResourceRequestArgs): Promise<AccessToken>
+  revoke(args: ResourceRequestArgs): Promise<void>
 }
 
 export const rotateToken = async (
   deps: RouteDeps,
-  args: TokenRequestArgs,
+  args: ResourceRequestArgs,
   validateOpenApiResponse: ResponseValidator<AccessToken>
 ) => {
   const { axiosInstance, logger } = deps
@@ -36,7 +31,7 @@ export const rotateToken = async (
 
 export const revokeToken = async (
   deps: RouteDeps,
-  args: TokenRequestArgs,
+  args: ResourceRequestArgs,
   validateOpenApiResponse: ResponseValidator<void>
 ) => {
   const { axiosInstance, logger } = deps
@@ -68,9 +63,9 @@ export const createTokenRoutes = (deps: RouteDeps): TokenRoutes => {
   })
 
   return {
-    rotate: (args: TokenRequestArgs) =>
+    rotate: (args: ResourceRequestArgs) =>
       rotateToken(deps, args, rotateTokenValidator),
-    revoke: (args: TokenRequestArgs) =>
+    revoke: (args: ResourceRequestArgs) =>
       revokeToken(deps, args, revokeTokenValidator)
   }
 }

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -42,9 +42,11 @@ export const withEnvVariableOverride = (
       process.env[key] = override[key]
     }
 
-    await testCallback()
-
-    process.env = savedEnvVars
+    try {
+      await testCallback()
+    } finally {
+      process.env = savedEnvVars
+    }
   }
 }
 
@@ -71,7 +73,6 @@ export const mockPaymentPointer = (
   overrides?: Partial<PaymentPointer>
 ): PaymentPointer => ({
   id: 'https://example.com/.well-known/pay',
-  publicName: 'Payment Pointer',
   authServer: 'https://auth.wallet.example/authorize',
   assetScale: 2,
   assetCode: 'USD',

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -39,9 +39,7 @@ export const withEnvVariableOverride = (
   return async () => {
     const savedEnvVars = Object.assign({}, process.env)
 
-    for (const key in override) {
-      process.env[key] = override[key]
-    }
+    Object.assign(process.env, override)
 
     try {
       await testCallback()

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -11,7 +11,9 @@ import {
   OutgoingPayment,
   OutgoingPaymentPaginationResult,
   IncomingPaymentPaginationResult,
-  AccessToken
+  AccessToken,
+  PaymentPointer,
+  JWK
 } from '../types'
 import base64url from 'base64url'
 import { v4 as uuid } from 'uuid'
@@ -37,6 +39,26 @@ export const mockOpenApiResponseValidators = () => ({
     throw new Error('Failed to validate response')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }) as ResponseValidator<any>
+})
+
+export const mockJwk = (overrides?: Partial<JWK>): JWK => ({
+  x: uuid(),
+  kid: uuid(),
+  alg: 'EdDSA',
+  kty: 'OKP',
+  crv: 'Ed25519',
+  ...overrides
+})
+
+export const mockPaymentPointer = (
+  overrides?: Partial<PaymentPointer>
+): PaymentPointer => ({
+  id: 'https://example.com/.well-known/pay',
+  publicName: 'Payment Pointer',
+  authServer: 'https://auth.wallet.example/authorize',
+  assetScale: 2,
+  assetCode: 'USD',
+  ...overrides
 })
 
 export const mockILPStreamConnection = (

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -31,6 +31,23 @@ export const defaultAxiosInstance = createAxiosInstance({
   privateKey: generateKeyPairSync('ed25519').privateKey
 })
 
+export const withEnvVariableOverride = (
+  override: Record<string, string>,
+  testCallback: () => Promise<void>
+): (() => Promise<void>) => {
+  return async () => {
+    const savedEnvVars = Object.assign({}, process.env)
+
+    for (const key in override) {
+      process.env[key] = override[key]
+    }
+
+    await testCallback()
+
+    process.env = savedEnvVars
+  }
+}
+
 export const mockOpenApiResponseValidators = () => ({
   successfulValidator: ((data: unknown): data is unknown =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Update incoming payment & outgoing payment client `list` `create` `complete` requests to use `paymentPointer` as an argument instead of `url`, e.g.:

```ts
await client.incomingPayment.create({ url, accessToken, body: { description, incomingAmount } } // before
await client.incomingPayment.create({ paymentPointer, accessToken }, { description, incomingAmount }) // after
```
- Update tests to get 100% coverage:
![Screen Shot 2023-01-13 at 1 57 29 PM](https://user-images.githubusercontent.com/15069181/212417745-22e30b95-9fdb-4a47-8f54-c0003fa93d31.png)



## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- Parent issue: #663

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
