### PR TITLE
feat(auth): move introspection endpoint to its own server

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -201,7 +201,7 @@ $ helm install ...
 | `IDENTITY_SERVER_SECRET`       | `replace-me`                                                     | API key                                                                    |
 | `INCOMING_PAYMENT_INTERACTION` | `false`                                                          | flag - incoming payments grants are interactive or not                     |
 | `QUOTE_INTERACTION`            | `false`                                                          | flag - quote grants are interactive or not                                 |
-| `INTROSPECTION_PORT`           | `3007`                                                           | port of this Open Payments Auth Token Introspection Server                 |
+| `INTROSPECTION_PORT`           | `3007`                                                           | port of this Open Payments Auth - Token Introspection Server               |
 | `LOG_LEVEL`                    | `info`                                                           | [Pino Log Level](https://getpino.io/#/docs/api?id=levels)                  |
 | `NODE_ENV`                     | `development`                                                    | node environment, `development`, `test`, or `production`                   |
 | `PORT`                         | `3006`                                                           | port of this Open Payments Auth Server, same as in `AUTH_SERVER_DOMAIN`    |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -201,7 +201,6 @@ $ helm install ...
 | `IDENTITY_SERVER_SECRET`       | `replace-me`                                                     | API key                                                                    |
 | `INCOMING_PAYMENT_INTERACTION` | `false`                                                          | flag - incoming payments grants are interactive or not                     |
 | `QUOTE_INTERACTION`            | `false`                                                          | flag - quote grants are interactive or not                                 |
-| `INTROSPECTION_HTTPSIG`        | `false`                                                          | flag - check http signature on introspection requests                      |
 | `INTROSPECTION_PORT`           | `3007`                                                           | port of this Open Payments Auth Token Introspection Server                 |
 | `LOG_LEVEL`                    | `info`                                                           | [Pino Log Level](https://getpino.io/#/docs/api?id=levels)                  |
 | `NODE_ENV`                     | `development`                                                    | node environment, `development`, `test`, or `production`                   |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -146,7 +146,7 @@ $ helm install ...
 | ------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------ |
 | `ADMIN_PORT`                    | `3001`                                                      | GraphQL Server port                                                      |
 | `AUTH_SERVER_GRANT_URL`         | `http://127.0.0.1:3006`                                     | endpoint to on the Open Payments Auth Server to request a grant          |
-| `AUTH_SERVER_INTROSPECTION_URL` | `http://127.0.0.1:3007/introspect`                          | endpoint to on the Open Payments Auth Server to introspect an auth token |
+| `AUTH_SERVER_INTROSPECTION_URL` | `http://127.0.0.1:3007`                                     | endpoint to on the Open Payments Auth Server to introspect an auth token |
 | `CONNECTOR_PORT`                | `3002`                                                      | STREAM/ILP connector port                                                |
 | `DATABASE_URL`                  | `postgresql://postgres:password@localhost:5432/development` | Postgres database URL                                                    |
 | `ILP_ADDRESS`                   | `test.rafiki`                                               | ILP address of this Rafiki instance                                      |
@@ -193,6 +193,7 @@ $ helm install ...
 | `ACCESS_TOKEN_EXPIRY_SECONDS`  | `10 * 60`                                                        | expiry time for access tokens (default: 10 minutes)                        |
 | `ADMIN_PORT`                   | `3003`                                                           | GraphQL Server port                                                        |
 | `AUTH_DATABASE_URL`            | `postgresql://postgres:password@localhost:5432/auth_development` | Postgres database URL                                                      |
+| `AUTH_PORT`                    | `3006`                                                           | port of this Open Payments Auth Server                                     |
 | `AUTH_SERVER_DOMAIN`           | `http://localhost:3006`                                          | endpoint of this Open Payments Auth Server                                 |
 | `COOKIE_KEY`                   | 32 random bytes                                                  | signed cookie key                                                          |
 | `DATABASE_CLEANUP_WORKERS`     | `1`                                                              | number of workers processing expired or revoked access tokens              |
@@ -201,6 +202,7 @@ $ helm install ...
 | `INCOMING_PAYMENT_INTERACTION` | `false`                                                          | flag - incoming payments grants are interactive or not                     |
 | `QUOTE_INTERACTION`            | `false`                                                          | flag - quote grants are interactive or not                                 |
 | `INTROSPECTION_HTTPSIG`        | `false`                                                          | flag - check http signature on introspection requests                      |
+| `INTROSPECTION_PORT`           | `3007`                                                           | port of this Open Payments Auth Token Introspection Server                 |
 | `LOG_LEVEL`                    | `info`                                                           | [Pino Log Level](https://getpino.io/#/docs/api?id=levels)                  |
 | `NODE_ENV`                     | `development`                                                    | node environment, `development`, `test`, or `production`                   |
 | `PORT`                         | `3006`                                                           | port of this Open Payments Auth Server, same as in `AUTH_SERVER_DOMAIN`    |

--- a/localenv/cloud-nine-wallet/docker-compose.yml
+++ b/localenv/cloud-nine-wallet/docker-compose.yml
@@ -74,7 +74,6 @@ services:
     environment:
       NODE_ENV: development
       AUTH_DATABASE_URL: postgresql://cloud_nine_wallet_auth:cloud_nine_wallet_auth@database/cloud_nine_wallet_auth
-      INTROSPECTION_HTTPSIG: "false"
     depends_on:
       - database
   signatures:

--- a/localenv/cloud-nine-wallet/docker-compose.yml
+++ b/localenv/cloud-nine-wallet/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       TIGERBEETLE_REPLICA_ADDRESSES: ${TIGERBEETLE_REPLICA_ADDRESSES-''}
       NONCE_REDIS_KEY: test
       AUTH_SERVER_GRANT_URL: http://cloud-nine-wallet-auth:3006
-      AUTH_SERVER_INTROSPECTION_URL: http://cloud-nine-wallet-auth:3006/introspect
+      AUTH_SERVER_INTROSPECTION_URL: http://cloud-nine-wallet-auth:3007
       ILP_ADDRESS: test.cloud-nine-wallet
       STREAM_SECRET: BjPXtnd00G2mRQwP/8ZpwyZASOch5sUXT5o0iR5b5wU=
       ADMIN_KEY: admin

--- a/localenv/happy-life-bank/docker-compose.yml
+++ b/localenv/happy-life-bank/docker-compose.yml
@@ -71,7 +71,6 @@ services:
     environment:
       NODE_ENV: development
       AUTH_DATABASE_URL: postgresql://happy_life_bank_auth:happy_life_bank_auth@database/happy_life_bank_auth
-      INTROSPECTION_HTTPSIG: "false"
       AUTH_SERVER_DOMAIN: "http://localhost:4006"
   signatures:
     hostname: happy-life-bank-signatures

--- a/localenv/happy-life-bank/docker-compose.yml
+++ b/localenv/happy-life-bank/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       TIGERBEETLE_REPLICA_ADDRESSES: ${TIGERBEETLE_REPLICA_ADDRESSES-''}
       NONCE_REDIS_KEY: test
       AUTH_SERVER_GRANT_URL: http://happy-life-bank-auth:3006
-      AUTH_SERVER_INTROSPECTION_URL: http://happy-life-bank-auth:3006/introspect
+      AUTH_SERVER_INTROSPECTION_URL: http://happy-life-bank-auth:3007
       ILP_ADDRESS: test.happy-life-bank
       STREAM_SECRET: BjPXtnd00G2mRQwP/8ZpwyZASOch5sUXT5o0iR5b5wU=
       ADMIN_KEY: admin

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -25,8 +25,13 @@ docker build -f packages/auth/Dockerfile -t rafiki-auth .
 
 The authorization service extends the following endpoints:
 
-- `POST /auth`: Initializes a grant request for a client.
-- `POST /auth/continue/:id`: Continues a grant request after a resource owner has authorized said grant request.
-- `POST /introspect`: Performs introspection an access token and determines if it is valid.
-- `POST /auth/token/:id`: Rotates an access token and issues a new one.
-- `DEL /auth/token/:id`: Revokes an access token.
+- `POST /`: Initializes a grant request for a client.
+- `POST /continue/:id`: Continues a grant request after a resource owner has authorized said grant request.
+- `POST /token/:id`: Rotates an access token and issues a new one.
+- `DEL /token/:id`: Revokes an access token.
+
+## Introspection endpoint
+
+The introspection service extends the following endpoint:
+
+- `POST /`: Performs introspection of an access token and determines if it is valid.

--- a/packages/auth/src/app.ts
+++ b/packages/auth/src/app.ts
@@ -98,7 +98,8 @@ export interface AppServices {
 export type AppContainer = IocContract<AppServices>
 
 export class App {
-  private server!: Server
+  private authServer!: Server
+  private introspectionServer!: Server
   private adminServer!: Server
   public apolloServer!: ApolloServer
   private closeEmitter!: EventEmitter
@@ -211,8 +212,8 @@ export class App {
 
     const accessTokenRoutes = await this.container.use('accessTokenRoutes')
     const grantRoutes = await this.container.use('grantRoutes')
-
     const openApi = await this.container.use('openApi')
+
     /* Back-channel GNAP Routes */
     // Grant Initiation
     router.post<DefaultState, CreateContext>(
@@ -267,20 +268,6 @@ export class App {
       }),
       tokenHttpsigMiddleware,
       accessTokenRoutes.revoke
-    )
-
-    /* AS <-> RS Routes */
-    // Token Introspection
-    router.post<DefaultState, IntrospectContext>(
-      '/introspect',
-      createValidatorMiddleware<IntrospectContext>(
-        openApi.tokenIntrospectionSpec,
-        {
-          path: '/',
-          method: HttpMethod.POST
-        }
-      ),
-      accessTokenRoutes.introspect
     )
 
     /* Front Channel Routes */
@@ -343,7 +330,39 @@ export class App {
     koa.use(router.middleware())
     koa.use(router.routes())
 
-    this.server = koa.listen(port)
+    this.authServer = koa.listen(port)
+  }
+
+  public async startIntrospectionServer(port: number | string): Promise<void> {
+    const koa = await this.createKoaServer()
+
+    const router = new Router<DefaultState, AppContext>()
+    router.use(bodyParser())
+    router.get('/healthz', (ctx: AppContext): void => {
+      ctx.status = 200
+    })
+
+    const accessTokenRoutes = await this.container.use('accessTokenRoutes')
+    const openApi = await this.container.use('openApi')
+
+    // Token Introspection
+    router.post<DefaultState, IntrospectContext>(
+      '/',
+      createValidatorMiddleware<IntrospectContext>(
+        openApi.tokenIntrospectionSpec,
+        {
+          path: '/',
+          method: HttpMethod.POST
+        }
+      ),
+      accessTokenRoutes.introspect
+    )
+
+    koa.use(cors())
+    koa.use(router.middleware())
+    koa.use(router.routes())
+
+    this.introspectionServer = koa.listen(port)
   }
 
   private async createKoaServer(): Promise<Koa<Koa.DefaultState, AppContext>> {
@@ -386,8 +405,14 @@ export class App {
         })
       }
 
-      if (this.server) {
-        this.server.close((): void => {
+      if (this.authServer) {
+        this.authServer.close((): void => {
+          resolve()
+        })
+      }
+
+      if (this.introspectionServer) {
+        this.introspectionServer.close((): void => {
           resolve()
         })
       }
@@ -397,15 +422,19 @@ export class App {
   }
 
   public getAdminPort(): number {
-    const address = this.adminServer?.address()
-    if (address && !(typeof address == 'string')) {
-      return address.port
-    }
-    return 0
+    return this.getPort(this.adminServer)
   }
 
-  public getPort(): number {
-    const address = this.server?.address()
+  public getAuthPort(): number {
+    return this.getPort(this.authServer)
+  }
+
+  public getIntrospectionPort(): number {
+    return this.getPort(this.introspectionServer)
+  }
+
+  private getPort(server: Server): number {
+    const address = server?.address()
     if (address && !(typeof address == 'string')) {
       return address.port
     }

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -43,7 +43,6 @@ export const Config = {
   accessTokenExpirySeconds: envInt('ACCESS_TOKEN_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes
   databaseCleanupWorkers: envInt('DATABASE_CLEANUP_WORKERS', 1),
   accessTokenDeletionDays: envInt('ACCESS_TOKEN_DELETION_DAYS', 30),
-  introspectionHttpsig: envBool('INTROSPECTION_HTTPSIG', false),
   incomingPaymentInteraction: envBool('INCOMING_PAYMENT_INTERACTION', false),
   quoteInteraction: envBool('QUOTE_INTERACTION', false)
 }

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -18,8 +18,9 @@ export type IAppConfig = typeof Config
 
 export const Config = {
   logLevel: envString('LOG_LEVEL', 'info'),
-  authPort: envInt('PORT', 3006),
   adminPort: envInt('ADMIN_PORT', 3003),
+  authPort: envInt('AUTH_PORT', 3006),
+  introspectionPort: envInt('INTROSPECTION_PORT', 3007),
   env: envString('NODE_ENV', 'development'),
   databaseUrl:
     process.env.NODE_ENV === 'test'

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -243,8 +243,10 @@ export const start = async (
   await app.boot()
   await app.startAdminServer(config.adminPort)
   await app.startAuthServer(config.authPort)
+  await app.startIntrospectionServer(config.introspectionPort)
   logger.info(`Admin listening on ${app.getAdminPort()}`)
-  logger.info(`Auth server listening on ${app.getPort()}`)
+  logger.info(`Auth server listening on ${app.getAuthPort()}`)
+  logger.info(`Introspection server listening on ${app.getIntrospectionPort()}`)
 }
 
 // If this script is run directly, start the server

--- a/packages/auth/src/tests/app.ts
+++ b/packages/auth/src/tests/app.ts
@@ -31,6 +31,7 @@ export const createTestApp = async (
 ): Promise<TestContainer> => {
   const config = await container.use('config')
   config.authPort = 0
+  config.introspectionPort = 0
   config.adminPort = 0
 
   const logger = createLogger({
@@ -96,7 +97,7 @@ export const createTestApp = async (
 
   return {
     app,
-    port: app.getPort(),
+    port: app.getAuthPort(),
     adminPort: app.getAdminPort(),
     knex,
     apolloClient: client,

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -77,7 +77,7 @@ export const Config = {
   ),
   authServerIntrospectionUrl: envString(
     'AUTH_SERVER_INTROSPECTION_URL',
-    'http://127.0.0.1:3007/introspect'
+    'http://127.0.0.1:3007/'
   ),
 
   outgoingPaymentWorkers: envInt('OUTGOING_PAYMENT_WORKERS', 4),


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- move token introspection endpoint to its own server
- does not have to be open port since it is run together with auth server and backend server
- updated localenv accordingly

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #1021 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
