### PR TITLE
fix(backend): prevent palindromic asset codes from causing test failure

### DIFF
--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -125,14 +125,9 @@ describe('Incoming Payment Service', (): void => {
           incomingAmount: {
             value: BigInt(123),
             assetCode: String.fromCharCode(
-              ...asset.code.split('').map((letter) => {
-                let charCode = letter.charCodeAt(0)
-                if (charCode < 91) {
-                  return --charCode
-                } else {
-                  return ++charCode
-                }
-              })
+              ...asset.code
+                .split('')
+                .map((letter) => ((letter.charCodeAt(0) + 1 - 65) % 26) + 65)
             ),
             assetScale: asset.scale
           },

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -127,7 +127,7 @@ describe('Incoming Payment Service', (): void => {
             assetCode: String.fromCharCode(
               ...asset.code.split('').map((letter) => {
                 let charCode = letter.charCodeAt(0)
-                if (charCode === 91) {
+                if (charCode < 91) {
                   return --charCode
                 } else {
                   return ++charCode

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -124,7 +124,16 @@ describe('Incoming Payment Service', (): void => {
           walletAddressId,
           incomingAmount: {
             value: BigInt(123),
-            assetCode: asset.code.split('').reverse().join(''),
+            assetCode: String.fromCharCode(
+              ...asset.code.split('').map((letter) => {
+                let charCode = letter.charCodeAt(0)
+                if (charCode === 91) {
+                  return --charCode
+                } else {
+                  return ++charCode
+                }
+              })
+            ),
             assetScale: asset.scale
           },
           expiresAt: new Date(Date.now() + 30_000),


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Updates the `Cannot create incoming payment with different asset details than underlying wallet address` test to shift the character codes of an asset code by one rather than reversing it.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

Fixes #2112.

This test is intended to test a case where the asset code in an incoming payment creation call is discrepant with what is attached to the associated wallet address. However, because reversing the order was the strategy to create discrepancy, palindromic asset codes would produce the same asset code as the original.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
