### PR TITLE
fix(localenv): add image names to build only once per compose file

### DIFF
--- a/localenv/cloud-nine-wallet/docker-compose.yml
+++ b/localenv/cloud-nine-wallet/docker-compose.yml
@@ -2,6 +2,7 @@ name: c9
 services:
   cloud-nine-mock-ase:
     hostname: cloud-nine-wallet
+    image: rafiki-mock-ase
     build:
       context: ../..
       dockerfile: ./localenv/mock-account-servicing-entity/Dockerfile
@@ -23,6 +24,7 @@ services:
       - cloud-nine-backend
   cloud-nine-backend:
     hostname: cloud-nine-wallet-backend
+    image: rafiki-backend
     build:
       context: ../..
       dockerfile: ./packages/backend/Dockerfile
@@ -61,6 +63,7 @@ services:
       - shared-redis
   cloud-nine-auth:
     hostname: cloud-nine-wallet-auth
+    image: rafiki-auth
     build:
       context: ../..
       dockerfile: ./packages/auth/Dockerfile
@@ -76,6 +79,7 @@ services:
       - shared-database
   cloud-nine-signatures:
     hostname: cloud-nine-wallet-signatures
+    image: rafiki-postman-signatures
     build:
       context: ../..
       dockerfile: ./localenv/local-http-signatures/Dockerfile
@@ -108,6 +112,7 @@ services:
       - rafiki
   cloud-nine-admin:
     hostname: cloud-nine-wallet-admin
+    image: rafiki-frontend
     build:
       context: ../..
       dockerfile: ./packages/frontend/Dockerfile

--- a/localenv/happy-life-bank/docker-compose.yml
+++ b/localenv/happy-life-bank/docker-compose.yml
@@ -2,6 +2,7 @@ name: hl
 services:
   happy-life-mock-ase:
     hostname: happy-life-bank
+    image: rafiki-mock-ase
     build:
       context: ../..
       dockerfile: ./localenv/mock-account-servicing-entity/Dockerfile
@@ -23,6 +24,7 @@ services:
       - happy-life-backend
   happy-life-backend:
     hostname: happy-life-bank-backend
+    image: rafiki-backend
     build:
       context: ../..
       dockerfile: ./packages/backend/Dockerfile
@@ -58,6 +60,7 @@ services:
       PAYMENT_POINTER_URL: https://happy-life-bank-backend/.well-known/pay
   happy-life-auth:
     hostname: happy-life-bank-auth
+    image: rafiki-auth
     build:
       context: ../..
       dockerfile: ./packages/auth/Dockerfile
@@ -72,6 +75,7 @@ services:
       AUTH_SERVER_DOMAIN: "http://localhost:4006"
   happy-life-signatures:
     hostname: happy-life-bank-signatures
+    image: rafiki-postman-signatures
     build:
       context: ../..
       dockerfile: ./localenv/local-http-signatures/Dockerfile
@@ -84,6 +88,7 @@ services:
       - ../happy-life-bank/private-key.pem:/workspace/private-key.pem
   happy-life-admin:
     hostname: happy-life-bank-admin
+    image: rafiki-frontend
     build:
       context: ../..
       dockerfile: ./packages/frontend/Dockerfile


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
Previously, when running `pnpm localenv:compose build`, we would build e.g. `rafiki-cloud-nine-backend` and `rafiki-happy-life-backend`, but the images are both the same, namely the backend images. 

I added image names a la `image: rafiki-backend` to the compose files such that the images are only built once.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
