### PR TITLE
chore: fix timestamp-related tests failures

### DIFF
--- a/infrastructure/helm/tigerbeetle/values.yaml
+++ b/infrastructure/helm/tigerbeetle/values.yaml
@@ -23,7 +23,7 @@ statefulset:
   clusterId: "0"
 
   image:
-    repository: ghcr.io/tigerbeetledb/tigerbeetle
+    repository: ghcr.io/tigerbeetle/tigerbeetle
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "0.13.38"

--- a/packages/backend/src/shared/baseModel.ts
+++ b/packages/backend/src/shared/baseModel.ts
@@ -112,8 +112,6 @@ export abstract class BaseModel extends DbErrors(Model) {
   public $beforeInsert(context: QueryContext): void {
     super.$beforeInsert(context)
     this.id = this.id || uuid()
-    this.createdAt = new Date()
-    this.updatedAt = new Date()
   }
 
   public $beforeUpdate(_opts: ModelOptions, _queryContext: QueryContext): void {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- _Should_ fix some sporadic tests failures for pagination
- Sets proper image for tigerbeetle in helm chart (after #1541)

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Sometimes, we would get webhook event pagination tests failures such as:
```js
FAIL backend src/graphql/resolvers/webhooks.test.ts
  ● Webhook Events Query › Common query resolver pagination › pageInfo is correct on pagination from middle

    expect(received).toEqual(expected) // deep equality

    Expected: "d86328d9-aaa4-4435-9109-d127a6db63b4"
    Received: "598ebaff-2fef-4e57-9226-7eed8d76[75](https://github.com/interledger/rafiki/actions/runs/5474725660/jobs/9969921725#step:5:76)db"

      212 |       expect(query.pageInfo.hasPreviousPage).toBeTruthy()
      213 |       expect(query.pageInfo.startCursor).toEqual(models[20].id)
    > 214 |       expect(query.pageInfo.endCursor).toEqual(models[39].id)
          |                                        ^
      215 |     })
      216 |
      217 |     test('pageInfo is correct on pagination near end', async (): Promise<void> => {
```
This was happening earlier for me, [comment](https://github.com/interledger/rafiki/pull/1454#issuecomment-1577082196), because:

> ... The TL;DR of it was that models were being created with the same `createdAt` timestamp, which ended up resulting in a different order of models when they were stored in memory: `let modelsCreated: Type[]` in `baseModel.test.ts` vs when they were fetched from the database. The tests would fail when the cursor fell on one of these models with the same `createdAt`. 

This means, in order to fix these tests, `createdAt` should be a unique value. Previously, we were setting `createdAt` and `updatedAt` in a `$beforeInsert` objection hook:

```js
  public $beforeInsert(context: QueryContext): void {
    super.$beforeInsert(context)
    this.id = this.id || uuid()
    this.createdAt = new Date()
    this.updatedAt = new Date()
  }
```
Which puts the responsibility of setting the timestamps on node, not the database. In all of our migrations, we already have
```js
    table.timestamp('createdAt').defaultTo(knex.fn.now())
    table.timestamp('updatedAt').defaultTo(knex.fn.now())
```
which would use `CURRENT_TIMESTAMP` in Postgres instead, with a higher precision that node.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
