### PR TITLE
fix: fetch walletAddress graph in quote and outgoing payment service

### DIFF
--- a/packages/backend/src/open_payments/payment/incoming/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.test.ts
@@ -80,7 +80,6 @@ describe('Incoming Payment Routes', (): void => {
   })
 
   describe('get/list', (): void => {
-    console.log('incoming get/list walletAddress=', walletAddress)
     getRouteTests({
       getWalletAddress: async () => walletAddress,
       createModel: async ({ client }) =>

--- a/packages/backend/src/open_payments/payment/incoming/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.test.ts
@@ -80,6 +80,7 @@ describe('Incoming Payment Routes', (): void => {
   })
 
   describe('get/list', (): void => {
+    console.log('incoming get/list walletAddress=', walletAddress)
     getRouteTests({
       getWalletAddress: async () => walletAddress,
       createModel: async ({ client }) =>

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -362,8 +362,7 @@ describe('OutgoingPaymentService', (): void => {
               receiveAmount: quote.receiveAmount,
               metadata: options.metadata,
               state: OutgoingPaymentState.Funding,
-              asset,
-              quote,
+              asset: quote.asset,
               peerId: outgoingPeer ? peer.id : null
             })
 

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -79,7 +79,7 @@ async function getOutgoingPayment(
 ): Promise<OutgoingPayment | undefined> {
   const outgoingPayment = await OutgoingPayment.query(deps.knex)
     .get(options)
-    .withGraphFetched('quote.asset')
+    .withGraphFetched('[quote.asset, walletAddress]')
   if (outgoingPayment) return await addSentAmount(deps, outgoingPayment)
   else return
 }
@@ -127,7 +127,7 @@ async function createOutgoingPayment(
           client: options.client,
           grantId
         })
-        .withGraphFetched('[quote.asset]')
+        .withGraphFetched('[quote.asset, walletAddress]')
 
       if (
         payment.walletAddressId !== payment.quote.walletAddressId ||
@@ -401,7 +401,7 @@ async function getWalletAddressPage(
 ): Promise<OutgoingPayment[]> {
   const page = await OutgoingPayment.query(deps.knex)
     .list(options)
-    .withGraphFetched('quote.asset')
+    .withGraphFetched('[quote.asset, walletAddress]')
   const amounts = await deps.accountingService.getAccountsTotalSent(
     page.map((payment: OutgoingPayment) => payment.id)
   )

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -50,7 +50,9 @@ async function getQuote(
   deps: ServiceDependencies,
   options: GetOptions
 ): Promise<Quote | undefined> {
-  return Quote.query(deps.knex).get(options).withGraphFetched('[asset, fee]')
+  return Quote.query(deps.knex)
+    .get(options)
+    .withGraphFetched('[asset, fee, walletAddress]')
 }
 
 interface QuoteOptionsBase {
@@ -144,7 +146,7 @@ async function createQuote(
           estimatedExchangeRate: quote.estimatedExchangeRate,
           additionalFields: quote.additionalFields
         })
-        .withGraphFetched('[asset, fee]')
+        .withGraphFetched('[asset, fee, walletAddress]')
 
       return await finalizeQuote(
         {
@@ -300,5 +302,5 @@ async function getWalletAddressPage(
 ): Promise<Quote[]> {
   return await Quote.query(deps.knex)
     .list(options)
-    .withGraphFetched('[asset, fee]')
+    .withGraphFetched('[asset, fee, walletAddress]')
 }

--- a/packages/backend/src/open_payments/wallet_address/model.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/model.test.ts
@@ -208,14 +208,6 @@ export const getRouteTests = <M extends WalletAddressSubresource>({
     expectedMatch?: M
   ) => {
     const walletAddress = await getWalletAddress()
-    if (urlPath === '/quotes') {
-      console.log(
-        'getRouteTests walletaddress=',
-        walletAddress,
-        'urlPath=',
-        urlPath
-      )
-    }
     walletAddress.id = walletAddressId
     const ctx = setup<ListContext>({
       reqOpts: {
@@ -249,7 +241,6 @@ export const getRouteTests = <M extends WalletAddressSubresource>({
     testGet: async ({ id, walletAddressId, client }, expectedMatch) => {
       const walletAddress = await getWalletAddress()
       walletAddress.id = walletAddressId
-      // console.log('walletAddress=', walletAddress || 'no wallet address')
       const ctx = setup<ReadContext>({
         reqOpts: {
           headers: { Accept: 'application/json' },
@@ -263,7 +254,6 @@ export const getRouteTests = <M extends WalletAddressSubresource>({
         client,
         accessAction: client ? AccessAction.Read : AccessAction.ReadAll
       })
-      // console.log('ctx=', ctx)
       if (expectedMatch) {
         await expect(get(ctx)).resolves.toBeUndefined()
         expect(ctx.response).toSatisfyApiSpec()

--- a/packages/backend/src/open_payments/wallet_address/model.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/model.test.ts
@@ -111,58 +111,37 @@ const baseGetTests = <M extends WalletAddressSubresource>({
             match    | description
             ${match} | ${GetOption.Matching}
             ${false} | ${GetOption.Conflicting}
-            ${match} | ${GetOption.Unspecified}
-          `('$description walletAddressId', ({ match, description }): void => {
-            let walletAddressId: string
+          `('$description id', ({ match, description }): void => {
+            let id: string
             beforeEach((): void => {
-              switch (description) {
-                case GetOption.Matching:
-                  walletAddressId = model.walletAddressId
-                  break
-                case GetOption.Conflicting:
-                  walletAddressId = uuid()
-                  break
-                case GetOption.Unspecified:
-                  walletAddressId = ''
-                  break
-              }
+              id = description === GetOption.Matching ? model.id : uuid()
             })
-            describe.each`
-              match    | description
-              ${match} | ${GetOption.Matching}
-              ${false} | ${GetOption.Conflicting}
-            `('$description id', ({ match, description }): void => {
-              let id: string
-              beforeEach((): void => {
-                id = description === GetOption.Matching ? model.id : uuid()
-              })
 
-              test(`${
-                match ? '' : 'cannot '
-              }get a model`, async (): Promise<void> => {
-                await testGet(
-                  {
-                    id,
-                    client,
-                    walletAddressId
-                  },
-                  match ? model : undefined
-                )
-              })
-            })
             test(`${
               match ? '' : 'cannot '
-            }list model`, async (): Promise<void> => {
-              if (testList && walletAddressId) {
-                await testList(
-                  {
-                    walletAddressId,
-                    client
-                  },
-                  match ? model : undefined
-                )
-              }
+            }get a model`, async (): Promise<void> => {
+              await testGet(
+                {
+                  id,
+                  client,
+                  walletAddressId: model.walletAddressId
+                },
+                match ? model : undefined
+              )
             })
+          })
+          test(`${
+            match ? '' : 'cannot '
+          }list model`, async (): Promise<void> => {
+            if (testList && model.walletAddressId) {
+              await testList(
+                {
+                  walletAddressId: model.walletAddressId,
+                  client
+                },
+                match ? model : undefined
+              )
+            }
           })
         }
       })
@@ -229,6 +208,14 @@ export const getRouteTests = <M extends WalletAddressSubresource>({
     expectedMatch?: M
   ) => {
     const walletAddress = await getWalletAddress()
+    if (urlPath === '/quotes') {
+      console.log(
+        'getRouteTests walletaddress=',
+        walletAddress,
+        'urlPath=',
+        urlPath
+      )
+    }
     walletAddress.id = walletAddressId
     const ctx = setup<ListContext>({
       reqOpts: {
@@ -262,6 +249,7 @@ export const getRouteTests = <M extends WalletAddressSubresource>({
     testGet: async ({ id, walletAddressId, client }, expectedMatch) => {
       const walletAddress = await getWalletAddress()
       walletAddress.id = walletAddressId
+      // console.log('walletAddress=', walletAddress || 'no wallet address')
       const ctx = setup<ReadContext>({
         reqOpts: {
           headers: { Accept: 'application/json' },
@@ -275,6 +263,7 @@ export const getRouteTests = <M extends WalletAddressSubresource>({
         client,
         accessAction: client ? AccessAction.Read : AccessAction.ReadAll
       })
+      // console.log('ctx=', ctx)
       if (expectedMatch) {
         await expect(get(ctx)).resolves.toBeUndefined()
         expect(ctx.response).toSatisfyApiSpec()

--- a/packages/backend/src/tests/quote.ts
+++ b/packages/backend/src/tests/quote.ts
@@ -158,7 +158,7 @@ export async function createQuote(
     }
   }
 
-  const withGraphFetchedArray = ['asset']
+  const withGraphFetchedArray = ['asset', 'walletAddress']
   if (withFee) {
     withGraphFetchedArray.push('fee')
   }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Fetches the `walletAddress` graph when creating or reading Quotes or Outgoing Payments.
- Fixes some tests in the Outgoing Payments and Quotes services/routes.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Makes progress on #2074.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
