### PR TITLE
feat(backend): return WWW-Authenticate header in public incoming payment response

### DIFF
--- a/packages/backend/src/open_payments/auth/middleware.test.ts
+++ b/packages/backend/src/open_payments/auth/middleware.test.ts
@@ -87,6 +87,9 @@ describe('Auth Middleware', (): void => {
       const throwSpy = jest.spyOn(ctx, 'throw')
       await expect(middleware(ctx, next)).resolves.toBeUndefined()
       expect(throwSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(ctx.response.get('WWW-Authenticate')).toBe(
+        `GNAP as_uri=${Config.authServerGrantUrl}`
+      )
       expect(next).toHaveBeenCalled()
     })
 

--- a/packages/backend/src/open_payments/auth/middleware.ts
+++ b/packages/backend/src/open_payments/auth/middleware.ts
@@ -132,6 +132,7 @@ export function createTokenIntrospectionMiddleware({
       await next()
     } catch (err) {
       if (bypassError && err instanceof HttpError) {
+        ctx.set('WWW-Authenticate', `GNAP as_uri=${config.authServerGrantUrl}`)
         return await next()
       }
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Returns the `WWW-Authenticate` header on the public incoming payment response.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #2045.

Because `GET /incoming-payments` can be called without authentication and respond without at `401`, it was not being returned with a `WWW-Authenticate` header as per GNAP spec in the event of failed token introspection.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
