### PR TITLE
feat: get peering details

### DIFF
--- a/packages/backend/src/asset/service.test.ts
+++ b/packages/backend/src/asset/service.test.ts
@@ -193,4 +193,20 @@ describe('Asset Service', (): void => {
       getPage: (pagination?: Pagination) => assetService.getPage(pagination)
     })
   })
+
+  describe('getAll', (): void => {
+    test('returns all assets', async (): Promise<void> => {
+      const assets = await Promise.all([
+        assetService.create(randomAsset()),
+        assetService.create(randomAsset()),
+        assetService.create(randomAsset())
+      ])
+
+      await expect(assetService.getAll()).resolves.toEqual(assets)
+    })
+
+    test('returns empty array if no assets', async (): Promise<void> => {
+      await expect(assetService.getAll()).resolves.toEqual([])
+    })
+  })
 })

--- a/packages/backend/src/asset/service.ts
+++ b/packages/backend/src/asset/service.ts
@@ -25,6 +25,7 @@ export interface AssetService {
   update(options: UpdateOptions): Promise<Asset | AssetError>
   get(id: string): Promise<void | Asset>
   getPage(pagination?: Pagination): Promise<Asset[]>
+  getAll(): Promise<Asset[]>
 }
 
 interface ServiceDependencies extends BaseService {
@@ -48,7 +49,8 @@ export async function createAssetService({
     create: (options) => createAsset(deps, options),
     update: (options) => updateAsset(deps, options),
     get: (id) => getAsset(deps, id),
-    getPage: (pagination?) => getAssetsPage(deps, pagination)
+    getPage: (pagination?) => getAssetsPage(deps, pagination),
+    getAll: () => getAll(deps)
   }
 }
 
@@ -117,4 +119,8 @@ async function getAssetsPage(
   pagination?: Pagination
 ): Promise<Asset[]> {
   return await Asset.query(deps.knex).getPage(pagination)
+}
+
+async function getAll(deps: ServiceDependencies): Promise<Asset[]> {
+  return await Asset.query(deps.knex)
 }

--- a/packages/backend/src/auto-peering/routes.test.ts
+++ b/packages/backend/src/auto-peering/routes.test.ts
@@ -1,0 +1,68 @@
+import { IocContract } from '@adonisjs/fold'
+import { initIocContainer } from '..'
+import { AppContext, AppServices } from '../app'
+import { Config } from '../config/app'
+import { createTestApp, TestContainer } from '../tests/app'
+import { createAsset } from '../tests/asset'
+import { createContext } from '../tests/context'
+import { truncateTables } from '../tests/tableManager'
+import { AutoPeeringRoutes } from './routes'
+
+describe('Auto Peering Routes', (): void => {
+  let deps: IocContract<AppServices>
+  let appContainer: TestContainer
+  let autoPeeringRoutes: AutoPeeringRoutes
+
+  beforeAll(async (): Promise<void> => {
+    deps = initIocContainer({ ...Config, enableAutoPeering: true })
+    appContainer = await createTestApp(deps)
+    autoPeeringRoutes = await deps.use('autoPeeringRoutes')
+  })
+
+  afterEach(async (): Promise<void> => {
+    await truncateTables(appContainer.knex)
+  })
+
+  afterAll(async (): Promise<void> => {
+    await appContainer.shutdown()
+  })
+
+  describe('get', (): void => {
+    test('returns peering details with assets', async (): Promise<void> => {
+      const assets = await Promise.all([
+        createAsset(deps),
+        createAsset(deps),
+        createAsset(deps)
+      ])
+
+      const ctx = createContext<AppContext>({
+        headers: { Accept: 'application/json' },
+        url: `/`
+      })
+
+      await expect(autoPeeringRoutes.get(ctx)).resolves.toBeUndefined()
+      expect(ctx.body).toEqual({
+        ilpAddress: Config.ilpAddress,
+        assets: expect.arrayContaining(
+          assets.map((asset) => ({
+            code: asset.code,
+            scale: asset.scale
+          }))
+        )
+      })
+    })
+
+    test('returns peering details without assets', async (): Promise<void> => {
+      const ctx = createContext<AppContext>({
+        headers: { Accept: 'application/json' },
+        url: `/`
+      })
+
+      await expect(autoPeeringRoutes.get(ctx)).resolves.toBeUndefined()
+      expect(ctx.body).toEqual({
+        ilpAddress: Config.ilpAddress,
+        assets: []
+      })
+    })
+  })
+})

--- a/packages/backend/src/auto-peering/routes.ts
+++ b/packages/backend/src/auto-peering/routes.ts
@@ -1,0 +1,35 @@
+import { AppContext } from '../app'
+import { BaseService } from '../shared/baseService'
+import { AutoPeeringService } from './service'
+
+export interface ServiceDependencies extends BaseService {
+  autoPeeringService: AutoPeeringService
+}
+
+export interface AutoPeeringRoutes {
+  get(ctx: AppContext): Promise<void>
+}
+
+export async function createAutoPeeringRoutes(
+  deps_: ServiceDependencies
+): Promise<AutoPeeringRoutes> {
+  const deps: ServiceDependencies = {
+    ...deps_,
+    logger: deps_.logger.child({
+      service: 'AutoPeeringRoutes'
+    })
+  }
+
+  return {
+    get: (ctx: AppContext) => getPeeringDetails(deps, ctx)
+  }
+}
+
+async function getPeeringDetails(
+  deps: ServiceDependencies,
+  ctx: AppContext
+): Promise<void> {
+  const peeringDetails = await deps.autoPeeringService.getPeeringDetails()
+
+  ctx.body = peeringDetails
+}

--- a/packages/backend/src/auto-peering/service.test.ts
+++ b/packages/backend/src/auto-peering/service.test.ts
@@ -1,0 +1,55 @@
+import { IocContract } from '@adonisjs/fold'
+import { initIocContainer } from '..'
+import { AppServices } from '../app'
+import { Config } from '../config/app'
+import { createTestApp, TestContainer } from '../tests/app'
+import { createAsset } from '../tests/asset'
+import { truncateTables } from '../tests/tableManager'
+import { AutoPeeringService } from './service'
+
+describe('Auto Peering Service', (): void => {
+  let deps: IocContract<AppServices>
+  let appContainer: TestContainer
+  let autoPeeringService: AutoPeeringService
+
+  beforeAll(async (): Promise<void> => {
+    deps = initIocContainer({ ...Config, enableAutoPeering: true })
+    appContainer = await createTestApp(deps)
+    autoPeeringService = await deps.use('autoPeeringService')
+  })
+
+  afterEach(async (): Promise<void> => {
+    await truncateTables(appContainer.knex)
+  })
+
+  afterAll(async (): Promise<void> => {
+    await appContainer.shutdown()
+  })
+
+  describe('getPeeringDetails', (): void => {
+    test('returns peering details', async (): Promise<void> => {
+      const assets = await Promise.all([
+        createAsset(deps),
+        createAsset(deps),
+        createAsset(deps)
+      ])
+
+      expect(autoPeeringService.getPeeringDetails()).resolves.toEqual({
+        ilpAddress: Config.ilpAddress,
+        assets: expect.arrayContaining(
+          assets.map((asset) => ({
+            code: asset.code,
+            scale: asset.scale
+          }))
+        )
+      })
+    })
+
+    test('returns peering details with no assets', async (): Promise<void> => {
+      expect(autoPeeringService.getPeeringDetails()).resolves.toEqual({
+        ilpAddress: Config.ilpAddress,
+        assets: []
+      })
+    })
+  })
+})

--- a/packages/backend/src/auto-peering/service.ts
+++ b/packages/backend/src/auto-peering/service.ts
@@ -1,0 +1,46 @@
+import { AssetService } from '../asset/service'
+import { IAppConfig } from '../config/app'
+import { BaseService } from '../shared/baseService'
+
+export interface PeeringDetails {
+  ilpAddress: string
+  assets: { code: string; scale: number }[]
+}
+
+export interface AutoPeeringService {
+  getPeeringDetails(): Promise<PeeringDetails>
+}
+
+export interface ServiceDependencies extends BaseService {
+  assetService: AssetService
+  config: IAppConfig
+}
+
+export async function createAutoPeeringService(
+  deps_: ServiceDependencies
+): Promise<AutoPeeringService> {
+  const deps: ServiceDependencies = {
+    ...deps_,
+    logger: deps_.logger.child({
+      service: 'AutoPeeringService'
+    })
+  }
+
+  return {
+    getPeeringDetails: () => getPeeringDetails(deps)
+  }
+}
+
+async function getPeeringDetails(
+  deps: ServiceDependencies
+): Promise<PeeringDetails> {
+  const assets = await deps.assetService.getAll()
+
+  return {
+    ilpAddress: deps.config.ilpAddress,
+    assets: assets.map((asset) => ({
+      code: asset.code,
+      scale: asset.scale
+    }))
+  }
+}

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -33,6 +33,8 @@ export const Config = {
   openPaymentsUrl: envString('OPEN_PAYMENTS_URL', 'http://127.0.0.1:3003'),
   openPaymentsPort: envInt('OPEN_PAYMENTS_PORT', 3003),
   connectorPort: envInt('CONNECTOR_PORT', 3002),
+  autoPeeringServerPort: envInt('AUTO_PEERING_SERVER_PORT', 3005),
+  enableAutoPeering: envBool('ENABLE_AUTO_PEERING', false),
   databaseUrl:
     process.env.NODE_ENV === 'test'
       ? `${process.env.DATABASE_URL}_${process.env.JEST_WORKER_ID}`

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -46,6 +46,8 @@ import { createReceiverService } from './open_payments/receiver/service'
 import { createRemoteIncomingPaymentService } from './open_payments/payment/incoming_remote/service'
 import { createCombinedPaymentService } from './open_payments/payment/combined/service'
 import { createFeeService } from './fee/service'
+import { createAutoPeeringService } from './auto-peering/service'
+import { createAutoPeeringRoutes } from './auto-peering/routes'
 
 BigInt.prototype.toJSON = function () {
   return this.toString()
@@ -416,6 +418,23 @@ export function initIocContainer(
     })
   })
 
+  container.singleton('autoPeeringService', async (deps) => {
+    return createAutoPeeringService({
+      logger: await deps.use('logger'),
+      knex: await deps.use('knex'),
+      assetService: await deps.use('assetService'),
+      config: await deps.use('config')
+    })
+  })
+
+  container.singleton('autoPeeringRoutes', async (deps) => {
+    return await createAutoPeeringRoutes({
+      logger: await deps.use('logger'),
+      knex: await deps.use('knex'),
+      autoPeeringService: await deps.use('autoPeeringService')
+    })
+  })
+
   return container
 }
 
@@ -507,6 +526,13 @@ export const start = async (
   connectorServer = connectorApp.listenPublic(config.connectorPort)
   logger.info(`Connector listening on ${config.connectorPort}`)
   logger.info('🐒 has 🚀. Get ready for 🍌🍌🍌🍌🍌')
+
+  if (config.enableAutoPeering) {
+    await app.startAutoPeeringServer(config.autoPeeringServerPort)
+    logger.info(
+      `Auto-peering server listening on ${config.autoPeeringServerPort}`
+    )
+  }
 }
 
 // If this script is run directly, start the server


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adding auto peering server (default port 3005)
- Adding auto peering service & routes that return ilpAddress as well as list of supported assets

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Start of auto-peering story. Adding GET route for returning peering details (for peering discoverability). The new server instantiation itself is under a flag (defaults OFF)

Fixes #1763 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
