### PR TITLE
feat: add base parameter to /rates API

### DIFF
--- a/localenv/mock-account-servicing-entity/app/routes/rates.ts
+++ b/localenv/mock-account-servicing-entity/app/routes/rates.ts
@@ -1,15 +1,33 @@
 import type { LoaderArgs } from '@remix-run/node'
 import { json } from '@remix-run/node'
 
+interface Rates {
+  [currency: string]: { [currency: string]: number }
+}
+
+const exchangeRates: Rates = {
+  USD: {
+    EUR: 1.1602,
+    ZAR: 17.3792
+  },
+  EUR: {
+    USD: 0.8619,
+    ZAR: 20.44
+  },
+  ZAR: {
+    USD: 0.0575,
+    EUR: 0.0489
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function loader({ request }: LoaderArgs) {
+  const base = new URL(request.url).searchParams.get('base') || 'USD'
+
   return json(
     {
-      base: 'USD',
-      rates: {
-        EUR: 1.1602,
-        ZAR: 17.3792
-      }
+      base,
+      rates: exchangeRates[base] ?? {}
     },
     { status: 200 }
   )

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -229,6 +229,7 @@ describe('OutgoingPaymentService', (): void => {
     Config.exchangeRatesUrl = 'https://test.rates'
     nock(Config.exchangeRatesUrl)
       .get('/')
+      .query(true)
       .reply(200, () => ({
         base: 'USD',
         rates: {

--- a/packages/backend/src/open_payments/quote/service.test.ts
+++ b/packages/backend/src/open_payments/quote/service.test.ts
@@ -72,6 +72,7 @@ describe('QuoteService', (): void => {
     Config.signatureSecret = SIGNATURE_SECRET
     nock(Config.exchangeRatesUrl)
       .get('/')
+      .query(true)
       .reply(200, () => ({
         base: 'USD',
         rates: {

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -221,9 +221,11 @@ export async function startQuote(
   deps: ServiceDependencies,
   options: StartQuoteOptions
 ): Promise<Pay.Quote> {
-  const rates = await deps.ratesService.rates().catch((_err: Error) => {
-    throw new Error('missing rates')
-  })
+  const rates = await deps.ratesService
+    .rates(options.receiver.assetCode)
+    .catch((_err: Error) => {
+      throw new Error('missing rates')
+    })
 
   const plugin = deps.makeIlpPlugin({
     sourceAccount: options.paymentPointer,

--- a/packages/backend/src/openapi/exchange-rates.yaml
+++ b/packages/backend/src/openapi/exchange-rates.yaml
@@ -16,7 +16,14 @@ tags:
     description: Exchange rates
 paths:
   /:
-    parameters: []
+    parameters:
+      - schema:
+          type: string
+          minLength: 1
+        name: base
+        in: query
+        required: true
+        description: Base exchange rate Base exchange rate
     get:
       summary: Fetch exchange rates
       operationId: get-rates

--- a/packages/backend/src/rates/util.test.ts
+++ b/packages/backend/src/rates/util.test.ts
@@ -1,60 +1,64 @@
 import { convert, Asset } from './util'
 
-describe('Rates util', function () {
-  describe('convert', function () {
-    it('converts same scales', () => {
-      // Rate > 1
-      expect(
-        convert({
-          exchangeRate: 1.5,
-          sourceAmount: 100n,
-          sourceAsset: asset(9),
-          destinationAsset: asset(9)
-        })
-      ).toBe(150n)
-      // Rate < 1
-      expect(
-        convert({
-          exchangeRate: 0.5,
-          sourceAmount: 100n,
-          sourceAsset: asset(9),
-          destinationAsset: asset(9)
-        })
-      ).toBe(50n)
-      // Round down
-      expect(
-        convert({
-          exchangeRate: 0.5,
-          sourceAmount: 101n,
-          sourceAsset: asset(9),
-          destinationAsset: asset(9)
-        })
-      ).toBe(50n)
+describe('Rates util', () => {
+  describe('convert', () => {
+    describe('convert same scales', () => {
+      test.each`
+        exchangeRate | sourceAmount | assetScale | expectedResult | description
+        ${1.5}       | ${100n}      | ${9}       | ${150n}        | ${'exchange rate above 1'}
+        ${1.1602}    | ${12345n}    | ${2}       | ${14323n}      | ${'exchange rate above 1 with rounding up'}
+        ${1.1602}    | ${10001n}    | ${2}       | ${11603n}      | ${'exchange rate above 1 with rounding down'}
+        ${0.5}       | ${100n}      | ${9}       | ${50n}         | ${'exchange rate below 1'}
+        ${0.5}       | ${101n}      | ${9}       | ${51n}         | ${'exchange rate below 1 with rounding up'}
+        ${0.8611}    | ${1000n}     | ${2}       | ${861n}        | ${'exchange rate below 1 with rounding down'}
+      `(
+        '$description',
+        async ({
+          exchangeRate,
+          sourceAmount,
+          assetScale,
+          expectedResult
+        }): Promise<void> => {
+          expect(
+            convert({
+              exchangeRate,
+              sourceAmount,
+              sourceAsset: createAsset(assetScale),
+              destinationAsset: createAsset(assetScale)
+            })
+          ).toBe(expectedResult)
+        }
+      )
     })
 
-    it('converts different scales', () => {
-      // Scale low → high
-      expect(
-        convert({
-          exchangeRate: 1.5,
-          sourceAmount: 100n,
-          sourceAsset: asset(9),
-          destinationAsset: asset(12)
-        })
-      ).toBe(150_000n)
-      // Scale high → low
-      expect(
-        convert({
-          exchangeRate: 1.5,
-          sourceAmount: 100_000n,
-          sourceAsset: asset(12),
-          destinationAsset: asset(9)
-        })
-      ).toBe(150n)
+    describe('convert different scales', () => {
+      test.each`
+        exchangeRate | sourceAmount | sourceAssetScale | destinationAssetScale | expectedResult | description
+        ${1.5}       | ${100n}      | ${9}             | ${12}                 | ${150_000n}    | ${'convert scale from low to high'}
+        ${1.5}       | ${100_000n}  | ${12}            | ${9}                  | ${150n}        | ${'convert scale from high to low'}
+      `(
+        '$description',
+        async ({
+          exchangeRate,
+          sourceAmount,
+          sourceAssetScale,
+          destinationAssetScale,
+          expectedResult
+        }): Promise<void> => {
+          expect(
+            convert({
+              exchangeRate,
+              sourceAmount,
+              sourceAsset: createAsset(sourceAssetScale),
+              destinationAsset: createAsset(destinationAssetScale)
+            })
+          ).toBe(expectedResult)
+        }
+      )
     })
   })
 })
 
-function asset(scale: number): Asset {
-  return { code: '[ignored]', scale }
+function createAsset(scale: number): Asset {
+  return { code: 'XYZ', scale }
 }

--- a/packages/backend/src/rates/util.ts
+++ b/packages/backend/src/rates/util.ts
@@ -12,11 +12,8 @@ export interface Asset {
 }
 
 export function convert(opts: ConvertOptions): bigint {
-  const maxScale = Math.max(opts.sourceAsset.scale, opts.destinationAsset.scale)
-  const shiftUp = 10 ** maxScale
   const scaleDiff = opts.destinationAsset.scale - opts.sourceAsset.scale
   const scaledExchangeRate = opts.exchangeRate * 10 ** scaleDiff
-  return (
-    (opts.sourceAmount * BigInt(scaledExchangeRate * shiftUp)) / BigInt(shiftUp)
-  )
+
+  return BigInt(Math.round(Number(opts.sourceAmount) * scaledExchangeRate))
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Making sure rates service can handle different exchange rates with multiple decimal points: before, there would be a bug where the currency conversion would fail because BigInt could not support decimal place results that would arise from exchange rates with more decimals than the assetScale
- Adding `base` parameter to `/rates`, updating MASE to properly return with the `base` param

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- Fixes #1524 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
