### PR TITLE
feat(backend): add liquidity to payment and wallet address resolvers

### DIFF
--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -424,6 +424,8 @@ export type IncomingPayment = BasePayment & Model & {
   id: Scalars['ID']['output'];
   /** The maximum amount that should be paid into the wallet address under this incoming payment. */
   incomingAmount?: Maybe<Amount>;
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the incoming payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** The total amount that has been paid into the wallet address under this incoming payment. */
@@ -718,6 +720,8 @@ export type OutgoingPayment = BasePayment & Model & {
   error?: Maybe<Scalars['String']['output']>;
   /** Outgoing payment id */
   id: Scalars['ID']['output'];
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the outgoing payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** Quote for this outgoing payment */
@@ -784,6 +788,8 @@ export type Payment = BasePayment & Model & {
   createdAt: Scalars['String']['output'];
   /** Payment id */
   id: Scalars['ID']['output'];
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** Either the IncomingPaymentState or OutgoingPaymentState according to type */
@@ -1164,6 +1170,8 @@ export type WalletAddress = Model & {
   id: Scalars['ID']['output'];
   /** List of incoming payments received by this wallet address */
   incomingPayments?: Maybe<IncomingPaymentConnection>;
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** List of outgoing payments sent from this wallet address */
   outgoingPayments?: Maybe<OutgoingPaymentConnection>;
   /** Public name associated with the wallet address */
@@ -1717,6 +1725,7 @@ export type IncomingPaymentResolvers<ContextType = any, ParentType extends Resol
   expiresAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   incomingAmount?: Resolver<Maybe<ResolversTypes['Amount']>, ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   receivedAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
   state?: Resolver<ResolversTypes['IncomingPaymentState'], ParentType, ContextType>;
@@ -1811,6 +1820,7 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
   receiveAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -1853,6 +1863,7 @@ export type PageInfoResolvers<ContextType = any, ParentType extends ResolversPar
 export type PaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Payment'] = ResolversParentTypes['Payment']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['PaymentType'], ParentType, ContextType>;
@@ -2019,6 +2030,7 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   incomingPayments?: Resolver<Maybe<ResolversTypes['IncomingPaymentConnection']>, ParentType, ContextType, Partial<WalletAddressIncomingPaymentsArgs>>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   outgoingPayments?: Resolver<Maybe<ResolversTypes['OutgoingPaymentConnection']>, ParentType, ContextType, Partial<WalletAddressOutgoingPaymentsArgs>>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -2823,6 +2823,18 @@
             "deprecationReason": null
           },
           {
+            "name": "liquidity",
+            "description": "Available liquidity",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UInt64",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metadata",
             "description": "Additional metadata associated with the incoming payment.",
             "args": [],
@@ -4551,6 +4563,18 @@
             "deprecationReason": null
           },
           {
+            "name": "liquidity",
+            "description": "Available liquidity",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UInt64",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metadata",
             "description": "Additional metadata associated with the outgoing payment.",
             "args": [],
@@ -4983,6 +5007,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "liquidity",
+            "description": "Available liquidity",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UInt64",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -7624,6 +7660,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "IncomingPaymentConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "liquidity",
+            "description": "Available liquidity",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "UInt64",
               "ofType": null
             },
             "isDeprecated": false,

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -424,6 +424,8 @@ export type IncomingPayment = BasePayment & Model & {
   id: Scalars['ID']['output'];
   /** The maximum amount that should be paid into the wallet address under this incoming payment. */
   incomingAmount?: Maybe<Amount>;
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the incoming payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** The total amount that has been paid into the wallet address under this incoming payment. */
@@ -718,6 +720,8 @@ export type OutgoingPayment = BasePayment & Model & {
   error?: Maybe<Scalars['String']['output']>;
   /** Outgoing payment id */
   id: Scalars['ID']['output'];
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the outgoing payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** Quote for this outgoing payment */
@@ -784,6 +788,8 @@ export type Payment = BasePayment & Model & {
   createdAt: Scalars['String']['output'];
   /** Payment id */
   id: Scalars['ID']['output'];
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** Either the IncomingPaymentState or OutgoingPaymentState according to type */
@@ -1164,6 +1170,8 @@ export type WalletAddress = Model & {
   id: Scalars['ID']['output'];
   /** List of incoming payments received by this wallet address */
   incomingPayments?: Maybe<IncomingPaymentConnection>;
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** List of outgoing payments sent from this wallet address */
   outgoingPayments?: Maybe<OutgoingPaymentConnection>;
   /** Public name associated with the wallet address */
@@ -1717,6 +1725,7 @@ export type IncomingPaymentResolvers<ContextType = any, ParentType extends Resol
   expiresAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   incomingAmount?: Resolver<Maybe<ResolversTypes['Amount']>, ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   receivedAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
   state?: Resolver<ResolversTypes['IncomingPaymentState'], ParentType, ContextType>;
@@ -1811,6 +1820,7 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
   receiveAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -1853,6 +1863,7 @@ export type PageInfoResolvers<ContextType = any, ParentType extends ResolversPar
 export type PaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Payment'] = ResolversParentTypes['Payment']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['PaymentType'], ParentType, ContextType>;
@@ -2019,6 +2030,7 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   incomingPayments?: Resolver<Maybe<ResolversTypes['IncomingPaymentConnection']>, ParentType, ContextType, Partial<WalletAddressIncomingPaymentsArgs>>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   outgoingPayments?: Resolver<Maybe<ResolversTypes['OutgoingPaymentConnection']>, ParentType, ContextType, Partial<WalletAddressOutgoingPaymentsArgs>>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;

--- a/packages/backend/src/graphql/resolvers/combined_payments.test.ts
+++ b/packages/backend/src/graphql/resolvers/combined_payments.test.ts
@@ -82,6 +82,7 @@ describe('Payment', (): void => {
                   id
                   type
                   walletAddressId
+                  liquidity
                   state
                   metadata
                   createdAt
@@ -118,7 +119,8 @@ describe('Payment', (): void => {
       metadata: combinedOutgoingPayment.metadata,
       walletAddressId: combinedOutgoingPayment.walletAddressId,
       state: combinedOutgoingPayment.state,
-      createdAt: combinedOutgoingPayment.createdAt.toISOString()
+      createdAt: combinedOutgoingPayment.createdAt.toISOString(),
+      liquidity: '0'
     })
 
     const combinedIncomingPayment = toCombinedPayment(
@@ -131,7 +133,8 @@ describe('Payment', (): void => {
       metadata: combinedIncomingPayment.metadata,
       walletAddressId: combinedIncomingPayment.walletAddressId,
       state: combinedIncomingPayment.state,
-      createdAt: combinedIncomingPayment.createdAt.toISOString()
+      createdAt: combinedIncomingPayment.createdAt.toISOString(),
+      liquidity: '0'
     })
   })
 

--- a/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
@@ -366,7 +366,7 @@ describe('Incoming Payment Resolver', (): void => {
         })
       })
 
-      test('200 - with liquidity', async (): Promise<void> => {
+      test('200 - with added liquidity', async (): Promise<void> => {
         await accountingService.createDeposit({
           id: uuid(),
           account: payment,

--- a/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
@@ -317,6 +317,7 @@ describe('Incoming Payment Resolver', (): void => {
                   walletAddressId
                   state
                   expiresAt
+                  liquidity
                   incomingAmount {
                     value
                     assetCode
@@ -343,6 +344,7 @@ describe('Incoming Payment Resolver', (): void => {
           walletAddressId: payment.walletAddressId,
           state,
           expiresAt: expiresAt.toISOString(),
+          liquidity: '0',
           incomingAmount: {
             value: payment.incomingAmount?.value.toString(),
             assetCode: payment.incomingAmount?.assetCode,

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -30,6 +30,10 @@ import { getPeer, getPeers, createPeer, updatePeer, deletePeer } from './peer'
 import {
   getAssetLiquidity,
   getPeerLiquidity,
+  getWalletAddressLiquidity,
+  getIncomingPaymentLiquidity,
+  getOutgoingPaymentLiquidity,
+  getPaymentLiquidity,
   addAssetLiquidity,
   addPeerLiquidity,
   createAssetLiquidityWithdrawal,
@@ -79,9 +83,19 @@ export const resolvers: Resolvers = {
     payments: getCombinedPayments
   },
   WalletAddress: {
+    liquidity: getWalletAddressLiquidity,
     incomingPayments: getWalletAddressIncomingPayments,
     outgoingPayments: getWalletAddressOutgoingPayments,
     quotes: getWalletAddressQuotes
+  },
+  IncomingPayment: {
+    liquidity: getIncomingPaymentLiquidity
+  },
+  OutgoingPayment: {
+    liquidity: getOutgoingPaymentLiquidity
+  },
+  Payment: {
+    liquidity: getPaymentLiquidity
   },
   Mutation: {
     createWalletAddressKey,

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -6,7 +6,11 @@ import {
   LiquidityMutationResponse,
   WalletAddressWithdrawalMutationResponse,
   AssetResolvers,
-  PeerResolvers
+  PeerResolvers,
+  WalletAddressResolvers,
+  IncomingPaymentResolvers,
+  OutgoingPaymentResolvers,
+  PaymentResolvers
 } from '../generated/graphql'
 import { ApolloContext } from '../../app'
 import {
@@ -25,6 +29,26 @@ export const getAssetLiquidity: AssetResolvers<ApolloContext>['liquidity'] =
   }
 
 export const getPeerLiquidity: PeerResolvers<ApolloContext>['liquidity'] =
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
+    return await getLiquidity(ctx, parent.id as string)
+  }
+
+export const getWalletAddressLiquidity: WalletAddressResolvers<ApolloContext>['liquidity'] =
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
+    return await getLiquidity(ctx, parent.id as string)
+  }
+
+export const getIncomingPaymentLiquidity: IncomingPaymentResolvers<ApolloContext>['liquidity'] =
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
+    return await getLiquidity(ctx, parent.id as string)
+  }
+
+export const getOutgoingPaymentLiquidity: OutgoingPaymentResolvers<ApolloContext>['liquidity'] =
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
+    return await getLiquidity(ctx, parent.id as string)
+  }
+
+export const getPaymentLiquidity: PaymentResolvers<ApolloContext>['liquidity'] =
   async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
     return await getLiquidity(ctx, parent.id as string)
   }

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -25,40 +25,47 @@ import { PeerError } from '../../payment-method/ilp/peer/errors'
 
 export const getAssetLiquidity: AssetResolvers<ApolloContext>['liquidity'] =
   async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
-    return await getLiquidity(ctx, parent.id as string)
+    return await getPeerOrAssetLiquidity(ctx, parent.id as string)
   }
 
 export const getPeerLiquidity: PeerResolvers<ApolloContext>['liquidity'] =
   async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
-    return await getLiquidity(ctx, parent.id as string)
+    return await getPeerOrAssetLiquidity(ctx, parent.id as string)
   }
 
 export const getWalletAddressLiquidity: WalletAddressResolvers<ApolloContext>['liquidity'] =
-  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
-    return await getLiquidity(ctx, parent.id as string)
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64'] | null> => {
+    return (await getLiquidity(ctx, parent.id as string)) ?? null
   }
 
 export const getIncomingPaymentLiquidity: IncomingPaymentResolvers<ApolloContext>['liquidity'] =
-  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
-    return await getLiquidity(ctx, parent.id as string)
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64'] | null> => {
+    return (await getLiquidity(ctx, parent.id as string)) ?? null
   }
 
 export const getOutgoingPaymentLiquidity: OutgoingPaymentResolvers<ApolloContext>['liquidity'] =
-  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
-    return await getLiquidity(ctx, parent.id as string)
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64'] | null> => {
+    return (await getLiquidity(ctx, parent.id as string)) ?? null
   }
 
 export const getPaymentLiquidity: PaymentResolvers<ApolloContext>['liquidity'] =
-  async (parent, args, ctx): Promise<ResolversTypes['UInt64']> => {
-    return await getLiquidity(ctx, parent.id as string)
+  async (parent, args, ctx): Promise<ResolversTypes['UInt64'] | null> => {
+    return (await getLiquidity(ctx, parent.id as string)) ?? null
   }
 
 const getLiquidity = async (
   ctx: ApolloContext,
   id: string
-): Promise<bigint> => {
+): Promise<bigint | undefined> => {
   const accountingService = await ctx.container.use('accountingService')
-  const liquidity = await accountingService.getBalance(id)
+  return await accountingService.getBalance(id)
+}
+
+const getPeerOrAssetLiquidity = async (
+  ctx: ApolloContext,
+  id: string
+): Promise<bigint> => {
+  const liquidity = await getLiquidity(ctx, id)
   if (liquidity === undefined) {
     throw new Error('No liquidity account found')
   }

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -127,6 +127,7 @@ describe('OutgoingPayment Resolvers', (): void => {
                     error
                     stateAttempts
                     receiver
+                    liquidity
                     debitAmount {
                       value
                       assetCode
@@ -169,6 +170,7 @@ describe('OutgoingPayment Resolvers', (): void => {
             error,
             stateAttempts: 0,
             receiver: payment.receiver,
+            liquidity: '0',
             debitAmount: {
               value: payment.debitAmount.value.toString(),
               assetCode: payment.debitAmount.assetCode,

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -207,6 +207,36 @@ describe('OutgoingPayment Resolvers', (): void => {
           })
         }
       )
+
+      test('200 - with added liquidity', async (): Promise<void> => {
+        await accountingService.createDeposit({
+          id: uuid(),
+          account: payment,
+          amount: 100n
+        })
+
+        const query = await appContainer.apolloClient
+          .query({
+            query: gql`
+              query OutgoingPayment($paymentId: String!) {
+                outgoingPayment(id: $paymentId) {
+                  id
+                  liquidity
+                }
+              }
+            `,
+            variables: {
+              paymentId: payment.id
+            }
+          })
+          .then((query): OutgoingPayment => query.data?.outgoingPayment)
+
+        expect(query).toEqual({
+          id: payment.id,
+          liquidity: '100',
+          __typename: 'OutgoingPayment'
+        })
+      })
     })
 
     test('404', async (): Promise<void> => {

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -380,10 +380,11 @@ describe('Wallet Address Resolvers', (): void => {
       ${'Alice'}
       ${undefined}
     `(
-      'Can get an wallet address (publicName: $publicName)',
+      'Can get a wallet address (publicName: $publicName)',
       async ({ publicName }): Promise<void> => {
         const walletAddress = await createWalletAddress(deps, {
-          publicName
+          publicName,
+          createLiquidityAccount: true
         })
         const query = await appContainer.apolloClient
           .query({
@@ -391,6 +392,7 @@ describe('Wallet Address Resolvers', (): void => {
               query WalletAddress($walletAddressId: String!) {
                 walletAddress(id: $walletAddressId) {
                   id
+                  liquidity
                   asset {
                     code
                     scale
@@ -415,6 +417,7 @@ describe('Wallet Address Resolvers', (): void => {
         expect(query).toEqual({
           __typename: 'WalletAddress',
           id: walletAddress.id,
+          liquidity: '0',
           asset: {
             __typename: 'Asset',
             code: walletAddress.asset.code,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -546,6 +546,8 @@ type WalletAddress implements Model {
   id: ID!
   "Asset of the wallet address"
   asset: Asset!
+  "Available liquidity"
+  liquidity: UInt64
   "Wallet Address URL"
   url: String!
   "Public name associated with the wallet address"
@@ -624,6 +626,8 @@ type IncomingPayment implements BasePayment & Model {
   id: ID!
   "Id of the wallet address under which this incoming payment was created"
   walletAddressId: ID!
+  "Available liquidity"
+  liquidity: UInt64
   "Incoming payment state"
   state: IncomingPaymentState!
   "Date-time of expiry. After this time, the incoming payment will not accept further payments made to it."
@@ -693,6 +697,8 @@ type OutgoingPayment implements BasePayment & Model {
   id: ID!
   "Id of the wallet address under which this outgoing payment was created"
   walletAddressId: ID!
+  "Available liquidity"
+  liquidity: UInt64
   "Outgoing payment state"
   state: OutgoingPaymentState!
   error: String
@@ -743,6 +749,8 @@ type Payment implements BasePayment & Model {
   walletAddressId: ID!
   "Either the IncomingPaymentState or OutgoingPaymentState according to type"
   state: String!
+  "Available liquidity"
+  liquidity: UInt64
   "Additional metadata associated with the payment."
   metadata: JSONObject
   "Date-time of creation"

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -424,6 +424,8 @@ export type IncomingPayment = BasePayment & Model & {
   id: Scalars['ID']['output'];
   /** The maximum amount that should be paid into the wallet address under this incoming payment. */
   incomingAmount?: Maybe<Amount>;
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the incoming payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** The total amount that has been paid into the wallet address under this incoming payment. */
@@ -718,6 +720,8 @@ export type OutgoingPayment = BasePayment & Model & {
   error?: Maybe<Scalars['String']['output']>;
   /** Outgoing payment id */
   id: Scalars['ID']['output'];
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the outgoing payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** Quote for this outgoing payment */
@@ -784,6 +788,8 @@ export type Payment = BasePayment & Model & {
   createdAt: Scalars['String']['output'];
   /** Payment id */
   id: Scalars['ID']['output'];
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** Additional metadata associated with the payment. */
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   /** Either the IncomingPaymentState or OutgoingPaymentState according to type */
@@ -1164,6 +1170,8 @@ export type WalletAddress = Model & {
   id: Scalars['ID']['output'];
   /** List of incoming payments received by this wallet address */
   incomingPayments?: Maybe<IncomingPaymentConnection>;
+  /** Available liquidity */
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
   /** List of outgoing payments sent from this wallet address */
   outgoingPayments?: Maybe<OutgoingPaymentConnection>;
   /** Public name associated with the wallet address */
@@ -1717,6 +1725,7 @@ export type IncomingPaymentResolvers<ContextType = any, ParentType extends Resol
   expiresAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   incomingAmount?: Resolver<Maybe<ResolversTypes['Amount']>, ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   receivedAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
   state?: Resolver<ResolversTypes['IncomingPaymentState'], ParentType, ContextType>;
@@ -1811,6 +1820,7 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
   error?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
   receiveAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -1853,6 +1863,7 @@ export type PageInfoResolvers<ContextType = any, ParentType extends ResolversPar
 export type PaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Payment'] = ResolversParentTypes['Payment']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
   state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['PaymentType'], ParentType, ContextType>;
@@ -2019,6 +2030,7 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   incomingPayments?: Resolver<Maybe<ResolversTypes['IncomingPaymentConnection']>, ParentType, ContextType, Partial<WalletAddressIncomingPaymentsArgs>>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   outgoingPayments?: Resolver<Maybe<ResolversTypes['OutgoingPaymentConnection']>, ParentType, ContextType, Partial<WalletAddressOutgoingPaymentsArgs>>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds the `liquidity` field to graphQL requests on `IncomingPayment`, `OutgoingPayment`, and `Payment`

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

Fixes #1694.
Allows liquidity for payments and wallet addresses to be displayed on the admin UI.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
