### PR TITLE
fix(backend): rename paymentPointerId column in combinedPaymentsView to walletAddressId

### DIFF
--- a/packages/backend/migrations/20230918113102_rename_payment_pointer_tables.js
+++ b/packages/backend/migrations/20230918113102_rename_payment_pointer_tables.js
@@ -85,7 +85,10 @@ exports.up = function (knex) {
         // renames payment_pointer.not_found values (if any) to wallet_address.not_found for type key in data json column
         type: knex.raw("REPLACE(type, 'payment_pointer.', 'wallet_address.')")
       })
-      .whereLike('type', 'payment_pointer%')
+      .whereLike('type', 'payment_pointer%'),
+    knex.schema.alterView('combinedPaymentsView', function (view) {
+      view.column('paymentPointerId').rename('walletAddressId')
+    })
   ])
 }
 
@@ -172,6 +175,9 @@ exports.down = function (knex) {
       .update({
         type: knex.raw("REPLACE(type, 'wallet_address.', 'payment_pointer.')")
       })
-      .whereLike('type', 'wallet_address%')
+      .whereLike('type', 'wallet_address%'),
+    knex.schema.alterView('combinedPaymentsView', function (view) {
+      view.column('walletAddressId').rename('paymentPointerId')
+    })
   ])
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Renames a column in `combinedPaymentsView` from `paymentPointerId` to `walletAddressId`.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #2041.
This change was missed when [#1937 feat(backend): rename "payment pointer" tables & columns to use "wallet address"](https://github.com/interledger/rafiki/pull/1937) was merged in.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
