### PR TITLE
feat(auth): fix auth tests for access tokens

### DIFF
--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -93,9 +93,13 @@ describe('Access Token Service', (): void => {
     })
 
     test('Can get an access token by its managementId', async (): Promise<void> => {
+      const retrievedGrant = await Grant.query(trx).findById(grant.id)
       await expect(
         accessTokenService.getByManagementId(accessToken.managementId)
-      ).resolves.toMatchObject(accessToken)
+      ).resolves.toMatchObject({
+        ...accessToken,
+        grant: retrievedGrant
+      })
     })
 
     test('Cannot get an access token that does not exist', async (): Promise<void> => {

--- a/packages/auth/src/signature/middleware.test.ts
+++ b/packages/auth/src/signature/middleware.test.ts
@@ -229,8 +229,10 @@ describe('Signature Service', (): void => {
 
       expect(next).toHaveBeenCalled()
       expect(ctx.response.status).toEqual(200)
-      expect(ctx.accessToken).toMatchObject(token)
-      expect(ctx.accessToken.grant).toEqual(grant)
+      expect(ctx.accessToken).toMatchObject({
+        ...token,
+        grant
+      })
 
       scope.done()
     })


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Expect `Grant` object to be included with `AccessToken` when it is retrieved from the database in tests.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Possibly due to a package update from `objectionjs`, as the `pnpm-lock` file has been updated recently, queries for `AccessToken` from the access token service include the `Grant` model which wasn't accounted for in the tests.  
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
