### PR TITLE
feat: fetching retrieves non-revoked keys for a payment pointer

### DIFF
--- a/packages/backend/src/open_payments/payment_pointer/key/service.test.ts
+++ b/packages/backend/src/open_payments/payment_pointer/key/service.test.ts
@@ -65,6 +65,28 @@ describe('Payment Pointer Key Service', (): void => {
         paymentPointerKeyService.getKeysByPaymentPointerId(paymentPointer.id)
       ).resolves.toEqual([key])
     })
+
+    test('Fetching Only Retrieves Non-Revoked Keys for a Payment Pointer', async (): Promise<void> => {
+      const paymentPointer = await createPaymentPointer(deps)
+
+      const keyOption1 = {
+        paymentPointerId: paymentPointer.id,
+        jwk: TEST_KEY
+      }
+
+      const keyOption2 = {
+        paymentPointerId: paymentPointer.id,
+        jwk: generateJwk({ keyId: uuid() })
+      }
+
+      const key1 = await paymentPointerKeyService.create(keyOption1)
+      const key2 = await paymentPointerKeyService.create(keyOption2)
+      await paymentPointerKeyService.revoke(key1.id)
+
+      await expect(
+        paymentPointerKeyService.getKeysByPaymentPointerId(paymentPointer.id)
+      ).resolves.toEqual([key2])
+    })
   })
 
   describe('Revoke Payment Pointer Keys', (): void => {

--- a/packages/backend/src/open_payments/payment_pointer/key/service.ts
+++ b/packages/backend/src/open_payments/payment_pointer/key/service.ts
@@ -80,7 +80,8 @@ async function getKeysByPaymentPointerId(
   paymentPointerId: string
 ): Promise<PaymentPointerKey[]> {
   const keys = await PaymentPointerKey.query(deps.knex).where({
-    paymentPointerId
+    paymentPointerId,
+    revoked: false
   })
   return keys
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- When fetching payment pointer keys only non-revoked keys are returned

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #1760 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
