### PR TITLE
chore: build images once

### DIFF
--- a/localenv/happy-life-bank/docker-compose.yml
+++ b/localenv/happy-life-bank/docker-compose.yml
@@ -3,9 +3,7 @@ services:
   happy-life-mock-ase:
     hostname: happy-life-bank
     image: rafiki-mock-ase
-    build:
-      context: ../..
-      dockerfile: ./localenv/mock-account-servicing-entity/Dockerfile
+    pull_policy: never
     restart: always
     networks:
       - rafiki
@@ -21,13 +19,12 @@ services:
       - ../happy-life-bank/seed.yml:/workspace/seed.yml
       - ../happy-life-bank/private-key.pem:/workspace/private-key.pem
     depends_on:
+      - cloud-nine-mock-ase
       - happy-life-backend
   happy-life-backend:
     hostname: happy-life-bank-backend
     image: rafiki-backend
-    build:
-      context: ../..
-      dockerfile: ./packages/backend/Dockerfile
+    pull_policy: never
     restart: always
     privileged: true
     ports:
@@ -56,12 +53,12 @@ services:
       REDIS_URL: redis://shared-redis:6379/1
       QUOTE_URL: http://happy-life-bank/quotes
       PAYMENT_POINTER_URL: https://happy-life-bank-backend/.well-known/pay
+    depends_on:
+      - cloud-nine-backend
   happy-life-auth:
     hostname: happy-life-bank-auth
     image: rafiki-auth
-    build:
-      context: ../..
-      dockerfile: ./packages/auth/Dockerfile
+    pull_policy: never
     restart: always
     networks:
       - rafiki
@@ -72,12 +69,12 @@ services:
       NODE_ENV: development
       AUTH_DATABASE_URL: postgresql://happy_life_bank_auth:happy_life_bank_auth@shared-database/happy_life_bank_auth
       AUTH_SERVER_DOMAIN: "http://localhost:4006"
+    depends_on:
+      - cloud-nine-auth
   happy-life-signatures:
     hostname: happy-life-bank-signatures
     image: rafiki-postman-signatures
-    build:
-      context: ../..
-      dockerfile: ./localenv/local-http-signatures/Dockerfile
+    pull_policy: never
     restart: always
     ports:
       - '3041:3000'
@@ -85,12 +82,12 @@ services:
       KEY_FILE: /workspace/private-key.pem
     volumes:
       - ../happy-life-bank/private-key.pem:/workspace/private-key.pem
+    depends_on:
+      - cloud-nine-signatures
   happy-life-admin:
     hostname: happy-life-bank-admin
     image: rafiki-frontend
-    build:
-      context: ../..
-      dockerfile: ./packages/frontend/Dockerfile
+    pull_policy: never
     restart: always
     networks:
       - rafiki
@@ -101,6 +98,7 @@ services:
       GRAPHQL_URL: http://happy-life-bank-backend:3001/graphql
       OPEN_PAYMENTS_URL: https://happy-life-bank-backend/
     depends_on:
+      - cloud-nine-admin
       - happy-life-backend
 
 networks:


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
With these changes, on a clean localenv start-up we will only build the local images once.

Total time spent executing `pnpm localenv:compose up -d`:
- branch `main`: 6.68s user 8.89s system 9% cpu 2:37.82 total
- branch `rp--localenv-docker-images` 4.45s user 5.88s system 6% cpu 2:27.95 total

Despite the fact that all `happy-life-bank` services rely on those of `cloud-nine-wallet`, it does not impact the execution time. The 10s difference might be due to some network delays during image building/pulling.
## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- closes #1811 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
