### PR TITLE
feat(graphql-security): support for deep graphql queries on introspection 

### DIFF
--- a/packages/auth/src/app.ts
+++ b/packages/auth/src/app.ts
@@ -162,7 +162,7 @@ export class App {
       maxDepth: {
         enabled: true,
         n: 10,
-        ignoreIntrospection: false
+        ignoreIntrospection: true
       },
       costLimit: {
         enabled: true,

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -322,7 +322,7 @@ export class App {
       maxDepth: {
         enabled: true,
         n: 10,
-        ignoreIntrospection: false
+        ignoreIntrospection: true
       },
       costLimit: {
         enabled: true,


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->

This PR sets the ignoreIntrospection flag on maxDepth for the apolloArmor to true, so that integrators can query the graphql schema with codegen tools

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

Rafiki.money uses a codegen tool for graphql. The tool and the GUI for apolloClient were blocked by the new security addition ApolloArmor, specifically on the depth of the queries.
We should allow deep queries on introspection

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated
