### PR TITLE
chore: update incoming payment creation payload

### DIFF
--- a/packages/backend/src/open_payments/payment/incoming_remote/service.ts
+++ b/packages/backend/src/open_payments/payment/incoming_remote/service.ts
@@ -74,9 +74,9 @@ async function create(
         incomingAmount: args.incomingAmount
           ? serializeAmount(args.incomingAmount)
           : undefined,
-        description: args.description,
+        description: args.description ?? undefined,
         expiresAt: args.expiresAt?.toISOString(),
-        externalRef: args.externalRef
+        externalRef: args.externalRef ?? undefined
       }
     )
   } catch (error) {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Make sure `externalRef` and `description` are undefined if missing

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
When trying to make a `createReceiver` GraphQL API call with the following input:
```json
{
  "input": {
    "description": null,
    "externalRef": null,
    "incomingAmount": {
      "assetCode": "USD",
      "assetScale": 2,
      "value": 100
    },
    "paymentPointerUrl": "https://happy-life-bank-backend/accounts/pfry"
  }
}
```
results in 
```json
{
    "data": {
        "createReceiver": {
            "code": "500",
            "message": "invalid remote incoming payment request",
            "receiver": null,
            "success": false
        }
    }
}
```
This is because the Open Payments OpenAPI spec doesn't accept "null" as a valid value when making the request (to the external Rafiki instance via the Open Payments client), and thus, the OpenAPI validation fails on the response. This PR makes sure we pass in `undefined` in case null is passed in


## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
