### PR TITLE
Bc/2070/open payments cleanup

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -435,7 +435,7 @@ export function initIocContainer(
         'paymentMethodHandlerService'
       ),
       peerService: await deps.use('peerService'),
-      paymentPointerService: await deps.use('paymentPointerService')
+      walletAddressService: await deps.use('walletAddressService')
     })
   })
   container.singleton('outgoingPaymentRoutes', async (deps) => {

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -284,8 +284,7 @@ describe('OutgoingPaymentService', (): void => {
           client,
           receiver,
           debitAmount,
-          validDestination: false,
-          method: 'ilp'
+          validDestination: false
         }),
       get: (options) => outgoingPaymentService.get(options),
       list: (options) => outgoingPaymentService.getWalletAddressPage(options)
@@ -421,8 +420,7 @@ describe('OutgoingPaymentService', (): void => {
         const { quote } = await createOutgoingPayment(deps, {
           walletAddressId,
           receiver,
-          validDestination: false,
-          method: 'ilp'
+          validDestination: false
         })
         await expect(
           outgoingPaymentService.create({
@@ -685,8 +683,7 @@ describe('OutgoingPaymentService', (): void => {
                 debitAmount: debitAmount ? paymentAmount : undefined,
                 receiveAmount: debitAmount ? undefined : paymentAmount,
                 grant,
-                validDestination: false,
-                method: 'ilp'
+                validDestination: false
               })
               assert.ok(firstPayment)
               if (failed) {
@@ -772,8 +769,7 @@ describe('OutgoingPaymentService', (): void => {
                   receiveAmount: debitAmount ? undefined : paymentAmount,
                   client,
                   grant,
-                  validDestination: false,
-                  method: 'ilp'
+                  validDestination: false
                 })
                 assert.ok(firstPayment)
                 if (failed) {
@@ -963,7 +959,7 @@ describe('OutgoingPaymentService', (): void => {
         OutgoingPaymentState.Failed,
         retryableError.message
       )
-      
+
       expect(payment.stateAttempts).toBe(0)
       await expectOutcome(payment, {
         accountBalance: payment.debitAmount.value - 10n,
@@ -975,124 +971,125 @@ describe('OutgoingPaymentService', (): void => {
     })
 
     test('FAILED (non-retryable error)', async (): Promise<void> => {
-        const createdPayment = await setup({
-          receiver,
-          debitAmount,
-          method: 'ilp'
-        })
-
-        mockPaymentHandlerPay(
-          createdPayment,
-          incomingPayment,
-          new PaymentMethodHandlerError('Failed payment', {
-            description: '',
-            retryable: false
-          })
-        )
-
-        const payment = await processNext(
-          createdPayment.id,
-          OutgoingPaymentState.Failed,
-          'Failed payment'
-        )
-
-        await expectOutcome(payment, {
-          accountBalance: payment.debitAmount.value,
-          amountSent: 0n,
-          amountDelivered: 0n,
-          incomingPaymentReceived: incomingPayment.receivedAmount.value,
-          withdrawAmount: 0n
-        })
+      const createdPayment = await setup({
+        receiver,
+        debitAmount,
+        method: 'ilp'
       })
 
-      test('SENDING→COMPLETED (partial payment, resume, complete)', async (): Promise<void> => {
-        const createdPayment = await setup({
+      mockPaymentHandlerPay(
+        createdPayment,
+        incomingPayment,
+        new PaymentMethodHandlerError('Failed payment', {
+          description: '',
+          retryable: false
+        })
+      )
+
+      const payment = await processNext(
+        createdPayment.id,
+        OutgoingPaymentState.Failed,
+        'Failed payment'
+      )
+
+      await expectOutcome(payment, {
+        accountBalance: payment.debitAmount.value,
+        amountSent: 0n,
+        amountDelivered: 0n,
+        incomingPaymentReceived: incomingPayment.receivedAmount.value,
+        withdrawAmount: 0n
+      })
+    })
+
+    test('SENDING→COMPLETED (partial payment, resume, complete)', async (): Promise<void> => {
+      const createdPayment = await setup({
+        receiver,
+        receiveAmount,
+        method: 'ilp'
+      })
+
+      await makeTransfer({
+        incomingPayment,
+        receiveAmount: 5n,
+        outgoingPayment: createdPayment,
+        debitAmount: 10n
+      })
+
+      mockPaymentHandlerPay(createdPayment, incomingPayment)
+
+      const payment = await processNext(
+        createdPayment.id,
+        OutgoingPaymentState.Completed
+      )
+
+      await expectOutcome(payment, {
+        accountBalance: 0n,
+        amountSent: payment.debitAmount.value,
+        amountDelivered: payment.receiveAmount.value,
+        incomingPaymentReceived: payment.receiveAmount.value
+      })
+    })
+
+    // Caused by retry after failed SENDING→COMPLETED transition commit.
+    test('COMPLETED (already fully paid)', async (): Promise<void> => {
+      const createdPayment = await setup(
+        {
           receiver,
           receiveAmount,
           method: 'ilp'
-        })
+        },
+        receiveAmount
+      )
 
-        await makeTransfer({
-          incomingPayment,
-          receiveAmount: 5n,
-          outgoingPayment: createdPayment,
-          debitAmount: 10n
-        })
+      mockPaymentHandlerPay(createdPayment, incomingPayment)
 
-        mockPaymentHandlerPay(createdPayment, incomingPayment)
+      await processNext(createdPayment.id, OutgoingPaymentState.Completed)
+      // Pretend that the transaction didn't commit.
+      await OutgoingPayment.query(knex)
+        .findById(createdPayment.id)
+        .patch({ state: OutgoingPaymentState.Sending })
 
-        const payment = await processNext(
-          createdPayment.id,
-          OutgoingPaymentState.Completed
-        )
-
-        await expectOutcome(payment, {
-          accountBalance: 0n,
-          amountSent: payment.debitAmount.value,
-          amountDelivered: payment.receiveAmount.value,
-          incomingPaymentReceived: payment.receiveAmount.value
-        })
+      mockPaymentHandlerPay(createdPayment, incomingPayment)
+      const payment = await processNext(
+        createdPayment.id,
+        OutgoingPaymentState.Completed
+      )
+      await expectOutcome(payment, {
+        accountBalance: 0n,
+        amountSent: payment.debitAmount.value,
+        amountDelivered: payment.receiveAmount.value,
+        incomingPaymentReceived: payment.receiveAmount.value
       })
+    })
 
-      // Caused by retry after failed SENDING→COMPLETED transition commit.
-      test('COMPLETED (already fully paid)', async (): Promise<void> => {
-        const createdPayment = await setup(
-          {
-            receiver,
-            receiveAmount,
-            method: 'ilp'
-          },
-          receiveAmount
-        )
+    test('COMPLETED (already fully paid)', async (): Promise<void> => {
+      const { id: paymentId } = await setup(
+        {
+          receiver,
+          receiveAmount,
+          method: 'ilp'
+        },
+        receiveAmount
+      )
+      // The quote thinks there's a full amount to pay, but actually sending will find the incoming payment has been paid (e.g. by another payment).
+      await payIncomingPayment(receiveAmount.value)
 
-        mockPaymentHandlerPay(createdPayment, incomingPayment)
-
-        await processNext(createdPayment.id, OutgoingPaymentState.Completed)
-        // Pretend that the transaction didn't commit.
-        await OutgoingPayment.query(knex)
-          .findById(createdPayment.id)
-          .patch({ state: OutgoingPaymentState.Sending })
-
-        mockPaymentHandlerPay(createdPayment, incomingPayment)
-        const payment = await processNext(
-          createdPayment.id,
-          OutgoingPaymentState.Completed
-        )
-        await expectOutcome(payment, {
-          accountBalance: 0n,
-          amountSent: payment.debitAmount.value,
-          amountDelivered: payment.receiveAmount.value,
-          incomingPaymentReceived: payment.receiveAmount.value
-        })
+      const payment = await processNext(
+        paymentId,
+        OutgoingPaymentState.Completed
+      )
+      await expectOutcome(payment, {
+        accountBalance: payment.debitAmount.value,
+        amountSent: BigInt(0),
+        amountDelivered: BigInt(0),
+        incomingPaymentReceived: receiveAmount.value,
+        withdrawAmount: payment.debitAmount.value
       })
+    })
 
-      test('COMPLETED (already fully paid)', async (): Promise<void> => {
-        const { id: paymentId } = await setup(
-          {
-            receiver,
-            receiveAmount,
-            method: 'ilp'
-          },
-          receiveAmount
-        )
-        // The quote thinks there's a full amount to pay, but actually sending will find the incoming payment has been paid (e.g. by another payment).
-        await payIncomingPayment(receiveAmount.value)
-
-        const payment = await processNext(
-          paymentId,
-          OutgoingPaymentState.Completed
-        )
-        await expectOutcome(payment, {
-          accountBalance: payment.debitAmount.value,
-          amountSent: BigInt(0),
-          amountDelivered: BigInt(0),
-          incomingPaymentReceived: receiveAmount.value,
-          withdrawAmount: payment.debitAmount.value
-        })
-      })
-
-      test('FAILED (source asset changed)', async (): Promise<void> => {
-        const { id: paymentId } = await setup({
+    test('FAILED (source asset changed)', async (): Promise<void> => {
+      const { id: paymentId } = await setup(
+        {
           receiver,
           receiveAmount,
           method: 'ilp'
@@ -1150,8 +1147,7 @@ describe('OutgoingPaymentService', (): void => {
         walletAddressId,
         receiver,
         debitAmount,
-        validDestination: false,
-        method: 'ilp'
+        validDestination: false
       })
       quoteAmount = payment.debitAmount.value
       await expectOutcome(payment, { accountBalance: BigInt(0) })

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -29,10 +29,6 @@ import {
   WalletAddressService,
   WalletAddressSubresourceService
 } from '../../wallet_address/service'
-import {
-  IlpPlugin,
-  IlpPluginOptions
-} from '../../../payment-method/ilp/ilp_plugin'
 import { sendWebhookEvent } from './lifecycle'
 import * as worker from './worker'
 import { Interval } from 'luxon'
@@ -56,7 +52,7 @@ export interface ServiceDependencies extends BaseService {
   accountingService: AccountingService
   receiverService: ReceiverService
   peerService: PeerService
-  makeIlpPlugin: (options: IlpPluginOptions) => IlpPlugin
+  paymentMethodHandlerService: PaymentMethodHandlerService
   walletAddressService: WalletAddressService
 }
 

--- a/packages/backend/src/payment-method/handler/service.test.ts
+++ b/packages/backend/src/payment-method/handler/service.test.ts
@@ -69,17 +69,17 @@ describe('PaymentMethodHandlerService', (): void => {
   describe('pay', (): void => {
     test('calls ilpPaymentService for ILP payment type', async (): Promise<void> => {
       const asset = await createAsset(deps)
-      const paymentPointer = await createPaymentPointer(deps, {
+      const walletAddress = await createWalletAddress(deps, {
         assetId: asset.id
       })
       const { receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
-          sendingPaymentPointer: paymentPointer,
-          receivingPaymentPointer: paymentPointer,
+          sendingWalletAddress: walletAddress,
+          receivingWalletAddress: walletAddress,
           quoteOptions: {
             debitAmount: {
-              assetCode: paymentPointer.asset.code,
-              assetScale: paymentPointer.asset.scale,
+              assetCode: walletAddress.asset.code,
+              assetScale: walletAddress.asset.scale,
               value: 100n
             }
           }

--- a/packages/backend/src/payment-method/ilp/service.test.ts
+++ b/packages/backend/src/payment-method/ilp/service.test.ts
@@ -368,13 +368,13 @@ describe('IlpPaymentService', (): void => {
                   [incomingAssetCode]: exchangeRate
                 }))
 
-                const receivingPaymentPointer =
+                const receivingWalletAddress =
                   walletAddressMap[incomingAssetCode]
                 const sendingWalletAddress = walletAddressMap[debitAssetCode]
 
                 const options: StartQuoteOptions = {
                   walletAddress: sendingWalletAddress,
-                  receiver: await createReceiver(deps, receivingPaymentPointer),
+                  receiver: await createReceiver(deps, receivingWalletAddress),
                   debitAmount: {
                     assetCode: sendingWalletAddress.asset.code,
                     assetScale: sendingWalletAddress.asset.scale,
@@ -391,8 +391,8 @@ describe('IlpPaymentService', (): void => {
                     value: debitAmountValue
                   },
                   receiveAmount: {
-                    assetCode: receivingPaymentPointer.asset.code,
-                    assetScale: receivingPaymentPointer.asset.scale,
+                    assetCode: receivingWalletAddress.asset.code,
+                    assetScale: receivingWalletAddress.asset.scale,
                     value: expectedReceiveAmount
                   }
                 })
@@ -447,7 +447,7 @@ describe('IlpPaymentService', (): void => {
       const { incomingPayment, receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             debitAmount: {
               value: 100n,
@@ -476,7 +476,7 @@ describe('IlpPaymentService', (): void => {
       const { incomingPayment, receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             exchangeRate: 1,
             debitAmount: {
@@ -525,7 +525,7 @@ describe('IlpPaymentService', (): void => {
       const { incomingPayment, receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             debitAmount: {
               value: 100n,
@@ -563,7 +563,7 @@ describe('IlpPaymentService', (): void => {
       const { incomingPayment, receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             debitAmount: {
               value: 100n,
@@ -601,7 +601,7 @@ describe('IlpPaymentService', (): void => {
       const { receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             debitAmount: {
               value: 100n,
@@ -636,7 +636,7 @@ describe('IlpPaymentService', (): void => {
       const { receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             debitAmount: {
               value: 100n,
@@ -675,7 +675,7 @@ describe('IlpPaymentService', (): void => {
       const { receiver, outgoingPayment } =
         await createOutgoingPaymentWithReceiver(deps, {
           sendingWalletAddress: walletAddressMap['USD'],
-          receivingPaymentPointer: walletAddressMap['USD'],
+          receivingWalletAddress: walletAddressMap['USD'],
           quoteOptions: {
             debitAmount: {
               value: 100n,

--- a/packages/backend/src/tests/outgoingPayment.ts
+++ b/packages/backend/src/tests/outgoingPayment.ts
@@ -44,6 +44,7 @@ export async function createOutgoingPayment(
     const incomingPayment = await createIncomingPayment(deps, {
       walletAddressId: options.walletAddressId
     })
+    await incomingPayment.$query().delete()
     const walletAddress = await walletAddressService.get(
       options.walletAddressId
     )

--- a/packages/backend/src/tests/outgoingPayment.ts
+++ b/packages/backend/src/tests/outgoingPayment.ts
@@ -13,6 +13,7 @@ import { CreateIncomingPaymentOptions } from '../open_payments/payment/incoming/
 import { IncomingPayment } from '../open_payments/payment/incoming/model'
 import { createIncomingPayment } from './incomingPayment'
 import assert from 'assert'
+import { IlpAddress } from 'ilp-packet'
 
 type CreateTestQuoteAndOutgoingPaymentOptions = Omit<
   CreateOutgoingPaymentOptions & CreateTestQuoteOptions,
@@ -116,12 +117,11 @@ export async function createOutgoingPaymentWithReceiver(
     walletAddressId: args.receivingWalletAddress.id
   })
 
-  const connectionService = await deps.use('connectionService')
   const receiver = new Receiver(
-    incomingPayment.toOpenPaymentsType(
-      args.receivingWalletAddress,
-      connectionService.get(incomingPayment)!
-    )
+    incomingPayment.toOpenPaymentsTypeWithMethods(args.receivingWalletAddress, {
+      ilpAddress: 'test.ilp' as IlpAddress,
+      sharedSecret: Buffer.from('')
+    })
   )
 
   const outgoingPayment = await createOutgoingPayment(deps, {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- some merge cleanup (renaming payment pointer to wallet address, updating service dependency)
- fixes combined payment tests. the combined payments are a view of both incoming and outgoing payments and the new `createOutgoingPayment` test util function creates an incoming payment (after removing connections). This side effect caused the pagination and some other tests to fail which didn't expect this additional payment.
## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #2081 
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
