### PR TITLE
fix(backend): fix create remote incoming payment

### DIFF
--- a/packages/backend/src/open_payments/payment/incoming_remote/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming_remote/service.test.ts
@@ -55,7 +55,7 @@ describe('Remote Incoming Payment Service', (): void => {
       assetCode: 'USD',
       assetScale: 2
     }
-    const walletAddress = mockWalletAddress()
+    const walletAddress = mockWalletAddress({ id: 'https://example.com' })
     const grantOptions = {
       accessType: AccessType.IncomingPayment,
       accessActions: [AccessAction.Create, AccessAction.ReadAll],

--- a/packages/backend/src/open_payments/payment/incoming_remote/service.ts
+++ b/packages/backend/src/open_payments/payment/incoming_remote/service.ts
@@ -68,9 +68,10 @@ async function create(
   }
 
   try {
+    const url = new URL(walletAddressUrl)
     return await deps.openPaymentsClient.incomingPayment.create(
       {
-        url: walletAddressUrl,
+        url: url.origin,
         accessToken: grantOrError.accessToken
       },
       {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Updates the remote incoming payment service's call to the Open Payments client to use the domain of the wallet URL it receives, rather than the full wallet address.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #2117.

When creating a remote receiver, Rafiki would try to send the full wallet address into a call of `openPaymentsClient.incomingPayment.create`. Because of the way the spec has changed however, meant that we were sending requests to `http://domain/walletaddress/incoming-payments` when it should have been to `http://domain/incoming-payments`.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
