### PR TITLE
fix: the localenv seed set up now only creates a single peering relat…

### DIFF
--- a/localenv/cloud-nine-wallet/seed.yml
+++ b/localenv/cloud-nine-wallet/seed.yml
@@ -19,6 +19,7 @@ assets:
     scale: 0
     liquidity: 10000
     liquidityThreshold: 1000
+peeringAsset: 'USD'
 peers:
   - initialLiquidity: '100000'
     peerUrl: http://happy-life-bank-backend:3002

--- a/localenv/happy-life-bank/seed.yml
+++ b/localenv/happy-life-bank/seed.yml
@@ -19,6 +19,7 @@ assets:
     scale: 0
     liquidity: 10000
     liquidityThreshold: 1000
+peeringAsset: 'USD'
 peers:
   - initialLiquidity: '1000000000000'
     peerUrl: http://cloud-nine-wallet-backend:3002

--- a/localenv/mock-account-servicing-entity/app/lib/parse_config.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/parse_config.server.ts
@@ -57,6 +57,7 @@ export interface Config {
   publicHost: string
   testnetAutoPeerUrl: string
   authServerDomain: string
+  peeringAsset: string
 }
 
 export const CONFIG: Config = {
@@ -68,5 +69,6 @@ export const CONFIG: Config = {
   key: loadOrGenerateKey(process.env.KEY_FILE),
   publicHost: process.env.PUBLIC_HOST ?? '',
   testnetAutoPeerUrl: process.env.TESTNET_AUTOPEER_URL ?? '',
-  authServerDomain: process.env.AUTH_SERVER_DOMAIN || 'http://localhost:3006'
+  authServerDomain: process.env.AUTH_SERVER_DOMAIN || 'http://localhost:3006',
+  peeringAsset: process.env.PEERING_ASSET || 'USD'
 }

--- a/localenv/mock-account-servicing-entity/app/lib/parse_config.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/parse_config.server.ts
@@ -45,6 +45,7 @@ export interface Fee {
 export interface SeedInstance {
   self: Self
   assets: Array<Asset>
+  peeringAsset: string
   peers: Array<Peering>
   accounts: Array<Account>
   fees: Array<Fee>
@@ -57,7 +58,6 @@ export interface Config {
   publicHost: string
   testnetAutoPeerUrl: string
   authServerDomain: string
-  peeringAsset: string
 }
 
 export const CONFIG: Config = {
@@ -69,6 +69,5 @@ export const CONFIG: Config = {
   key: loadOrGenerateKey(process.env.KEY_FILE),
   publicHost: process.env.PUBLIC_HOST ?? '',
   testnetAutoPeerUrl: process.env.TESTNET_AUTOPEER_URL ?? '',
-  authServerDomain: process.env.AUTH_SERVER_DOMAIN || 'http://localhost:3006',
-  peeringAsset: process.env.PEERING_ASSET || 'USD'
+  authServerDomain: process.env.AUTH_SERVER_DOMAIN || 'http://localhost:3006'
 }

--- a/localenv/mock-account-servicing-entity/app/lib/run_seed.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/run_seed.server.ts
@@ -40,7 +40,7 @@ export async function setupFromSeed(config: Config): Promise<void> {
     }
   }
 
-  const peeringAsset = config.peeringAsset
+  const peeringAsset = config.seed.peeringAsset
 
   const peerResponses = await Promise.all(
     config.seed.peers.map(async (peer: Peering) => {

--- a/localenv/mock-account-servicing-entity/app/lib/run_seed.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/run_seed.server.ts
@@ -40,13 +40,15 @@ export async function setupFromSeed(config: Config): Promise<void> {
     }
   }
 
+  const peeringAsset = config.peeringAsset
+
   const peerResponses = await Promise.all(
     config.seed.peers.map(async (peer: Peering) => {
       const peerResponse = await createPeer(
         peer.peerIlpAddress,
         peer.peerUrl,
-        assets['USD'].id,
-        assets['USD'].code,
+        assets[peeringAsset].id,
+        assets[peeringAsset].code,
         peer.name,
         peer.liquidityThreshold
       ).then((response) => response.peer)
@@ -69,7 +71,7 @@ export async function setupFromSeed(config: Config): Promise<void> {
     console.log('autopeering url: ', CONFIG.testnetAutoPeerUrl)
     const autoPeerResponse = await createAutoPeer(
       CONFIG.testnetAutoPeerUrl,
-      assets['USD'].id
+      assets[peeringAsset].id
     ).catch((e) => {
       console.log('error on autopeering: ', e)
       return

--- a/localenv/mock-account-servicing-entity/app/lib/run_seed.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/run_seed.server.ts
@@ -40,43 +40,41 @@ export async function setupFromSeed(config: Config): Promise<void> {
     }
   }
 
-  for (const asset of Object.values(assets)) {
-    const peerResponses = await Promise.all(
-      config.seed.peers.map(async (peer: Peering) => {
-        const peerResponse = await createPeer(
-          peer.peerIlpAddress,
-          peer.peerUrl,
-          asset.id,
-          asset.code,
-          peer.name,
-          peer.liquidityThreshold
-        ).then((response) => response.peer)
-        if (!peerResponse) {
-          throw new Error('peer response not defined')
-        }
-        const transferUid = v4()
-        const liquidity = await addPeerLiquidity(
-          peerResponse.id,
-          peer.initialLiquidity,
-          transferUid
-        )
-        return [peerResponse, liquidity]
-      })
-    )
+  const peerResponses = await Promise.all(
+    config.seed.peers.map(async (peer: Peering) => {
+      const peerResponse = await createPeer(
+        peer.peerIlpAddress,
+        peer.peerUrl,
+        assets['USD'].id,
+        assets['USD'].code,
+        peer.name,
+        peer.liquidityThreshold
+      ).then((response) => response.peer)
+      if (!peerResponse) {
+        throw new Error('peer response not defined')
+      }
+      const transferUid = v4()
+      const liquidity = await addPeerLiquidity(
+        peerResponse.id,
+        peer.initialLiquidity,
+        transferUid
+      )
+      return [peerResponse, liquidity]
+    })
+  )
 
-    console.log(JSON.stringify(peerResponses, null, 2))
+  console.log(JSON.stringify(peerResponses, null, 2))
 
-    if (CONFIG.testnetAutoPeerUrl) {
-      console.log('autopeering url: ', CONFIG.testnetAutoPeerUrl)
-      const autoPeerResponse = await createAutoPeer(
-        CONFIG.testnetAutoPeerUrl,
-        asset.id
-      ).catch((e) => {
-        console.log('error on autopeering: ', e)
-        return
-      })
-      console.log(JSON.stringify(autoPeerResponse, null, 2))
-    }
+  if (CONFIG.testnetAutoPeerUrl) {
+    console.log('autopeering url: ', CONFIG.testnetAutoPeerUrl)
+    const autoPeerResponse = await createAutoPeer(
+      CONFIG.testnetAutoPeerUrl,
+      assets['USD'].id
+    ).catch((e) => {
+      console.log('error on autopeering: ', e)
+      return
+    })
+    console.log(JSON.stringify(autoPeerResponse, null, 2))
   }
 
   // Clear the accounts before seeding.

--- a/localenv/mock-account-servicing-entity/seed.example.yml
+++ b/localenv/mock-account-servicing-entity/seed.example.yml
@@ -11,6 +11,7 @@ assets:
     scale: 2
     liquidity: 10000
     liquidityThreshold: 1000
+peeringAsset: 'USD'
 peers:
   - initialLiquidity: '100000'
     peerUrl: http://peer-backend:3002


### PR DESCRIPTION
…ionship for the two mock ASEs

<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Whenever people peer, they should peer over one asset. The local playground was creating a peering relationship for each asset between cloud nine and happy life banks. This PR ensures the two mock ASEs only peer with each other using USD.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
