### PR TITLE
fix: re-aligning both webhook type enum definitions

### DIFF
--- a/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
@@ -19,8 +19,8 @@ export enum EventType {
   OutgoingPaymentCompleted = 'outgoing_payment.completed',
   OutgoingPaymentFailed = 'outgoing_payment.failed',
   PaymentPointerNotFound = 'payment_pointer.not_found',
-  LiquidityAsset = 'asset.liquidity_low',
-  LiquidityPeer = 'peer.liquidity_low'
+  AssetLiquidityLow = 'asset.liquidity_low',
+  PeerLiquidityLow = 'peer.liquidity_low'
 }
 
 export interface WebHook {

--- a/localenv/mock-account-servicing-entity/app/routes/webhooks.ts
+++ b/localenv/mock-account-servicing-entity/app/routes/webhooks.ts
@@ -38,8 +38,8 @@ export async function action({ request }: ActionArgs) {
       case EventType.PaymentPointerNotFound:
         await handlePaymentPointerNotFound(wh)
         break
-      case EventType.LiquidityAsset:
-      case EventType.LiquidityPeer:
+      case EventType.AssetLiquidityLow:
+      case EventType.PeerLiquidityLow:
         await handleLowLiquidity(wh)
         break
       default:

--- a/packages/frontend/app/shared/enums.ts
+++ b/packages/frontend/app/shared/enums.ts
@@ -5,6 +5,7 @@ export enum WebhookEventType {
   OutgoingPaymentCreated = 'outgoing_payment.created',
   OutgoingPaymentCompleted = 'outgoing_payment.completed',
   OutgoingPaymentFailed = 'outgoing_payment.failed',
+  PaymentPointerNotFound = 'payment_pointer.not_found',
   AssetLiquidityLow = 'asset.liquidity_low',
   PeerLiquidityLow = 'peer.liquidity_low'
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Getting webhook event enums in sync between frontend and the mock account servicing entity

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
