### PR TITLE
feat(auth): update interaction hash method

### DIFF
--- a/packages/auth/src/interaction/routes.test.ts
+++ b/packages/auth/src/interaction/routes.test.ts
@@ -295,7 +295,7 @@ describe('Interaction Routes', (): void => {
         const grantRequestUrl = config.authServerDomain + `/`
 
         const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${grantRequestUrl}`
-        const hash = crypto.createHash('sha3-512').update(data).digest('base64')
+        const hash = crypto.createHash('sha-256').update(data).digest('base64')
         clientRedirectUri.searchParams.set('hash', hash)
         assert.ok(interactRef)
         clientRedirectUri.searchParams.set('interact_ref', interactRef)

--- a/packages/auth/src/interaction/routes.ts
+++ b/packages/auth/src/interaction/routes.ts
@@ -256,7 +256,7 @@ async function finishInteraction(
       // https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-4.2.3
       const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${grantRequestUrl}`
 
-      const hash = crypto.createHash('sha3-512').update(data).digest('base64')
+      const hash = crypto.createHash('sha-256').update(data).digest('base64')
       clientRedirectUri.searchParams.set('hash', hash)
       clientRedirectUri.searchParams.set('interact_ref', interactRef)
       ctx.redirect(clientRedirectUri.toString())


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Updates the hashing method for the post-interaction hash to use `sha-256` instead of `sha3-512`.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

Fixes #1900.

Rafiki's original implentation of GNAP was based on version 11, which used `sha3-512` as a default hashing method for the post-interaction hash. The current version of GNAP (15) uses `sha-256` as the default.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
