### PR TITLE
feat(backend): mount resource server routes explicitly

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -36,22 +36,27 @@ import {
 import { RatesService } from './rates/service'
 import { spspMiddleware, SPSPConnectionContext } from './spsp/middleware'
 import { SPSPRoutes } from './spsp/routes'
-import { IncomingPaymentRoutes, CreateBody as IncomingCreateBody } from './open_payments/payment/incoming/routes'
+import {
+  IncomingPaymentRoutes,
+  CreateBody as IncomingCreateBody
+} from './open_payments/payment/incoming/routes'
 import { PaymentPointerKeyRoutes } from './open_payments/payment_pointer/key/routes'
 import { PaymentPointerRoutes } from './open_payments/payment_pointer/routes'
 import { IncomingPaymentService } from './open_payments/payment/incoming/service'
 import { StreamServer } from '@interledger/stream-receiver'
 import { WebhookService } from './webhook/service'
-import { QuoteRoutes, CreateBody as QuoteCreateBody } from './open_payments/quote/routes'
+import {
+  QuoteRoutes,
+  CreateBody as QuoteCreateBody
+} from './open_payments/quote/routes'
 import { QuoteService } from './open_payments/quote/service'
-import { OutgoingPaymentRoutes, CreateBody as OutgoingCreateBody } from './open_payments/payment/outgoing/routes'
+import {
+  OutgoingPaymentRoutes,
+  CreateBody as OutgoingCreateBody
+} from './open_payments/payment/outgoing/routes'
 import { OutgoingPaymentService } from './open_payments/payment/outgoing/service'
 import { IlpPlugin, IlpPluginOptions } from './shared/ilp_plugin'
-import {
-  createValidatorMiddleware,
-  HttpMethod,
-  isHttpMethod
-} from '@interledger/openapi'
+import { createValidatorMiddleware, HttpMethod } from '@interledger/openapi'
 import { PaymentPointerKeyService } from './open_payments/payment_pointer/key/service'
 import {
   AccessAction,
@@ -75,7 +80,6 @@ import { FeeService } from './fee/service'
 import { AutoPeeringService } from './auto-peering/service'
 import { AutoPeeringRoutes } from './auto-peering/routes'
 import { Rafiki as ConnectorApp } from './connector/core'
-import { createPaymentPointer } from './tests/paymentPointer'
 
 export interface AppContextData {
   logger: Logger
@@ -125,7 +129,6 @@ export type HttpSigContext = AppContext & {
   client: string
 }
 
-
 // Payment pointer subresources
 type CollectionRequest<BodyT = never, QueryT = ParsedUrlQuery> = Omit<
   PaymentPointerContext['request'],
@@ -144,7 +147,10 @@ type CollectionContext<BodyT = never, QueryT = ParsedUrlQuery> = Omit<
   accessAction: NonNullable<PaymentPointerContext['accessAction']>
 }
 
-type SignedCollectionContext<BodyT = never, QueryT = ParsedUrlQuery> = CollectionContext<BodyT, QueryT> & HttpSigContext
+type SignedCollectionContext<
+  BodyT = never,
+  QueryT = ParsedUrlQuery
+> = CollectionContext<BodyT, QueryT> & HttpSigContext
 
 type SubresourceRequest = Omit<AppContext['request'], 'params'> & {
   params: Record<'id', string>
@@ -370,13 +376,12 @@ export class App {
     router.post<DefaultState, SignedCollectionContext<IncomingCreateBody>>(
       PAYMENT_POINTER_PATH + '/incoming-payments',
       createPaymentPointerMiddleware(),
-      createValidatorMiddleware<ContextType<SignedCollectionContext<IncomingCreateBody>>>(
-        resourceServerSpec,
-        {
-          path: '/incoming-payments',
-          method: HttpMethod.POST
-        }
-      ),
+      createValidatorMiddleware<
+        ContextType<SignedCollectionContext<IncomingCreateBody>>
+      >(resourceServerSpec, {
+        path: '/incoming-payments',
+        method: HttpMethod.POST
+      }),
       createTokenIntrospectionMiddleware({
         requestType: AccessType.IncomingPayment,
         requestAction: RequestAction.Create
@@ -410,13 +415,12 @@ export class App {
     router.post<DefaultState, SignedCollectionContext<OutgoingCreateBody>>(
       PAYMENT_POINTER_PATH + '/outgoing-payments',
       createPaymentPointerMiddleware(),
-      createValidatorMiddleware<ContextType<SignedCollectionContext<OutgoingCreateBody>>>(
-        resourceServerSpec,
-        {
-          path: '/outgoing-payments',
-          method: HttpMethod.POST
-        }
-      ),
+      createValidatorMiddleware<
+        ContextType<SignedCollectionContext<OutgoingCreateBody>>
+      >(resourceServerSpec, {
+        path: '/outgoing-payments',
+        method: HttpMethod.POST
+      }),
       createTokenIntrospectionMiddleware({
         requestType: AccessType.OutgoingPayment,
         requestAction: RequestAction.Create
@@ -450,13 +454,12 @@ export class App {
     router.post<DefaultState, SignedCollectionContext<QuoteCreateBody>>(
       PAYMENT_POINTER_PATH + '/quotes',
       createPaymentPointerMiddleware(),
-      createValidatorMiddleware<ContextType<SignedCollectionContext<QuoteCreateBody>>>(
-        resourceServerSpec,
-        {
-          path: '/quotes',
-          method: HttpMethod.POST
-        }
-      ),
+      createValidatorMiddleware<
+        ContextType<SignedCollectionContext<QuoteCreateBody>>
+      >(resourceServerSpec, {
+        path: '/quotes',
+        method: HttpMethod.POST
+      }),
       createTokenIntrospectionMiddleware({
         requestType: AccessType.Quote,
         requestAction: RequestAction.Create


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Instead of using a "magic for-loop", the backend app now mounts each resource server route explicitly.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #916.

It has been pointed out that the for loop that is used to mount resource server routes onto the backend app isn't very readable. In the interest of code readability, this has been refactored to mount each route explicitly, so it's easy to understand what routes the backend extends.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
