### PR TITLE
fix: psql transfer lookup

### DIFF
--- a/packages/backend/src/accounting/psql/ledger-transfer/index.ts
+++ b/packages/backend/src/accounting/psql/ledger-transfer/index.ts
@@ -46,6 +46,7 @@ export async function getAccountTransfers(
         creditAccountId: accountId
       })
     )
+    // Get transfers for POSTED or non-expired PENDING transfers. VOIDED transfers are ignored.
     .where((query) =>
       query
         .where({ state: LedgerTransferState.POSTED })

--- a/packages/backend/src/accounting/psql/ledger-transfer/index.ts
+++ b/packages/backend/src/accounting/psql/ledger-transfer/index.ts
@@ -46,12 +46,12 @@ export async function getAccountTransfers(
         creditAccountId: accountId
       })
     )
-    .where((query) =>
-      query.where({ expiresAt: null }).orWhere('expiresAt', '>', new Date())
+    .where((query) => query.where({ state: LedgerTransferState.POSTED }))
+    .orWhere((query) =>
+      query
+        .where({ state: LedgerTransferState.PENDING })
+        .andWhere('expiresAt', '>', new Date())
     )
-    .andWhereNot({
-      state: LedgerTransferState.VOIDED
-    })
 
   return transfers.reduce(
     (results, transfer) => {

--- a/packages/backend/src/accounting/psql/ledger-transfer/index.ts
+++ b/packages/backend/src/accounting/psql/ledger-transfer/index.ts
@@ -46,11 +46,18 @@ export async function getAccountTransfers(
         creditAccountId: accountId
       })
     )
-    .where((query) => query.where({ state: LedgerTransferState.POSTED }))
-    .orWhere((query) =>
+    .where((query) =>
       query
-        .where({ state: LedgerTransferState.PENDING })
-        .andWhere('expiresAt', '>', new Date())
+        .where({ state: LedgerTransferState.POSTED })
+        .orWhere((query) =>
+          query
+            .where({ state: LedgerTransferState.PENDING })
+            .where((query) =>
+              query
+                .where({ expiresAt: null })
+                .orWhere('expiresAt', '>', new Date())
+            )
+        )
     )
 
   return transfers.reduce(


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
After doing some testing related to the off-by-one "issue" in the ILP library, I came across an incorrect behavior of the way that POSTED transfers are looked up when using PSQL accounting. Basically, POSTED transfers with an expiry date in the past were being incorrectly ignored. This PR fixes this behaviour. 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Postman collection updated
