### PR TITLE
feat: add test coverage commands

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,6 +12,7 @@
     "build": "pnpm build:deps && pnpm clean && tsc --build tsconfig.json && pnpm copy-files",
     "clean": "rm -fr dist/",
     "test": "jest --passWithNoTests --maxWorkers=50%",
+    "test:cov": "pnpm test -- --coverage --changedSince=main",
     "prepack": "pnpm build",
     "copy-files": "cp src/graphql/schema.graphql dist/graphql/ && cp -r ./src/openapi ./dist/"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,7 +12,9 @@
     "build": "pnpm build:deps && pnpm clean && tsc --build tsconfig.json && pnpm copy-files",
     "clean": "rm -fr dist/",
     "test": "jest --passWithNoTests --maxWorkers=50%",
-    "test:cov": "pnpm test -- --coverage --changedSince=main",
+    "test:cov": "pnpm test -- --coverage",
+    "test:sincemain": "pnpm test -- --changedSince=main",
+    "test:sincemain:cov": "pnpm test:sincemain --coverage",
     "prepack": "pnpm build",
     "copy-files": "cp src/graphql/schema.graphql dist/graphql/ && cp -r ./src/openapi ./dist/"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "test": "jest --passWithNoTests --maxWorkers=50%",
     "test:ci": "jest --passWithNoTests --maxWorkers=2",
-    "test:cov": "pnpm test -- --coverage --changedSince=main",
+    "test:cov": "pnpm test -- --coverage",
+    "test:sincemain": "pnpm test -- --changedSince=main",
+    "test:sincemain:cov": "pnpm test:sincemain --coverage",
     "knex": "knex",
     "generate": "graphql-codegen --config codegen.yml",
     "build:deps": "pnpm --filter token-introspection build",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "test": "jest --passWithNoTests --maxWorkers=50%",
     "test:ci": "jest --passWithNoTests --maxWorkers=2",
+    "test:cov": "pnpm test -- --coverage --changedSince=main",
     "knex": "knex",
     "generate": "graphql-codegen --config codegen.yml",
     "build:deps": "pnpm --filter token-introspection build",

--- a/packages/token-introspection/package.json
+++ b/packages/token-introspection/package.json
@@ -12,7 +12,8 @@
     "copy-files": "cp -r ./src/openapi/*.yaml ./dist/openapi",
     "generate:types": "openapi-typescript src/openapi/token-introspection.yaml --output src/openapi/generated/types.ts -t",
     "prepack": "pnpm build",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "test:cov": "pnpm test -- --coverage --changedSince=main"
   },
   "devDependencies": {
     "@types/node": "^18.7.12",

--- a/packages/token-introspection/package.json
+++ b/packages/token-introspection/package.json
@@ -13,7 +13,9 @@
     "generate:types": "openapi-typescript src/openapi/token-introspection.yaml --output src/openapi/generated/types.ts -t",
     "prepack": "pnpm build",
     "test": "jest --passWithNoTests",
-    "test:cov": "pnpm test -- --coverage --changedSince=main"
+    "test:cov": "pnpm test -- --coverage",
+    "test:sincemain": "pnpm test -- --changedSince=main",
+    "test:sincemain:cov": "pnpm test:sincemain --coverage"
   },
   "devDependencies": {
     "@types/node": "^18.7.12",


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- adds command to run tests and show coverage for files that jest thinks have changed or were related to changes since main

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Closes: https://github.com/interledger/rafiki/discussions/1821

Allows us to get current coverage of tests, but does not show any difference between current branch coverage and main.

If you're really motivated to show the difference from main, you can generate a summary on main and the base branch and run this command: 

    pnpx cov-diff coverage-summary1.json coverage-summary2.json

Not sure if that will prove useful but thought I'd share. https://www.npmjs.com/package/cov-diff

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
