### PR TITLE
fix(backend): combined_payment, ilp service tests

### DIFF
--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -963,7 +963,7 @@ describe('OutgoingPaymentService', (): void => {
         OutgoingPaymentState.Failed,
         retryableError.message
       )
-      
+
       expect(payment.stateAttempts).toBe(0)
       await expectOutcome(payment, {
         accountBalance: payment.debitAmount.value - 10n,
@@ -975,124 +975,125 @@ describe('OutgoingPaymentService', (): void => {
     })
 
     test('FAILED (non-retryable error)', async (): Promise<void> => {
-        const createdPayment = await setup({
-          receiver,
-          debitAmount,
-          method: 'ilp'
-        })
-
-        mockPaymentHandlerPay(
-          createdPayment,
-          incomingPayment,
-          new PaymentMethodHandlerError('Failed payment', {
-            description: '',
-            retryable: false
-          })
-        )
-
-        const payment = await processNext(
-          createdPayment.id,
-          OutgoingPaymentState.Failed,
-          'Failed payment'
-        )
-
-        await expectOutcome(payment, {
-          accountBalance: payment.debitAmount.value,
-          amountSent: 0n,
-          amountDelivered: 0n,
-          incomingPaymentReceived: incomingPayment.receivedAmount.value,
-          withdrawAmount: 0n
-        })
+      const createdPayment = await setup({
+        receiver,
+        debitAmount,
+        method: 'ilp'
       })
 
-      test('SENDING→COMPLETED (partial payment, resume, complete)', async (): Promise<void> => {
-        const createdPayment = await setup({
+      mockPaymentHandlerPay(
+        createdPayment,
+        incomingPayment,
+        new PaymentMethodHandlerError('Failed payment', {
+          description: '',
+          retryable: false
+        })
+      )
+
+      const payment = await processNext(
+        createdPayment.id,
+        OutgoingPaymentState.Failed,
+        'Failed payment'
+      )
+
+      await expectOutcome(payment, {
+        accountBalance: payment.debitAmount.value,
+        amountSent: 0n,
+        amountDelivered: 0n,
+        incomingPaymentReceived: incomingPayment.receivedAmount.value,
+        withdrawAmount: 0n
+      })
+    })
+
+    test('SENDING→COMPLETED (partial payment, resume, complete)', async (): Promise<void> => {
+      const createdPayment = await setup({
+        receiver,
+        receiveAmount,
+        method: 'ilp'
+      })
+
+      await makeTransfer({
+        incomingPayment,
+        receiveAmount: 5n,
+        outgoingPayment: createdPayment,
+        debitAmount: 10n
+      })
+
+      mockPaymentHandlerPay(createdPayment, incomingPayment)
+
+      const payment = await processNext(
+        createdPayment.id,
+        OutgoingPaymentState.Completed
+      )
+
+      await expectOutcome(payment, {
+        accountBalance: 0n,
+        amountSent: payment.debitAmount.value,
+        amountDelivered: payment.receiveAmount.value,
+        incomingPaymentReceived: payment.receiveAmount.value
+      })
+    })
+
+    // Caused by retry after failed SENDING→COMPLETED transition commit.
+    test('COMPLETED (already fully paid)', async (): Promise<void> => {
+      const createdPayment = await setup(
+        {
           receiver,
           receiveAmount,
           method: 'ilp'
-        })
+        },
+        receiveAmount
+      )
 
-        await makeTransfer({
-          incomingPayment,
-          receiveAmount: 5n,
-          outgoingPayment: createdPayment,
-          debitAmount: 10n
-        })
+      mockPaymentHandlerPay(createdPayment, incomingPayment)
 
-        mockPaymentHandlerPay(createdPayment, incomingPayment)
+      await processNext(createdPayment.id, OutgoingPaymentState.Completed)
+      // Pretend that the transaction didn't commit.
+      await OutgoingPayment.query(knex)
+        .findById(createdPayment.id)
+        .patch({ state: OutgoingPaymentState.Sending })
 
-        const payment = await processNext(
-          createdPayment.id,
-          OutgoingPaymentState.Completed
-        )
-
-        await expectOutcome(payment, {
-          accountBalance: 0n,
-          amountSent: payment.debitAmount.value,
-          amountDelivered: payment.receiveAmount.value,
-          incomingPaymentReceived: payment.receiveAmount.value
-        })
+      mockPaymentHandlerPay(createdPayment, incomingPayment)
+      const payment = await processNext(
+        createdPayment.id,
+        OutgoingPaymentState.Completed
+      )
+      await expectOutcome(payment, {
+        accountBalance: 0n,
+        amountSent: payment.debitAmount.value,
+        amountDelivered: payment.receiveAmount.value,
+        incomingPaymentReceived: payment.receiveAmount.value
       })
+    })
 
-      // Caused by retry after failed SENDING→COMPLETED transition commit.
-      test('COMPLETED (already fully paid)', async (): Promise<void> => {
-        const createdPayment = await setup(
-          {
-            receiver,
-            receiveAmount,
-            method: 'ilp'
-          },
-          receiveAmount
-        )
+    test('COMPLETED (already fully paid)', async (): Promise<void> => {
+      const { id: paymentId } = await setup(
+        {
+          receiver,
+          receiveAmount,
+          method: 'ilp'
+        },
+        receiveAmount
+      )
+      // The quote thinks there's a full amount to pay, but actually sending will find the incoming payment has been paid (e.g. by another payment).
+      await payIncomingPayment(receiveAmount.value)
 
-        mockPaymentHandlerPay(createdPayment, incomingPayment)
-
-        await processNext(createdPayment.id, OutgoingPaymentState.Completed)
-        // Pretend that the transaction didn't commit.
-        await OutgoingPayment.query(knex)
-          .findById(createdPayment.id)
-          .patch({ state: OutgoingPaymentState.Sending })
-
-        mockPaymentHandlerPay(createdPayment, incomingPayment)
-        const payment = await processNext(
-          createdPayment.id,
-          OutgoingPaymentState.Completed
-        )
-        await expectOutcome(payment, {
-          accountBalance: 0n,
-          amountSent: payment.debitAmount.value,
-          amountDelivered: payment.receiveAmount.value,
-          incomingPaymentReceived: payment.receiveAmount.value
-        })
+      const payment = await processNext(
+        paymentId,
+        OutgoingPaymentState.Completed
+      )
+      await expectOutcome(payment, {
+        accountBalance: payment.debitAmount.value,
+        amountSent: BigInt(0),
+        amountDelivered: BigInt(0),
+        incomingPaymentReceived: receiveAmount.value,
+        withdrawAmount: payment.debitAmount.value
       })
+    })
 
-      test('COMPLETED (already fully paid)', async (): Promise<void> => {
-        const { id: paymentId } = await setup(
-          {
-            receiver,
-            receiveAmount,
-            method: 'ilp'
-          },
-          receiveAmount
-        )
-        // The quote thinks there's a full amount to pay, but actually sending will find the incoming payment has been paid (e.g. by another payment).
-        await payIncomingPayment(receiveAmount.value)
-
-        const payment = await processNext(
-          paymentId,
-          OutgoingPaymentState.Completed
-        )
-        await expectOutcome(payment, {
-          accountBalance: payment.debitAmount.value,
-          amountSent: BigInt(0),
-          amountDelivered: BigInt(0),
-          incomingPaymentReceived: receiveAmount.value,
-          withdrawAmount: payment.debitAmount.value
-        })
-      })
-
-      test('FAILED (source asset changed)', async (): Promise<void> => {
-        const { id: paymentId } = await setup({
+    test('FAILED (source asset changed)', async (): Promise<void> => {
+      const { id: paymentId } = await setup(
+        {
           receiver,
           receiveAmount,
           method: 'ilp'

--- a/packages/backend/src/tests/outgoingPayment.ts
+++ b/packages/backend/src/tests/outgoingPayment.ts
@@ -44,6 +44,7 @@ export async function createOutgoingPayment(
     const incomingPayment = await createIncomingPayment(deps, {
       walletAddressId: options.walletAddressId
     })
+    await incomingPayment.$query().delete()
     const walletAddress = await walletAddressService.get(
       options.walletAddressId
     )
@@ -78,7 +79,7 @@ export async function createOutgoingPayment(
 
 interface CreateOutgoingPaymentWithReceiverArgs {
   receivingWalletAddress: WalletAddress
-  method: 'ilp',
+  method: 'ilp'
   incomingPaymentOptions?: Partial<CreateIncomingPaymentOptions>
   quoteOptions?: Partial<
     Pick<
@@ -116,8 +117,8 @@ export async function createOutgoingPaymentWithReceiver(
     walletAddressId: args.receivingWalletAddress.id
   })
 
-  const streamServer = await deps.use('streamServer')
-  const streamCredentials = streamServer.generateCredentials()
+  const streamCredentialsService = await deps.use('streamCredentialsService')
+  const streamCredentials = await streamCredentialsService.get(incomingPayment)
 
   const receiver = new Receiver(
     incomingPayment.toOpenPaymentsTypeWithMethods(


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- fixes combined payment tests. the combined payments are a view of both incoming and outgoing payments and the new createOutgoingPayment test util function now creates an incoming payment too (after removing connections). This side effect caused the pagination and some other tests to fail which didn’t expect this additional payment.
- fix how we are generating stream credentials in `createOutgoingPaymentWithReceiver`

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #2081 
- progress towards #2074 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
