### PR TITLE
fix: fallback in case estimated exchange rate is missing

### DIFF
--- a/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
@@ -95,7 +95,11 @@ function getAdjustedAmounts(
   // This is only an approximation of the true amount delivered due to exchange rate variance. Due to connection failures there isn't a reliable way to track that in sync with the amount sent (particularly within ILP payments)
   // eslint-disable-next-line no-case-declarations
   const amountDelivered = BigInt(
-    Math.ceil(Number(alreadySentAmount) * payment.quote.estimatedExchangeRate)
+    Math.ceil(
+      Number(alreadySentAmount) *
+        (payment.quote.estimatedExchangeRate ??
+          payment.quote.lowEstimatedExchangeRate.valueOf())
+    )
   )
   let maxReceiveAmount = payment.receiveAmount.value - amountDelivered
 

--- a/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
@@ -97,7 +97,7 @@ function getAdjustedAmounts(
   const amountDelivered = BigInt(
     Math.ceil(
       Number(alreadySentAmount) *
-        (payment.quote.estimatedExchangeRate ??
+        (payment.quote.estimatedExchangeRate ||
           payment.quote.lowEstimatedExchangeRate.valueOf())
     )
   )


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
Fixing
```
pnpm build

> @interledger/rafiki@1.0.0-alpha.3 build /Users/sabine/git/coil/rafiki
> tsc --build

packages/backend/src/open_payments/payment/outgoing/lifecycle.ts:98:43 - error TS18048: 'payment.quote.estimatedExchangeRate' is possibly 'undefined'.

98     Math.ceil(Number(alreadySentAmount) * payment.quote.estimatedExchangeRate)
                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.

 ELIFECYCLE  Command failed with exit code 2.
```

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
