### PR TITLE
Change timeout to ms in balance.ts and transfers.ts

### DIFF
--- a/packages/backend/src/accounting/tigerbeetle/transfers.ts
+++ b/packages/backend/src/accounting/tigerbeetle/transfers.ts
@@ -23,7 +23,7 @@ export interface NewTransferOptions {
   destinationAccountId: AccountId
   amount: bigint
   ledger: number
-  timeout?: bigint
+  timeoutMs?: bigint
   postId?: never
   voidId?: never
 }
@@ -65,7 +65,7 @@ export async function createTransfers(
       user_data: 0n,
       reserved: 0n,
       pending_id: 0n,
-      timeout: 0n,
+      timeoutMs: 0n,
       ledger: 0,
       code: ACCOUNT_TYPE,
       flags: 0,
@@ -83,9 +83,9 @@ export async function createTransfers(
       tbTransfer.credit_account_id = toTigerbeetleId(
         transfer.destinationAccountId
       )
-      if (transfer.timeout) {
+      if (transfer.timeoutMs) {
         tbTransfer.flags |= TransferFlags.pending
-        tbTransfer.timeout = transfer.timeout * BigInt(10e6) // ms -> ns
+        tbTransfer.timeoutMs = transfer.timeoutMs * BigInt(10e6) // ms -> ns
       }
     } else {
       tbTransfer.id = toTigerbeetleId(uuid())

--- a/packages/backend/src/connector/core/middleware/balance.ts
+++ b/packages/backend/src/connector/core/middleware/balance.ts
@@ -53,7 +53,7 @@ export function createBalanceMiddleware(): ILPMiddleware {
         destinationAccount: accounts.outgoing,
         sourceAmount,
         destinationAmount: destinationAmountOrError,
-        timeout: BigInt(5e9) // 5 seconds
+        timeoutMs: BigInt(5e3) // 5 seconds in milliseconds
       })
 
       if (isTransferError(trxOrError)) {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Timeout parameters should be named with the units associated with their particular context because we will be coverting them. In general timeouts are typically milliseconds but TigerBeetle uses nanoseconds. As we are using both of them, so the same name (e.g. timeout) it is creating an ambiguity.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- This fix allows us to convert the seconds into milliseconds instead of nanoseconds as the Tigerbeetle service method was actually expecting milliseconds to be converted into nanoseconds.

Fixes #1112 


## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
