### PR TITLE
fix: use sending asset for base rate when creating quote

### DIFF
--- a/packages/backend/src/middleware/cache/data-stores/in-memory.ts
+++ b/packages/backend/src/middleware/cache/data-stores/in-memory.ts
@@ -1,0 +1,46 @@
+import { CacheDataStore } from '.'
+
+interface Cached {
+  expiry: number
+  data: string
+}
+
+export function createInMemoryDataStore(keyTtlMs: number): CacheDataStore {
+  const map = new Map<string, Cached>()
+
+  const getAndCheckExpiry = (key: string): Cached | undefined => {
+    const cached = map.get(key)
+
+    if (cached?.expiry && Date.now() >= cached.expiry) {
+      deleteKey(key)
+      return undefined
+    }
+
+    return cached
+  }
+
+  const deleteKey = (key: string) => map.delete(key)
+
+  return {
+    async get(key): Promise<string | undefined> {
+      const cached = getAndCheckExpiry(key)
+
+      return cached?.data
+    },
+    async getKeyExpiry(key: string): Promise<Date | undefined> {
+      const cached = getAndCheckExpiry(key)
+
+      return cached ? new Date(cached.expiry) : undefined
+    },
+    async delete(key): Promise<void> {
+      deleteKey(key)
+    },
+    async set(key: string, value: string): Promise<boolean> {
+      map.set(key, { expiry: Date.now() + keyTtlMs, data: value })
+      return true
+    },
+    async deleteAll(): Promise<void> {
+      map.clear()
+    }
+  }
+}

--- a/packages/backend/src/middleware/cache/data-stores/index.ts
+++ b/packages/backend/src/middleware/cache/data-stores/index.ts
@@ -1,5 +1,7 @@
 export interface CacheDataStore {
   get(key: string): Promise<string | undefined>
+  getKeyExpiry(key: string): Promise<Date | undefined>
   set(key: string, value: string): Promise<boolean>
   delete(key: string): Promise<void>
+  deleteAll(): Promise<void>
 }

--- a/packages/backend/src/middleware/cache/data-stores/redis.test.ts
+++ b/packages/backend/src/middleware/cache/data-stores/redis.test.ts
@@ -68,7 +68,7 @@ describe('Redis Data Store', (): void => {
 
       const difference = keyExpiry?.getTime() - now
 
-      expect(ttlMs <= difference && difference <= ttlMs + 5).toBe(true) // ideally the key expiry would be set at exactly now + ttlMs, but we give redis spmel here
+      expect(ttlMs <= difference && difference <= ttlMs + 5).toBe(true) // ideally the key expiry would be set at exactly now + ttlMs, but we give redis some margin
     })
   })
 

--- a/packages/backend/src/middleware/cache/data-stores/redis.ts
+++ b/packages/backend/src/middleware/cache/data-stores/redis.ts
@@ -9,11 +9,20 @@ export function createRedisDataStore(
     async get(key: string): Promise<string | undefined> {
       return (await redisClient.get(key)) || undefined
     },
+    async getKeyExpiry(key: string): Promise<Date | undefined> {
+      const expiryTimestamp = await redisClient.pexpiretime(key)
+      return expiryTimestamp && expiryTimestamp > 0
+        ? new Date(parseInt(expiryTimestamp.toString()))
+        : undefined
+    },
     async set(key: string, value: string): Promise<boolean> {
       return (await redisClient.set(key, value, 'PX', keyTtlMs)) === 'OK'
     },
     async delete(key: string): Promise<void> {
       await redisClient.del(key)
+    },
+    async deleteAll(): Promise<void> {
+      await redisClient.flushall()
     }
   }
 }

--- a/packages/backend/src/middleware/cache/data-stores/redis.ts
+++ b/packages/backend/src/middleware/cache/data-stores/redis.ts
@@ -12,7 +12,7 @@ export function createRedisDataStore(
     async getKeyExpiry(key: string): Promise<Date | undefined> {
       const expiryTimestamp = await redisClient.pexpiretime(key)
       return expiryTimestamp && expiryTimestamp > 0
-        ? new Date(parseInt(expiryTimestamp.toString()))
+        ? new Date(+expiryTimestamp)
         : undefined
     },
     async set(key: string, value: string): Promise<boolean> {

--- a/packages/backend/src/middleware/cache/index.test.ts
+++ b/packages/backend/src/middleware/cache/index.test.ts
@@ -1,31 +1,14 @@
 import pino from 'pino'
-import { CacheDataStore } from './data-stores'
 import { cacheMiddleware } from '.'
 import { v4 as uuid } from 'uuid'
-
-const createTestDataStore = (): CacheDataStore => {
-  const map = new Map<string, string>()
-
-  return {
-    async get(key): Promise<string | undefined> {
-      return map.get(key)
-    },
-    async delete(key): Promise<void> {
-      map.delete(key)
-    },
-    async set(key: string, value: string): Promise<boolean> {
-      map.set(key, value)
-      return true
-    }
-  }
-}
+import { createInMemoryDataStore } from './data-stores/in-memory'
 
 describe('Cache Middleware', (): void => {
   const logger = pino({ level: 'silent' })
   const defaultRequest = () => Promise.resolve('requestResult')
   const defaultOperationName = 'defaultOperationName'
 
-  const dataStore = createTestDataStore()
+  const dataStore = createInMemoryDataStore(10000)
   const handleParamMismatch = () => {
     throw new Error('Param mismatch')
   }

--- a/packages/backend/src/open_payments/quote/service.test.ts
+++ b/packages/backend/src/open_payments/quote/service.test.ts
@@ -94,10 +94,9 @@ describe('QuoteService', (): void => {
       code: sendAmount.assetCode,
       scale: sendAmount.assetScale
     })
-    const paymentPointer = await createPaymentPointer(deps, {
+    sendingPaymentPointer = await createPaymentPointer(deps, {
       assetId: sendAssetId
     })
-    sendingPaymentPointer = paymentPointer
     const { id: destinationAssetId } = await createAsset(deps, destinationAsset)
     receivingPaymentPointer = await createPaymentPointer(deps, {
       assetId: destinationAssetId,

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -222,7 +222,7 @@ export async function startQuote(
   options: StartQuoteOptions
 ): Promise<Pay.Quote> {
   const rates = await deps.ratesService
-    .rates(options.receiver.assetCode)
+    .rates(options.paymentPointer.asset.code)
     .catch((_err: Error) => {
       throw new Error('missing rates')
     })

--- a/packages/backend/src/rates/service.test.ts
+++ b/packages/backend/src/rates/service.test.ts
@@ -1,4 +1,4 @@
-import { RatesService, ConvertError, Rates } from './service'
+import { RatesService, ConvertError } from './service'
 import { createTestApp, TestContainer } from '../tests/app'
 import { Config } from '../config/app'
 import { IocContract } from '@adonisjs/fold'

--- a/packages/backend/src/rates/service.ts
+++ b/packages/backend/src/rates/service.ts
@@ -1,6 +1,8 @@
 import { BaseService } from '../shared/baseService'
 import Axios, { AxiosInstance } from 'axios'
 import { convert, ConvertOptions } from './util'
+import { createInMemoryDataStore } from '../middleware/cache/data-stores/in-memory'
+import { CacheDataStore } from '../middleware/cache/data-stores'
 
 const REQUEST_TIMEOUT = 5_000 // millseconds
 
@@ -40,15 +42,16 @@ export function createRatesService(deps: ServiceDependencies): RatesService {
 
 class RatesServiceImpl implements RatesService {
   private axios: AxiosInstance
-  private ratesRequest?: Promise<Rates>
-  private ratesExpiry?: Date
-  private prefetchRequest?: Promise<Rates>
+  private cachedRates: CacheDataStore
+  private inProgressRequests: Record<string, Promise<Rates>> = {}
 
   constructor(private deps: ServiceDependencies) {
     this.axios = Axios.create({
       timeout: REQUEST_TIMEOUT,
       validateStatus: (status) => status === 200
     })
+
+    this.cachedRates = createInMemoryDataStore(deps.exchangeRatesLifetime)
   }
 
   async convert(
@@ -59,7 +62,7 @@ class RatesServiceImpl implements RatesService {
     if (sameCode && sameScale) return opts.sourceAmount
     if (sameCode) return convert({ exchangeRate: 1.0, ...opts })
 
-    const rates = await this.sharedLoad(opts.sourceAsset.code)
+    const rates = await this.getRates(opts.sourceAsset.code)
     const sourcePrice = rates[opts.sourceAsset.code]
     if (!sourcePrice) return ConvertError.MissingSourceAsset
     if (!isValidPrice(sourcePrice)) return ConvertError.InvalidSourcePrice
@@ -74,41 +77,54 @@ class RatesServiceImpl implements RatesService {
   }
 
   async rates(baseAssetCode: string): Promise<Rates> {
-    return this.sharedLoad(baseAssetCode)
+    return this.getRates(baseAssetCode)
   }
 
-  private sharedLoad(baseAssetCode: string): Promise<Rates> {
-    if (this.ratesRequest && this.ratesExpiry) {
-      if (this.ratesExpiry < new Date()) {
-        // Already expired: invalidate cached rates.
-        this.ratesRequest = undefined
-        this.ratesExpiry = undefined
-      } else if (
-        this.ratesExpiry.getTime() <
+  private async getRates(baseAssetCode: string): Promise<Rates> {
+    const [cachedRate, cachedExpiry] = await Promise.all([
+      this.cachedRates.get(baseAssetCode),
+      this.cachedRates.getKeyExpiry(baseAssetCode)
+    ])
+
+    if (cachedRate && cachedExpiry) {
+      const isCloseToExpiry =
+        cachedExpiry.getTime() <
         Date.now() + 0.5 * this.deps.exchangeRatesLifetime
-      ) {
-        // Expiring soon: start prefetch.
-        if (!this.prefetchRequest) {
-          this.prefetchRequest = this.loadNow(baseAssetCode).finally(() => {
-            this.prefetchRequest = undefined
-          })
-        }
+
+      if (isCloseToExpiry) {
+        this.fetchNewRatesAndCache(baseAssetCode) // don't await, just get new rates for later
       }
+
+      return JSON.parse(cachedRate)
     }
 
-    if (!this.ratesRequest) {
-      this.ratesRequest =
-        this.prefetchRequest ||
-        this.loadNow(baseAssetCode).catch((err) => {
-          this.ratesRequest = undefined
-          this.ratesExpiry = undefined
-          throw err
-        })
+    try {
+      return await this.fetchNewRatesAndCache(baseAssetCode)
+    } catch (err) {
+      this.cachedRates.delete(baseAssetCode)
+      throw err
     }
-    return this.ratesRequest
   }
 
-  private async loadNow(baseAssetCode: string): Promise<Rates> {
+  async fetchNewRatesAndCache(baseAssetCode: string): Promise<Rates> {
+    const inProgressRequest = this.inProgressRequests[baseAssetCode]
+    let rates: Rates
+
+    if (inProgressRequest) {
+      rates = await inProgressRequest
+    } else {
+      this.inProgressRequests[baseAssetCode] = this.fetchNewRates(baseAssetCode)
+
+      rates = await this.inProgressRequests[baseAssetCode]
+    }
+
+    delete this.inProgressRequests[baseAssetCode]
+
+    await this.cachedRates.set(baseAssetCode, JSON.stringify(rates))
+    return rates
+  }
+
+  private async fetchNewRates(baseAssetCode: string): Promise<Rates> {
     const url = this.deps.exchangeRatesUrl
     if (!url) return {}
 
@@ -127,8 +143,6 @@ class RatesServiceImpl implements RatesService {
       ...(rates ? rates : {})
     }
 
-    this.ratesRequest = Promise.resolve(data)
-    this.ratesExpiry = new Date(Date.now() + this.deps.exchangeRatesLifetime)
     return data
   }
 

--- a/packages/backend/src/rates/service.ts
+++ b/packages/backend/src/rates/service.ts
@@ -20,7 +20,7 @@ interface ServiceDependencies extends BaseService {
   exchangeRatesLifetime: number
 }
 
-export interface Rates {
+interface Rates {
   [currency: string]: number
 }
 

--- a/packages/backend/src/rates/service.ts
+++ b/packages/backend/src/rates/service.ts
@@ -20,7 +20,7 @@ interface ServiceDependencies extends BaseService {
   exchangeRatesLifetime: number
 }
 
-interface Rates {
+export interface Rates {
   [currency: string]: number
 }
 
@@ -106,17 +106,14 @@ class RatesServiceImpl implements RatesService {
     }
   }
 
-  async fetchNewRatesAndCache(baseAssetCode: string): Promise<Rates> {
+  private async fetchNewRatesAndCache(baseAssetCode: string): Promise<Rates> {
     const inProgressRequest = this.inProgressRequests[baseAssetCode]
-    let rates: Rates
 
-    if (inProgressRequest) {
-      rates = await inProgressRequest
-    } else {
+    if (!inProgressRequest) {
       this.inProgressRequests[baseAssetCode] = this.fetchNewRates(baseAssetCode)
-
-      rates = await this.inProgressRequests[baseAssetCode]
     }
+
+    const rates = await this.inProgressRequests[baseAssetCode]
 
     delete this.inProgressRequests[baseAssetCode]
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
In a discussion with @raducristianpopa, he noticed 
1. we should be using the sending asset code as base rate when creating the quote, instead of (incorrectly) the receiving asset code, and
2. Now that we are using a base rate when asking for rates from the ASE, the rates service caching does not take into account different possible base's. This means when we request rates with base USD, we cache the result, and will continue return USD even if we ask for EUR as base rate. 

This change:
- uses the sending asset code as base rate when creating a quote
- adds in-memory caching as a data store
- updates rate service to use in-memory caching data store & take into account base rate when caching & returning rates

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #1676

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
