### PR TITLE
chore: make estimatedExchangeRate nullable (for now)

### DIFF
--- a/packages/backend/migrations/20230927223235_make_quotes_generic.js
+++ b/packages/backend/migrations/20230927223235_make_quotes_generic.js
@@ -5,7 +5,7 @@
 exports.up = function (knex) {
   return knex.schema.alterTable('quotes', (table) => {
     table.json('additionalFields').nullable()
-    table.decimal('estimatedExchangeRate', 20, 10).notNullable()
+    table.decimal('estimatedExchangeRate', 20, 10).nullable()
   })
 }
 

--- a/packages/backend/src/open_payments/quote/model.ts
+++ b/packages/backend/src/open_payments/quote/model.ts
@@ -29,7 +29,7 @@ export class Quote extends PaymentPointerSubresource {
   public asset!: Asset
   public additionalFields!: Record<string, unknown>
 
-  public estimatedExchangeRate!: number
+  public estimatedExchangeRate?: number
   public feeId?: string
   public fee?: Fee
 

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -218,9 +218,10 @@ function calculateQuoteAmountsAfterFees(
   } else {
     // FixedSend
     const fees = quote.fee?.calculate(receiveAmountValue) ?? 0n
-    const exchangeAdjustedFees = BigInt(
-      Number(fees) * quote.estimatedExchangeRate.valueOf()
-    )
+    const estimatedExchangeRate =
+      quote.estimatedExchangeRate || quote.lowEstimatedExchangeRate.valueOf()
+
+    const exchangeAdjustedFees = BigInt(Number(fees) * estimatedExchangeRate)
     receiveAmountValue = BigInt(receiveAmountValue) - exchangeAdjustedFees
 
     if (receiveAmountValue <= exchangeAdjustedFees) {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- There is an issue in the `packages/backend/migrations/20230927223235_make_quotes_generic.js` migration if there is existing data, when trying to create a non-nullable `estimatedExchangeRate`. Fixing to `estimatedExchangeRate` in table to be nullable until https://github.com/interledger/rafiki/issues/2000 is being worked on

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Related to #1967

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
