### PR TITLE
feat(telemetry): add optionality info in docs

### DIFF
--- a/packages/documentation/src/content/docs/telemetry/overview.md
+++ b/packages/documentation/src/content/docs/telemetry/overview.md
@@ -16,7 +16,7 @@ We aim to track the growth of the network in terms of transaction sizes and the 
 
 Privacy is a paramount concern for us. Rafiki's telemetry feature is designed to provide valuable network insights without violating privacy or aiding malicious ASEs. For more information, please [read the privacy docs](../privacy).
 
-The telemetry functionality is currently enabled by default on non-livenet enviroment, i.e. any environment that is not dealing with real money. Account Servicing Entities (ASEs) can opt-out of telemetry completely. When active, it transmits metrics to the TESTNET collector. In the future, those ASEs operating in a production livenet environment (real money) can opt-in to share their metrics with a LIVENET collector.  
+The telemetry functionality is currently enabled by default on test (non-livenet) environments, i.e. any environment that is not dealing with real money. When active, it transmits metrics to the "testnet" collector. In the future, those ASEs operating in a production "livenet" environment (real money) will be able to opt-in to sharing their metrics with a "livenet" collector. Regardless of environment, Account Servicing Entities (ASEs) can also opt-out of telemetry completely.
 
 ## Architecture
 

--- a/packages/documentation/src/content/docs/telemetry/overview.md
+++ b/packages/documentation/src/content/docs/telemetry/overview.md
@@ -16,7 +16,7 @@ We aim to track the growth of the network in terms of transaction sizes and the 
 
 Privacy is a paramount concern for us. Rafiki's telemetry feature is designed to provide valuable network insights without violating privacy or aiding malicious ASEs. For more information, please [read the privacy docs](../privacy).
 
-The telemetry functionality, while optional for Application Service Environments (ASEs), is enabled by default. When active, it transmits metrics to the TESTNET collector. However, for those operating in a production environment, there is an option to redirect these metrics. By defining the LIVENET environment variable, the metrics will be sent to the LIVENET collector instead.
+The telemetry functionality is currently enabled by default on non-livenet enviroment, i.e. any environment that is not dealing with real money. Account Servicing Entities (ASEs) can opt-out of telemetry completely. When active, it transmits metrics to the TESTNET collector. In the future, those ASEs operating in a production livenet environment (real money) can opt-in to share their metrics with a LIVENET collector.  
 
 ## Architecture
 

--- a/packages/documentation/src/content/docs/telemetry/overview.md
+++ b/packages/documentation/src/content/docs/telemetry/overview.md
@@ -16,7 +16,7 @@ We aim to track the growth of the network in terms of transaction sizes and the 
 
 Privacy is a paramount concern for us. Rafiki's telemetry feature is designed to provide valuable network insights without violating privacy or aiding malicious ASEs. For more information, please [read the privacy docs](../privacy).
 
-The telemetry feature is optional for ASEs.
+The telemetry functionality, while optional for Application Service Environments (ASEs), is enabled by default. When active, it transmits metrics to the TESTNET collector. However, for those operating in a production environment, there is an option to redirect these metrics. By defining the LIVENET environment variable, the metrics will be sent to the LIVENET collector instead.
 
 ## Architecture
 


### PR DESCRIPTION
## Changes proposed in this pull request

optionality is now detailed in the telemetry overview docs.

## Context
fixes #1924

Note - since main rafiki readme has a more general introduction approach, a better place for the optionality is suggested in this PR -> telemetry overview docs

## Checklist

- [x] Related issues linked #1924
- [ ] Tests added/updated
- [x] Documentation added
- [ ] Make sure that all checks pass
- [ ] Postman collection updated
