### PR TITLE
feat(telemetry): LIVENET now points to new livenet NLB

### DIFF
--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -42,7 +42,9 @@ export const Config = {
   openTelemetryCollectors: envStringArray(
     'OPEN_TELEMETRY_COLLECTOR_URLS',
     process.env.LIVENET
-      ? []
+      ? [
+          'http://livenet-otel-collector-NLB-f7992547e797f23d.elb.eu-west-2.amazonaws.com:4317'
+        ]
       : [
           'http://otel-collector-NLB-e3172ff9d2f4bc8a.elb.eu-west-2.amazonaws.com:4317'
         ]


### PR DESCRIPTION

## Changes proposed in this pull request
LIVENET env variable being true now defaults the openTelemetryCollectors list of url's with the livenet otel collector url

## Context
fixes #2522

## Checklist

- [x] Related issues linked #2522
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated
