### PR TITLE
fix(auth): hash the correct url when interaction ends

### DIFF
--- a/packages/auth/src/interaction/routes.test.ts
+++ b/packages/auth/src/interaction/routes.test.ts
@@ -292,8 +292,7 @@ describe('Interaction Routes', (): void => {
         const { clientNonce } = grant
         const { nonce: interactNonce, ref: interactRef } = interaction
 
-        const grantRequestUrl =
-          config.authServerDomain + `/`
+        const grantRequestUrl = config.authServerDomain + `/`
 
         const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${grantRequestUrl}`
         const hash = crypto.createHash('sha3-512').update(data).digest('base64')

--- a/packages/auth/src/interaction/routes.test.ts
+++ b/packages/auth/src/interaction/routes.test.ts
@@ -292,10 +292,10 @@ describe('Interaction Routes', (): void => {
         const { clientNonce } = grant
         const { nonce: interactNonce, ref: interactRef } = interaction
 
-        const interactUrl =
-          config.identityServerDomain + `/interact/${interaction.id}`
+        const grantRequestUrl =
+          config.authServerDomain + `/`
 
-        const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${interactUrl}`
+        const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${grantRequestUrl}`
         const hash = crypto.createHash('sha3-512').update(data).digest('base64')
         clientRedirectUri.searchParams.set('hash', hash)
         assert.ok(interactRef)

--- a/packages/auth/src/interaction/routes.ts
+++ b/packages/auth/src/interaction/routes.ts
@@ -251,11 +251,11 @@ async function finishInteraction(
         nonce: interactNonce,
         ref: interactRef
       } = interaction
-      const interactUrl =
-        config.identityServerDomain + `/interact/${interactId}`
+      const grantRequestUrl =
+        config.authServerDomain + `/`
 
       // https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-4.2.3
-      const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${interactUrl}`
+      const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${grantRequestUrl}`
 
       const hash = crypto.createHash('sha3-512').update(data).digest('base64')
       clientRedirectUri.searchParams.set('hash', hash)

--- a/packages/auth/src/interaction/routes.ts
+++ b/packages/auth/src/interaction/routes.ts
@@ -251,8 +251,7 @@ async function finishInteraction(
         nonce: interactNonce,
         ref: interactRef
       } = interaction
-      const grantRequestUrl =
-        config.authServerDomain + `/`
+      const grantRequestUrl = config.authServerDomain + `/`
 
       // https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-4.2.3
       const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${grantRequestUrl}`


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Encodes the Grant Request endpoint in the post-interaction hash rather than the interaction redirect URI.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #1898.

Somehow I didn't catch that the wrong URI was being encoded in the post-interaction hash.
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
