### PR TITLE
feat: add pay method to ilpPaymentService

### DIFF
--- a/packages/backend/src/payment-method/handler/errors.ts
+++ b/packages/backend/src/payment-method/handler/errors.ts
@@ -1,0 +1,16 @@
+interface ErrorDetails {
+  description: string
+  retryable?: boolean
+}
+
+export class PaymentMethodHandlerError extends Error {
+  public description: string
+  public retryable?: boolean
+
+  constructor(message: string, args: ErrorDetails) {
+    super(message)
+    this.name = 'PaymentMethodHandlerError'
+    this.description = args.description
+    this.retryable = args.retryable
+  }
+}

--- a/packages/backend/src/payment-method/handler/service.ts
+++ b/packages/backend/src/payment-method/handler/service.ts
@@ -1,4 +1,5 @@
 import { Amount } from '../../open_payments/amount'
+import { OutgoingPayment } from '../../open_payments/payment/outgoing/model'
 import { PaymentPointer } from '../../open_payments/payment_pointer/model'
 import { Receiver } from '../../open_payments/receiver/model'
 import { BaseService } from '../../shared/baseService'
@@ -20,8 +21,16 @@ export interface PaymentQuote {
   additionalFields: Record<string, unknown>
 }
 
+export interface PayOptions {
+  receiver: Receiver
+  outgoingPayment: OutgoingPayment
+  finalDebitAmount: bigint
+  finalReceiveAmount: bigint
+}
+
 export interface PaymentMethodService {
   getQuote(quoteOptions: StartQuoteOptions): Promise<PaymentQuote>
+  pay(payOptions: PayOptions): Promise<void>
 }
 
 export type PaymentMethod = 'ILP'
@@ -31,6 +40,7 @@ export interface PaymentMethodHandlerService {
     method: PaymentMethod,
     quoteOptions: StartQuoteOptions
   ): Promise<PaymentQuote>
+  pay(method: PaymentMethod, payOptions: PayOptions): Promise<void>
 }
 
 interface ServiceDependencies extends BaseService {
@@ -57,6 +67,7 @@ export async function createPaymentMethodHandlerService({
 
   return {
     getQuote: (method, quoteOptions) =>
-      paymentMethods[method].getQuote(quoteOptions)
+      paymentMethods[method].getQuote(quoteOptions),
+    pay: (method, payOptions) => paymentMethods[method].pay(payOptions)
   }
 }

--- a/packages/backend/src/payment-method/ilp/service.test.ts
+++ b/packages/backend/src/payment-method/ilp/service.test.ts
@@ -1,6 +1,5 @@
 import nock from 'nock'
-
-import { IlpPaymentService } from './service'
+import { IlpPaymentService, retryableIlpErrors } from './service'
 import { initIocContainer } from '../../'
 import { createTestApp, TestContainer } from '../../tests/app'
 import { IAppConfig, Config } from '../../config/app'
@@ -16,11 +15,18 @@ import * as Pay from '@interledger/pay'
 
 import { createReceiver } from '../../tests/receiver'
 import { mockRatesApi } from '../../tests/rates'
+import { PaymentMethodHandlerError } from '../handler/errors'
+import { OutgoingPayment } from '../../open_payments/payment/outgoing/model'
+import { AccountingService } from '../../accounting/service'
+import { IncomingPayment } from '../../open_payments/payment/incoming/model'
+import { truncateTables } from '../../tests/tableManager'
+import { createOutgoingPaymentWithReceiver } from '../../tests/outgoingPayment'
 
 describe('IlpPaymentService', (): void => {
   let deps: IocContract<AppServices>
   let appContainer: TestContainer
   let ilpPaymentService: IlpPaymentService
+  let accountingService: AccountingService
   let config: IAppConfig
 
   const exchangeRatesUrl = 'https://example-rates.com'
@@ -38,7 +44,10 @@ describe('IlpPaymentService', (): void => {
 
     config = await deps.use('config')
     ilpPaymentService = await deps.use('ilpPaymentService')
+    accountingService = await deps.use('accountingService')
+  })
 
+  beforeEach(async (): Promise<void> => {
     assetMap['USD'] = await createAsset(deps, {
       code: 'USD',
       scale: 2
@@ -59,6 +68,7 @@ describe('IlpPaymentService', (): void => {
   })
 
   afterEach(async (): Promise<void> => {
+    await truncateTables(appContainer.knex)
     jest.restoreAllMocks()
     nock.cleanAll()
   })
@@ -187,8 +197,8 @@ describe('IlpPaymentService', (): void => {
         async () => {
           mockRatesApi(exchangeRatesUrl, () => ({}))
 
-          await expect(
-            ilpPaymentService.getQuote({
+          try {
+            await ilpPaymentService.getQuote({
               paymentPointer: paymentPointerMap['USD'],
               receiver: await createReceiver(deps, paymentPointerMap['USD']),
               debitAmount: {
@@ -197,7 +207,16 @@ describe('IlpPaymentService', (): void => {
                 value: 100n
               }
             })
-          ).rejects.toBe(Pay.PaymentError.InvalidSlippage)
+          } catch (error) {
+            expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+            expect((error as PaymentMethodHandlerError).message).toBe(
+              'Received error during ILP quoting'
+            )
+            expect((error as PaymentMethodHandlerError).description).toBe(
+              Pay.PaymentError.InvalidSlippage
+            )
+            expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+          }
         }
       )())
 
@@ -213,9 +232,18 @@ describe('IlpPaymentService', (): void => {
         maxSourceAmount: -1n
       } as Pay.Quote)
 
-      await expect(ilpPaymentService.getQuote(options)).rejects.toThrow(
-        'Invalid maxSourceAmount in ILP quote'
-      )
+      try {
+        await ilpPaymentService.getQuote(options)
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Received error during ILP quoting'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          'Invalid maxSourceAmount'
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+      }
 
       ratesScope.done()
     })
@@ -239,9 +267,18 @@ describe('IlpPaymentService', (): void => {
         minDeliveryAmount: -1n
       } as Pay.Quote)
 
-      await expect(ilpPaymentService.getQuote(options)).rejects.toThrow(
-        'Invalid minDeliveryAmount in ILP quote'
-      )
+      try {
+        await ilpPaymentService.getQuote(options)
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Received error during ILP quoting'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          'Invalid minDeliveryAmount'
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+      }
 
       ratesScope.done()
     })
@@ -305,65 +342,368 @@ describe('IlpPaymentService', (): void => {
             )()
         )
       })
+
+      describe('with debitAmount', () => {
+        test.each`
+          debitAssetCode | debitAmountValue | incomingAssetCode | expectedReceiveAmount | exchangeRate | slippage | description
+          ${'USD'}       | ${100n}          | ${'USD'}          | ${99n}                | ${1.0}       | ${0}     | ${'same currency, no slippage'}
+          ${'USD'}       | ${100n}          | ${'USD'}          | ${99n}                | ${1.0}       | ${0.01}  | ${'same currency, some slippage'}
+          ${'USD'}       | ${100n}          | ${'EUR'}          | ${89n}                | ${0.9}       | ${0.01}  | ${'cross currency, exchange rate < 1'}
+          ${'USD'}       | ${100n}          | ${'EUR'}          | ${197n}               | ${2.0}       | ${0.01}  | ${'cross currency, exchange rate > 1'}
+        `(
+          '$description',
+          async ({
+            incomingAssetCode,
+            debitAmountValue,
+            debitAssetCode,
+            expectedReceiveAmount,
+            slippage,
+            exchangeRate
+          }): Promise<void> =>
+            withConfigOverride(
+              () => config,
+              { slippage },
+              async () => {
+                const ratesScope = mockRatesApi(exchangeRatesUrl, () => ({
+                  [incomingAssetCode]: exchangeRate
+                }))
+
+                const receivingPaymentPointer =
+                  paymentPointerMap[incomingAssetCode]
+                const sendingPaymentPointer = paymentPointerMap[debitAssetCode]
+
+                const options: StartQuoteOptions = {
+                  paymentPointer: sendingPaymentPointer,
+                  receiver: await createReceiver(deps, receivingPaymentPointer),
+                  debitAmount: {
+                    assetCode: sendingPaymentPointer.asset.code,
+                    assetScale: sendingPaymentPointer.asset.scale,
+                    value: debitAmountValue
+                  }
+                }
+
+                const quote = await ilpPaymentService.getQuote(options)
+
+                expect(quote).toMatchObject({
+                  debitAmount: {
+                    assetCode: sendingPaymentPointer.asset.code,
+                    assetScale: sendingPaymentPointer.asset.scale,
+                    value: debitAmountValue
+                  },
+                  receiveAmount: {
+                    assetCode: receivingPaymentPointer.asset.code,
+                    assetScale: receivingPaymentPointer.asset.scale,
+                    value: expectedReceiveAmount
+                  }
+                })
+                ratesScope.done()
+              }
+            )()
+        )
+      })
+    })
+  })
+
+  describe('pay', (): void => {
+    function mockIlpPay(
+      overrideQuote: Partial<Pay.Quote>,
+      error?: Pay.PaymentError
+    ): jest.SpyInstance<
+      Promise<Pay.PaymentProgress>,
+      [options: Pay.PayOptions]
+    > {
+      return jest
+        .spyOn(Pay, 'pay')
+        .mockImplementationOnce(async (opts: Pay.PayOptions) => {
+          const res = await Pay.pay({
+            ...opts,
+            quote: { ...opts.quote, ...overrideQuote }
+          })
+          if (error) res.error = error
+          return res
+        })
+    }
+
+    async function validateBalances(
+      outgoingPayment: OutgoingPayment,
+      incomingPayment: IncomingPayment,
+      {
+        amountSent,
+        amountReceived
+      }: {
+        amountSent: bigint
+        amountReceived: bigint
+      }
+    ) {
+      await expect(
+        accountingService.getTotalSent(outgoingPayment.id)
+      ).resolves.toBe(amountSent)
+      await expect(
+        accountingService.getTotalReceived(incomingPayment.id)
+      ).resolves.toEqual(amountReceived)
+    }
+
+    test('successfully streams between accounts', async (): Promise<void> => {
+      const { incomingPayment, receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
+            }
+          }
+        })
+
+      await expect(
+        ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 100n,
+          finalReceiveAmount: 100n
+        })
+      ).resolves.toBeUndefined()
+
+      await validateBalances(outgoingPayment, incomingPayment, {
+        amountSent: 100n,
+        amountReceived: 100n
+      })
     })
 
-    describe('with debitAmount', () => {
-      test.each`
-        debitAssetCode | debitAmountValue | incomingAssetCode | expectedReceiveAmount | exchangeRate | slippage | description
-        ${'USD'}       | ${100n}          | ${'USD'}          | ${99n}                | ${1.0}       | ${0}     | ${'same currency, no slippage'}
-        ${'USD'}       | ${100n}          | ${'USD'}          | ${99n}                | ${1.0}       | ${0.01}  | ${'same currency, some slippage'}
-        ${'USD'}       | ${100n}          | ${'EUR'}          | ${89n}                | ${0.9}       | ${0.01}  | ${'cross currency, exchange rate < 1'}
-        ${'USD'}       | ${100n}          | ${'EUR'}          | ${197n}               | ${2.0}       | ${0.01}  | ${'cross currency, exchange rate > 1'}
-      `(
-        '$description',
-        async ({
-          incomingAssetCode,
-          debitAmountValue,
-          debitAssetCode,
-          expectedReceiveAmount,
-          slippage,
-          exchangeRate
-        }): Promise<void> =>
-          withConfigOverride(
-            () => config,
-            { slippage },
-            async () => {
-              const ratesScope = mockRatesApi(exchangeRatesUrl, () => ({
-                [incomingAssetCode]: exchangeRate
-              }))
-
-              const receivingPaymentPointer =
-                paymentPointerMap[incomingAssetCode]
-              const sendingPaymentPointer = paymentPointerMap[debitAssetCode]
-
-              const options: StartQuoteOptions = {
-                paymentPointer: sendingPaymentPointer,
-                receiver: await createReceiver(deps, receivingPaymentPointer),
-                debitAmount: {
-                  assetCode: sendingPaymentPointer.asset.code,
-                  assetScale: sendingPaymentPointer.asset.scale,
-                  value: debitAmountValue
-                }
-              }
-
-              const quote = await ilpPaymentService.getQuote(options)
-
-              expect(quote).toMatchObject({
-                debitAmount: {
-                  assetCode: sendingPaymentPointer.asset.code,
-                  assetScale: sendingPaymentPointer.asset.scale,
-                  value: debitAmountValue
-                },
-                receiveAmount: {
-                  assetCode: receivingPaymentPointer.asset.code,
-                  assetScale: receivingPaymentPointer.asset.scale,
-                  value: expectedReceiveAmount
-                }
-              })
-              ratesScope.done()
+    test('partially streams between accounts, then streams to completion', async (): Promise<void> => {
+      const { incomingPayment, receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            exchangeRate: 1,
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
             }
-          )()
+          }
+        })
+
+      mockIlpPay(
+        { maxSourceAmount: 5n, minDeliveryAmount: 5n },
+        Pay.PaymentError.ClosedByReceiver
       )
+
+      await expect(
+        ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 100n,
+          finalReceiveAmount: 100n
+        })
+      ).rejects.toThrow(PaymentMethodHandlerError)
+
+      await validateBalances(outgoingPayment, incomingPayment, {
+        amountSent: 5n,
+        amountReceived: 5n
+      })
+
+      await expect(
+        ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 100n - 5n,
+          finalReceiveAmount: 100n - 5n
+        })
+      ).resolves.toBeUndefined()
+
+      await validateBalances(outgoingPayment, incomingPayment, {
+        amountSent: 100n,
+        amountReceived: 100n
+      })
+    })
+
+    test('throws if invalid finalDebitAmount', async (): Promise<void> => {
+      const { incomingPayment, receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
+            }
+          }
+        })
+
+      try {
+        await ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 0n,
+          finalReceiveAmount: 50n
+        })
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Could not start ILP streaming'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          'Invalid finalDebitAmount'
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+      }
+
+      await validateBalances(outgoingPayment, incomingPayment, {
+        amountSent: 0n,
+        amountReceived: 0n
+      })
+    })
+
+    test('throws if invalid finalReceiveAmount', async (): Promise<void> => {
+      const { incomingPayment, receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
+            }
+          }
+        })
+
+      try {
+        await ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 50n,
+          finalReceiveAmount: 0n
+        })
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Could not start ILP streaming'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          'Invalid finalReceiveAmount'
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+      }
+
+      await validateBalances(outgoingPayment, incomingPayment, {
+        amountSent: 0n,
+        amountReceived: 0n
+      })
+    })
+
+    test('throws retryable ILP error', async (): Promise<void> => {
+      const { receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
+            }
+          }
+        })
+
+      mockIlpPay({}, Object.keys(retryableIlpErrors)[0] as Pay.PaymentError)
+
+      try {
+        await ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 50n,
+          finalReceiveAmount: 50n
+        })
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Received error during ILP pay'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          Object.keys(retryableIlpErrors)[0]
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(true)
+      }
+    })
+
+    test('throws non-retryable ILP error', async (): Promise<void> => {
+      const { receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
+            }
+          }
+        })
+
+      const nonRetryableIlpError = Object.values(Pay.PaymentError).find(
+        (error) => !retryableIlpErrors[error]
+      )
+
+      mockIlpPay({}, nonRetryableIlpError)
+
+      try {
+        await ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 50n,
+          finalReceiveAmount: 50n
+        })
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Received error during ILP pay'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          nonRetryableIlpError
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+      }
+    })
+
+    test('throws if invalid quote data', async (): Promise<void> => {
+      const { receiver, outgoingPayment } =
+        await createOutgoingPaymentWithReceiver(deps, {
+          sendingPaymentPointer: paymentPointerMap['USD'],
+          receivingPaymentPointer: paymentPointerMap['USD'],
+          quoteOptions: {
+            debitAmount: {
+              value: 100n,
+              assetScale: paymentPointerMap['USD'].asset.scale,
+              assetCode: paymentPointerMap['USD'].asset.code
+            }
+          }
+        })
+
+      outgoingPayment.quote.additionalFields.lowEstimatedExchangeRate = ''
+
+      try {
+        await ilpPaymentService.pay({
+          receiver,
+          outgoingPayment,
+          finalDebitAmount: 50n,
+          finalReceiveAmount: 50n
+        })
+      } catch (error) {
+        expect(error).toBeInstanceOf(PaymentMethodHandlerError)
+        expect((error as PaymentMethodHandlerError).message).toBe(
+          'Error parsing ILP quote'
+        )
+        expect((error as PaymentMethodHandlerError).description).toBe(
+          'Invalid ratio value'
+        )
+        expect((error as PaymentMethodHandlerError).retryable).toBe(false)
+      }
     })
   })
 })

--- a/packages/backend/src/payment-method/ilp/service.ts
+++ b/packages/backend/src/payment-method/ilp/service.ts
@@ -2,13 +2,15 @@ import { BaseService } from '../../shared/baseService'
 import {
   PaymentQuote,
   PaymentMethodService,
-  StartQuoteOptions
+  StartQuoteOptions,
+  PayOptions
 } from '../handler/service'
 import { RatesService } from '../../rates/service'
 import { IlpPlugin, IlpPluginOptions } from './ilp_plugin'
 import * as Pay from '@interledger/pay'
 import { convertRatesToIlpPrices } from './rates'
 import { IAppConfig } from '../../config/app'
+import { PaymentMethodHandlerError } from '../handler/errors'
 
 export interface IlpPaymentService extends PaymentMethodService {}
 
@@ -27,7 +29,8 @@ export async function createIlpPaymentService(
   }
 
   return {
-    getQuote: (quoteOptions) => getQuote(deps, quoteOptions)
+    getQuote: (quoteOptions) => getQuote(deps, quoteOptions),
+    pay: (payOptions) => pay(deps, payOptions)
   }
 }
 
@@ -45,12 +48,13 @@ async function getQuote(
     sourceAccount: options.paymentPointer,
     unfulfillable: true
   })
+  const destination = options.receiver.toResolvedPayment()
 
   try {
     await plugin.connect()
     const quoteOptions: Pay.QuoteOptions = {
       plugin,
-      destination: options.receiver.toResolvedPayment(),
+      destination,
       sourceAsset: {
         scale: options.paymentPointer.asset.scale,
         code: options.paymentPointer.asset.code
@@ -70,31 +74,31 @@ async function getQuote(
         slippage: deps.config.slippage,
         prices: convertRatesToIlpPrices(rates)
       })
-    } finally {
-      await Pay.closeConnection(
-        quoteOptions.plugin,
-        quoteOptions.destination
-      ).catch((err) => {
-        deps.logger.warn(
-          {
-            destination: quoteOptions.destination.destinationAddress,
-            error: err.message
-          },
-          'close quote connection failed'
-        )
+    } catch (error) {
+      const errorMessage = 'Received error during ILP quoting'
+      deps.logger.error({ error }, errorMessage)
+
+      throw new PaymentMethodHandlerError(errorMessage, {
+        description: Pay.isPaymentError(error) ? error : 'Unknown error',
+        retryable: canRetryError(error as Error | Pay.PaymentError)
       })
     }
-
     // Pay.startQuote should return PaymentError.InvalidSourceAmount or
     // PaymentError.InvalidDestinationAmount for non-positive amounts.
     // Outgoing payments' sendAmount or receiveAmount should never be
     // zero or negative.
     if (ilpQuote.maxSourceAmount <= BigInt(0)) {
-      throw new Error('Invalid maxSourceAmount in ILP quote')
+      throw new PaymentMethodHandlerError('Received error during ILP quoting', {
+        description: 'Invalid maxSourceAmount',
+        retryable: false
+      })
     }
 
     if (ilpQuote.minDeliveryAmount <= BigInt(0)) {
-      throw new Error('Invalid minDeliveryAmount in ILP quote')
+      throw new PaymentMethodHandlerError('Received error during ILP quoting', {
+        description: 'Invalid minDeliveryAmount',
+        retryable: false
+      })
     }
 
     return {
@@ -120,6 +124,18 @@ async function getQuote(
     }
   } finally {
     try {
+      await Pay.closeConnection(plugin, destination)
+    } catch (error) {
+      deps.logger.warn(
+        {
+          destination: destination.destinationAddress,
+          error: error instanceof Error && error.message
+        },
+        'close quote connection failed'
+      )
+    }
+
+    try {
       await plugin.disconnect()
     } catch (error) {
       deps.logger.warn(
@@ -128,4 +144,132 @@ async function getQuote(
       )
     }
   }
+}
+
+async function pay(
+  deps: ServiceDependencies,
+  options: PayOptions
+): Promise<void> {
+  const { receiver, outgoingPayment, finalDebitAmount, finalReceiveAmount } =
+    options
+
+  if (finalReceiveAmount <= 0n) {
+    throw new PaymentMethodHandlerError('Could not start ILP streaming', {
+      description: 'Invalid finalReceiveAmount',
+      retryable: false
+    })
+  }
+
+  if (finalDebitAmount <= 0n) {
+    throw new PaymentMethodHandlerError('Could not start ILP streaming', {
+      description: 'Invalid finalDebitAmount',
+      retryable: false
+    })
+  }
+
+  const {
+    lowEstimatedExchangeRate,
+    highEstimatedExchangeRate,
+    minExchangeRate,
+    maxPacketAmount
+  } = outgoingPayment.quote.additionalFields
+
+  const quote: Pay.Quote = {
+    maxPacketAmount: BigInt(maxPacketAmount as bigint),
+    paymentType: Pay.PaymentType.FixedDelivery,
+    maxSourceAmount: finalDebitAmount,
+    minDeliveryAmount: finalReceiveAmount,
+    lowEstimatedExchangeRate: fromJSONtoRatio(lowEstimatedExchangeRate),
+    highEstimatedExchangeRate: fromJSONtoRatio(
+      highEstimatedExchangeRate
+    ) as Pay.PositiveRatio,
+    minExchangeRate: fromJSONtoRatio(minExchangeRate)
+  }
+
+  const plugin = deps.makeIlpPlugin({
+    sourceAccount: outgoingPayment
+  })
+
+  const destination = receiver.toResolvedPayment()
+
+  try {
+    const receipt = await Pay.pay({ plugin, destination, quote })
+
+    deps.logger.debug(
+      {
+        destination: destination.destinationAddress,
+        error: receipt.error,
+        finalDebitAmount,
+        finalReceiveAmount,
+        receiptAmountSent: receipt.amountSent,
+        receiptAmountDelivered: receipt.amountDelivered
+      },
+      'ILP payment completed'
+    )
+
+    if (receipt.error) {
+      throw receipt.error
+    }
+  } catch (error) {
+    const errorMessage = 'Received error during ILP pay'
+    deps.logger.error(
+      { error, destination: destination.destinationAddress },
+      errorMessage
+    )
+
+    throw new PaymentMethodHandlerError(errorMessage, {
+      description: Pay.isPaymentError(error) ? error : 'Unknown error',
+      retryable: canRetryError(error as Error | Pay.PaymentError)
+    })
+  } finally {
+    try {
+      await Pay.closeConnection(plugin, destination)
+    } catch (error) {
+      deps.logger.warn(
+        {
+          destination: destination.destinationAddress,
+          error: error instanceof Error && error.message
+        },
+        'close pay connection failed'
+      )
+    }
+
+    try {
+      await plugin.disconnect()
+    } catch (error) {
+      deps.logger.warn(
+        { error: error instanceof Error && error.message },
+        'error disconnecting plugin'
+      )
+    }
+  }
+}
+
+function fromJSONtoRatio(ratio: unknown): Pay.Ratio {
+  if (Array.isArray(ratio) && ratio.length === 2) {
+    const numerator = Pay.Int.from(ratio[0])
+    const denominator = Pay.Int.from(ratio[1])
+
+    return Pay.Ratio.of(numerator, denominator)
+  }
+
+  throw new PaymentMethodHandlerError('Error parsing ILP quote', {
+    description: 'Invalid ratio value',
+    retryable: false
+  })
+}
+
+export function canRetryError(err: Error | Pay.PaymentError): boolean {
+  return err instanceof Error || !!retryableIlpErrors[err]
+}
+
+export const retryableIlpErrors: {
+  [paymentError in Pay.PaymentError]?: boolean
+} = {
+  [Pay.PaymentError.ConnectorError]: true,
+  [Pay.PaymentError.EstablishmentFailed]: true,
+  [Pay.PaymentError.InsufficientExchangeRate]: true,
+  [Pay.PaymentError.RateProbeFailed]: true,
+  [Pay.PaymentError.IdleTimeout]: true,
+  [Pay.PaymentError.ClosedByReceiver]: true
 }

--- a/packages/backend/src/tests/outgoingPayment.ts
+++ b/packages/backend/src/tests/outgoingPayment.ts
@@ -1,4 +1,5 @@
 import base64url from 'base64url'
+import { v4 as uuid } from 'uuid'
 import { IocContract } from '@adonisjs/fold'
 
 import { createQuote, CreateTestQuoteOptions } from './quote'
@@ -8,19 +9,26 @@ import { isOutgoingPaymentError } from '../open_payments/payment/outgoing/errors
 import { OutgoingPayment } from '../open_payments/payment/outgoing/model'
 import { CreateOutgoingPaymentOptions } from '../open_payments/payment/outgoing/service'
 import { LiquidityAccountType } from '../accounting/service'
+import { PaymentPointer } from '../open_payments/payment_pointer/model'
+import { CreateIncomingPaymentOptions } from '../open_payments/payment/incoming/service'
+import { IncomingPayment } from '../open_payments/payment/incoming/model'
+import { createIncomingPayment } from './incomingPayment'
+
+type CreateTestQuoteAndOutgoingPaymentOptions = Omit<
+  CreateOutgoingPaymentOptions & CreateTestQuoteOptions,
+  'quoteId'
+>
 
 export async function createOutgoingPayment(
   deps: IocContract<AppServices>,
-  options: Omit<
-    CreateOutgoingPaymentOptions & CreateTestQuoteOptions,
-    'quoteId'
-  >
+  options: CreateTestQuoteAndOutgoingPaymentOptions
 ): Promise<OutgoingPayment> {
   const quoteOptions: CreateTestQuoteOptions = {
     paymentPointerId: options.paymentPointerId,
     client: options.client,
     receiver: options.receiver,
-    validDestination: options.validDestination
+    validDestination: options.validDestination,
+    exchangeRate: options.exchangeRate
   }
   if (options.debitAmount) quoteOptions.debitAmount = options.debitAmount
   if (options.receiveAmount) quoteOptions.receiveAmount = options.receiveAmount
@@ -55,4 +63,69 @@ export async function createOutgoingPayment(
   )
 
   return outgoingPaymentOrError
+}
+
+interface CreateOutgoingPaymentWithReceiverArgs {
+  receivingPaymentPointer: PaymentPointer
+  incomingPaymentOptions?: Partial<CreateIncomingPaymentOptions>
+  quoteOptions?: Partial<
+    Pick<
+      CreateTestQuoteAndOutgoingPaymentOptions,
+      'debitAmount' | 'receiveAmount' | 'exchangeRate'
+    >
+  >
+  sendingPaymentPointer: PaymentPointer
+  fundOutgoingPayment?: boolean
+}
+
+interface CreateOutgoingPaymentWithReceiverResponse {
+  incomingPayment: IncomingPayment
+  outgoingPayment: OutgoingPayment
+  receiver: Receiver
+}
+
+export async function createOutgoingPaymentWithReceiver(
+  deps: IocContract<AppServices>,
+  args: CreateOutgoingPaymentWithReceiverArgs
+): Promise<CreateOutgoingPaymentWithReceiverResponse> {
+  const noAmountSet =
+    !args.quoteOptions?.debitAmount &&
+    !args.quoteOptions?.receiveAmount &&
+    !args.incomingPaymentOptions?.incomingAmount
+
+  if (noAmountSet) {
+    throw new Error('No receive or debit amount set')
+  }
+
+  const { fundOutgoingPayment = true } = args
+
+  const incomingPayment = await createIncomingPayment(deps, {
+    ...args.incomingPaymentOptions,
+    paymentPointerId: args.receivingPaymentPointer.id
+  })
+
+  const connectionService = await deps.use('connectionService')
+  const receiver = Receiver.fromIncomingPayment(
+    incomingPayment.toOpenPaymentsType(
+      args.receivingPaymentPointer,
+      connectionService.get(incomingPayment)!
+    )
+  )
+
+  const outgoingPayment = await createOutgoingPayment(deps, {
+    paymentPointerId: args.sendingPaymentPointer.id,
+    receiver: receiver.incomingPayment!.id!,
+    ...args.quoteOptions
+  })
+
+  if (fundOutgoingPayment) {
+    const outgoingPaymentService = await deps.use('outgoingPaymentService')
+    await outgoingPaymentService.fund({
+      id: outgoingPayment.id,
+      amount: outgoingPayment.debitAmount.value,
+      transferId: uuid()
+    })
+  }
+
+  return { incomingPayment, receiver, outgoingPayment }
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
This PR adds `pay` method support to the `ilpPaymentService`. This PR is basically prepping the service to be used during the lifecycle of an Outgoing Payment (stay tuned shortly), to abstract out all of the ILP pay stuff, so the outgoingPayment lifecycle is payment method agnostic:
https://github.com/interledger/rafiki/blob/c16a60fdfa10563998ffc26ea3b669109a98fe15/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts#L91-L131

It also introduces `PaymentMethodHandlerError` error class that will be used to signify details about a thrown error during the `paymentMethodHandler.pay` and  `paymentMethodHandler.startQuote` methods, so the caller can react according, for example, whether it is safe to retry the payment/quote or not.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Progress towards #1967 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
