### PR TITLE
fix: add mutation observer for long ToC

### DIFF
--- a/packages/documentation/astro.config.mjs
+++ b/packages/documentation/astro.config.mjs
@@ -20,6 +20,15 @@ export default defineConfig({
     starlight({
       title: 'Rafiki',
       customCss: ['./src/styles/ilf-docs.css', './src/styles/rafiki.css'],
+      head: [
+        {
+          tag: 'script',
+          attrs: {
+            src: '/scripts.js',
+            defer: true
+          }
+        }
+      ],
       logo: {
         src: './public/img/icon.svg'
       },

--- a/packages/documentation/public/scripts.js
+++ b/packages/documentation/public/scripts.js
@@ -1,0 +1,14 @@
+new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    if (mutation.type === 'attributes') {
+      const current = mutation.target.getAttribute('aria-current')
+
+      if (current) {
+        mutation.target.scrollIntoView({ block: 'center' })
+      }
+    }
+  }
+}).observe(document.querySelector('starlight-toc > nav > ul'), {
+  attributeFilter: ['aria-current'],
+  subtree: true
+})


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- This PR adds a `MutationObserver` which checks for `aria-current` changes in the ToC then scrolls new active links into view.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Closes #1781 
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
