### PR TITLE
feat(api): cancel outgoing payment

### DIFF
--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Cancel Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Cancel Outgoing Payment.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Cancel Outgoing Payment
+  type: graphql
+  seq: 43
+}
+
+post {
+  url: {{RafikiGraphqlHost}}/graphql
+  body: graphql
+  auth: none
+}
+
+body:graphql {
+  mutation CancelOutgoingPayment($input: CancelOutgoingPaymentInput!) {
+    cancelOutgoingPayment(input: $input) {
+      code
+      message
+      success
+    }
+  }
+}
+
+body:graphql:vars {
+  {
+    "input": {
+      "id": "{{outgoingPaymentId}}",
+      "reason": "Not enough balance"
+    }
+  }
+}

--- a/localenv/cloud-nine-wallet/seed.yml
+++ b/localenv/cloud-nine-wallet/seed.yml
@@ -40,6 +40,12 @@ accounts:
     path: accounts/wbdc
     brunoEnvVar: wbdcWalletAddress
     assetCode: USD
+  - name: "Broke Account"
+    id: 5a95366f-8cb4-4925-88d9-ae57dcb444bb
+    initialBalance: 50
+    path: accounts/broke
+    brunoEnvVar: brokeWalletAddress
+    assetCode: USD
 rates:
   EUR:
     MXN: 18.78

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -101,6 +101,13 @@ export type BasePayment = {
   walletAddressId: Scalars['ID']['output'];
 };
 
+export type CancelOutgoingPaymentInput = {
+  /** Outgoing payment id */
+  id: Scalars['ID']['input'];
+  /** Reason why this Outgoing Payment has been cancelled */
+  reason: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217), e.g. `USD` */
   code: Scalars['String']['input'];
@@ -551,6 +558,8 @@ export type Model = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Cancel Outgoing Payment */
+  cancelOutgoingPayment: OutgoingPaymentResponse;
   /** Create an asset */
   createAsset: AssetMutationResponse;
   /** Withdraw asset liquidity */
@@ -615,6 +624,11 @@ export type Mutation = {
   withdrawIncomingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
   /** Withdraw outgoing payment liquidity */
   withdrawOutgoingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
+};
+
+
+export type MutationCancelOutgoingPaymentArgs = {
+  input: CancelOutgoingPaymentInput;
 };
 
 
@@ -819,6 +833,8 @@ export type OutgoingPaymentResponse = {
 };
 
 export enum OutgoingPaymentState {
+  /** Payment cancelled */
+  Cancelled = 'CANCELLED',
   /** Successful completion */
   Completed = 'COMPLETED',
   /** Payment failed */
@@ -1488,6 +1504,7 @@ export type ResolversTypes = {
   AssetsConnection: ResolverTypeWrapper<Partial<AssetsConnection>>;
   BasePayment: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['BasePayment']>;
   Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']['output']>>;
+  CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1607,6 +1624,7 @@ export type ResolversParentTypes = {
   AssetsConnection: Partial<AssetsConnection>;
   BasePayment: ResolversInterfaceTypes<ResolversParentTypes>['BasePayment'];
   Boolean: Partial<Scalars['Boolean']['output']>;
+  CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -1899,6 +1917,7 @@ export type ModelResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  cancelOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCancelOutgoingPaymentArgs, 'input'>>;
   createAsset?: Resolver<ResolversTypes['AssetMutationResponse'], ParentType, ContextType, RequireFields<MutationCreateAssetArgs, 'input'>>;
   createAssetLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationCreateAssetLiquidityWithdrawalArgs, 'input'>>;
   createIncomingPayment?: Resolver<ResolversTypes['IncomingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCreateIncomingPaymentArgs, 'input'>>;

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -105,7 +105,7 @@ export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
   /** Reason why this Outgoing Payment has been cancelled */
-  reason: Scalars['String']['input'];
+  reason?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateAssetInput = {

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -104,7 +104,7 @@ export type BasePayment = {
 export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
-  /** Reason why this Outgoing Payment has been cancelled */
+  /** Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/localenv/mock-account-servicing-entity/seed.example.yml
+++ b/localenv/mock-account-servicing-entity/seed.example.yml
@@ -32,6 +32,12 @@ accounts:
     assetCode: USD
     scale: 2
     path: accounts/wbdc
+  - name: "Broke account"
+    id: 5a95366f-8cb4-4925-88d9-ae57dcb444bb
+    initialBalance: 0
+    assetCode: USD
+    scale: 2
+    path: accounts/broke
 fees:
   - fixed: 100
     basisPoints: 200

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -639,6 +639,49 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "CancelOutgoingPaymentInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": "Outgoing payment id",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reason",
+            "description": "Reason why this Outgoing Payment has been cancelled",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "CreateAssetInput",
         "description": null,
         "fields": null,
@@ -3731,6 +3774,39 @@
         "description": null,
         "fields": [
           {
+            "name": "cancelOutgoingPayment",
+            "description": "Cancel Outgoing Payment",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CancelOutgoingPaymentInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "OutgoingPaymentResponse",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createAsset",
             "description": "Create an asset",
             "args": [
@@ -5162,6 +5238,12 @@
         "inputFields": null,
         "interfaces": null,
         "enumValues": [
+          {
+            "name": "CANCELLED",
+            "description": "Payment cancelled",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "COMPLETED",
             "description": "Successful completion",

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -661,7 +661,7 @@
           },
           {
             "name": "reason",
-            "description": "Reason why this Outgoing Payment has been cancelled",
+            "description": "Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments.",
             "type": {
               "kind": "SCALAR",
               "name": "String",

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -663,13 +663,9 @@
             "name": "reason",
             "description": "Reason why this Outgoing Payment has been cancelled",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -101,6 +101,13 @@ export type BasePayment = {
   walletAddressId: Scalars['ID']['output'];
 };
 
+export type CancelOutgoingPaymentInput = {
+  /** Outgoing payment id */
+  id: Scalars['ID']['input'];
+  /** Reason why this Outgoing Payment has been cancelled */
+  reason: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217), e.g. `USD` */
   code: Scalars['String']['input'];
@@ -551,6 +558,8 @@ export type Model = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Cancel Outgoing Payment */
+  cancelOutgoingPayment: OutgoingPaymentResponse;
   /** Create an asset */
   createAsset: AssetMutationResponse;
   /** Withdraw asset liquidity */
@@ -615,6 +624,11 @@ export type Mutation = {
   withdrawIncomingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
   /** Withdraw outgoing payment liquidity */
   withdrawOutgoingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
+};
+
+
+export type MutationCancelOutgoingPaymentArgs = {
+  input: CancelOutgoingPaymentInput;
 };
 
 
@@ -819,6 +833,8 @@ export type OutgoingPaymentResponse = {
 };
 
 export enum OutgoingPaymentState {
+  /** Payment cancelled */
+  Cancelled = 'CANCELLED',
   /** Successful completion */
   Completed = 'COMPLETED',
   /** Payment failed */
@@ -1488,6 +1504,7 @@ export type ResolversTypes = {
   AssetsConnection: ResolverTypeWrapper<Partial<AssetsConnection>>;
   BasePayment: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['BasePayment']>;
   Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']['output']>>;
+  CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1607,6 +1624,7 @@ export type ResolversParentTypes = {
   AssetsConnection: Partial<AssetsConnection>;
   BasePayment: ResolversInterfaceTypes<ResolversParentTypes>['BasePayment'];
   Boolean: Partial<Scalars['Boolean']['output']>;
+  CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -1899,6 +1917,7 @@ export type ModelResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  cancelOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCancelOutgoingPaymentArgs, 'input'>>;
   createAsset?: Resolver<ResolversTypes['AssetMutationResponse'], ParentType, ContextType, RequireFields<MutationCreateAssetArgs, 'input'>>;
   createAssetLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationCreateAssetLiquidityWithdrawalArgs, 'input'>>;
   createIncomingPayment?: Resolver<ResolversTypes['IncomingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCreateIncomingPaymentArgs, 'input'>>;

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -105,7 +105,7 @@ export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
   /** Reason why this Outgoing Payment has been cancelled */
-  reason: Scalars['String']['input'];
+  reason?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateAssetInput = {

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -104,7 +104,7 @@ export type BasePayment = {
 export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
-  /** Reason why this Outgoing Payment has been cancelled */
+  /** Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -25,7 +25,8 @@ import {
   getOutgoingPayment,
   createOutgoingPayment,
   getWalletAddressOutgoingPayments,
-  createOutgoingPaymentFromIncomingPayment
+  createOutgoingPaymentFromIncomingPayment,
+  cancelOutgoingPayment
 } from './outgoing_payment'
 import { getPeer, getPeers, createPeer, updatePeer, deletePeer } from './peer'
 import {
@@ -115,6 +116,7 @@ export const resolvers: Resolvers = {
     createQuote,
     createOutgoingPayment,
     createOutgoingPaymentFromIncomingPayment,
+    cancelOutgoingPayment,
     createIncomingPayment,
     createReceiver,
     createPeer: createPeer,

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -539,7 +539,7 @@ describe('OutgoingPayment Resolvers', (): void => {
     })
   })
 
-  describe.only('Mutation.cancelOutgoingPayment', (): void => {
+  describe('Mutation.cancelOutgoingPayment', (): void => {
     let payment: OutgoingPaymentModel
     beforeEach(async () => {
       const walletAddress = await createWalletAddress(deps, {

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -545,32 +545,34 @@ describe('OutgoingPayment Resolvers', (): void => {
       const walletAddress = await createWalletAddress(deps, {
         assetId: asset.id
       })
-      
+
       payment = await createPayment({ walletAddressId: walletAddress.id })
     })
 
-    const reasons: (string | undefined)[] = [undefined, "Not enough balance"]
+    const reasons: (string | undefined)[] = [undefined, 'Not enough balance']
     test.each(reasons)(
       'should cancel outgoing payment with reason %s',
-      async(reason): Promise<void> => {
+      async (reason): Promise<void> => {
         const input = {
           id: payment.id,
           reason
         }
-  
+
         payment.state = OutgoingPaymentState.Cancelled
         payment.metadata = {
           cancellationReason: input.reason
         }
-  
+
         const cancelSpy = jest
           .spyOn(outgoingPaymentService, 'cancel')
           .mockResolvedValue(payment)
-  
+
         const mutationResponse = await appContainer.apolloClient
           .mutate({
             mutation: gql`
-              mutation CancelOutgoingPayment($input: CancelOutgoingPaymentInput!) {
+              mutation CancelOutgoingPayment(
+                $input: CancelOutgoingPaymentInput!
+              ) {
                 cancelOutgoingPayment(input: $input) {
                   code
                   success
@@ -588,38 +590,40 @@ describe('OutgoingPayment Resolvers', (): void => {
             (query): OutgoingPaymentResponse =>
               query.data?.cancelOutgoingPayment
           )
-  
-          expect(cancelSpy).toHaveBeenCalledWith(input)
-          expect(mutationResponse.code).toBe('200')
-          expect(mutationResponse.success).toBe(true)
-          expect(mutationResponse.payment).toEqual({
-            __typename: "OutgoingPayment",
-            id: input.id,
-            state: OutgoingPaymentState.Cancelled,
-            metadata: {
-              cancellationReason: input.reason
-            }
-          })
+
+        expect(cancelSpy).toHaveBeenCalledWith(input)
+        expect(mutationResponse.code).toBe('200')
+        expect(mutationResponse.success).toBe(true)
+        expect(mutationResponse.payment).toEqual({
+          __typename: 'OutgoingPayment',
+          id: input.id,
+          state: OutgoingPaymentState.Cancelled,
+          metadata: {
+            cancellationReason: input.reason
+          }
+        })
       }
     )
 
     const errors: [string, OutgoingPaymentError][] = [
-      [ '409', OutgoingPaymentError.WrongState ],
-      [ '404', OutgoingPaymentError.UnknownPayment ]
+      ['409', OutgoingPaymentError.WrongState],
+      ['404', OutgoingPaymentError.UnknownPayment]
     ]
     test.each(errors)(
       '%s - outgoing payment error',
-      async(statusCode, paymentError): Promise<void> => {
+      async (statusCode, paymentError): Promise<void> => {
         const cancelSpy = jest
-        .spyOn(outgoingPaymentService, 'cancel')
-        .mockResolvedValueOnce(paymentError)
+          .spyOn(outgoingPaymentService, 'cancel')
+          .mockResolvedValueOnce(paymentError)
 
         const input = { id: uuid() }
 
         const mutationResponse = await appContainer.apolloClient
           .mutate({
             mutation: gql`
-              mutation CancelOutgoingPayment($input: CancelOutgoingPaymentInput!) {
+              mutation CancelOutgoingPayment(
+                $input: CancelOutgoingPaymentInput!
+              ) {
                 cancelOutgoingPayment(input: $input) {
                   code
                   message
@@ -638,7 +642,7 @@ describe('OutgoingPayment Resolvers', (): void => {
             (query): OutgoingPaymentResponse =>
               query.data?.cancelOutgoingPayment
           )
-    
+
         expect(cancelSpy).toHaveBeenCalledWith(input)
         expect(mutationResponse).toEqual({
           __typename: 'OutgoingPaymentResponse',
@@ -647,7 +651,8 @@ describe('OutgoingPayment Resolvers', (): void => {
           success: false,
           payment: null
         })
-    })
+      }
+    )
   })
 
   describe('Wallet address outgoingPayments', (): void => {

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -549,11 +549,22 @@ describe('OutgoingPayment Resolvers', (): void => {
       payment = await createPayment({ walletAddressId })
     })
 
-    const states: [string, OutgoingPaymentError | null][] =
-        Object.values(OutgoingPaymentState).flatMap((state) => [
-          ["Not enough balance", state == OutgoingPaymentState.Funding ? null : OutgoingPaymentError.WrongState],
-          ["Missing KYC", state == OutgoingPaymentState.Funding ? null : OutgoingPaymentError.WrongState],
-        ])
+    const states: [string, OutgoingPaymentError | null][] = Object.values(
+      OutgoingPaymentState
+    ).flatMap((state) => [
+      [
+        'Not enough balance',
+        state == OutgoingPaymentState.Funding
+          ? null
+          : OutgoingPaymentError.WrongState
+      ],
+      [
+        'Missing KYC',
+        state == OutgoingPaymentState.Funding
+          ? null
+          : OutgoingPaymentError.WrongState
+      ]
+    ])
     test.each(states)(
       '200 - %s, error: %s',
       async (reason, error): Promise<void> => {
@@ -576,7 +587,9 @@ describe('OutgoingPayment Resolvers', (): void => {
         const response = await appContainer.apolloClient
           .mutate({
             mutation: gql`
-              mutation cancelOutgoingPayment($input: CancelOutgoingPaymentInput!) {
+              mutation cancelOutgoingPayment(
+                $input: CancelOutgoingPaymentInput!
+              ) {
                 cancelOutgoingPayment(input: $input) {
                   code
                   success
@@ -602,13 +615,12 @@ describe('OutgoingPayment Resolvers', (): void => {
             throw new Error('Data was empty')
           })
 
-
         expect(response.success).toBe(!error)
         expect(response.code).toEqual(error ? '409' : '200')
 
         if (!error) {
           expect(response.payment).toEqual({
-            __typename: "OutgoingPayment",
+            __typename: 'OutgoingPayment',
             id: payment.id,
             walletAddressId: payment.walletAddressId,
             state: OutgoingPaymentState.Cancelled,
@@ -618,7 +630,7 @@ describe('OutgoingPayment Resolvers', (): void => {
           })
         } else {
           expect(response.message).toEqual('wrong state')
-          expect(response.payment).toBeNull();
+          expect(response.payment).toBeNull()
         }
       }
     )

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -29,6 +29,31 @@ export const getOutgoingPayment: QueryResolvers<ApolloContext>['outgoingPayment'
     return paymentToGraphql(payment)
   }
 
+export const cancelOutgoingPayment: MutationResolvers<ApolloContext>['cancelOutgoingPayment'] =
+  async (parent, args, ctx): Promise<ResolversTypes['OutgoingPaymentResponse']> => {
+    const outgoingPaymentService = await ctx.container.use('outgoingPaymentService')
+
+    return outgoingPaymentService
+      .cancel(args.input)
+      .then((paymentOrError: OutgoingPayment | OutgoingPaymentError) =>
+        isOutgoingPaymentError(paymentOrError)
+          ? {
+            code: errorToCode[paymentOrError].toString(),
+            success: false,
+            message: errorToMessage[paymentOrError]
+          }
+          : {
+            code: '200',
+            success: true,
+            payment: paymentToGraphql(paymentOrError)
+          }
+      ).catch(() => ({
+        code: '500',
+        success: false,
+        message: 'Error trying to cancel outgoing payment'
+      }))
+  }
+
 export const createOutgoingPayment: MutationResolvers<ApolloContext>['createOutgoingPayment'] =
   async (
     parent,

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -30,24 +30,31 @@ export const getOutgoingPayment: QueryResolvers<ApolloContext>['outgoingPayment'
   }
 
 export const cancelOutgoingPayment: MutationResolvers<ApolloContext>['cancelOutgoingPayment'] =
-  async (parent, args, ctx): Promise<ResolversTypes['OutgoingPaymentResponse']> => {
-    const outgoingPaymentService = await ctx.container.use('outgoingPaymentService')
+  async (
+    parent,
+    args,
+    ctx
+  ): Promise<ResolversTypes['OutgoingPaymentResponse']> => {
+    const outgoingPaymentService = await ctx.container.use(
+      'outgoingPaymentService'
+    )
 
     return outgoingPaymentService
       .cancel(args.input)
       .then((paymentOrError: OutgoingPayment | OutgoingPaymentError) =>
         isOutgoingPaymentError(paymentOrError)
           ? {
-            code: errorToCode[paymentOrError].toString(),
-            success: false,
-            message: errorToMessage[paymentOrError]
-          }
+              code: errorToCode[paymentOrError].toString(),
+              success: false,
+              message: errorToMessage[paymentOrError]
+            }
           : {
-            code: '200',
-            success: true,
-            payment: paymentToGraphql(paymentOrError)
-          }
-      ).catch(() => ({
+              code: '200',
+              success: true,
+              payment: paymentToGraphql(paymentOrError)
+            }
+      )
+      .catch(() => ({
         code: '500',
         success: false,
         message: 'Error trying to cancel outgoing payment'

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -182,6 +182,11 @@ type Mutation {
     input: CreateOutgoingPaymentInput!
   ): OutgoingPaymentResponse!
 
+  "Cancel Outgoing Payment"
+  cancelOutgoingPayment(
+    input: CancelOutgoingPaymentInput!
+  ): OutgoingPaymentResponse!
+
   "Create an Open Payments Outgoing Payment from an incoming payment"
   createOutgoingPaymentFromIncomingPayment(
     input: CreateOutgoingPaymentFromIncomingPaymentInput!
@@ -807,6 +812,8 @@ enum OutgoingPaymentState {
   COMPLETED
   "Payment failed"
   FAILED
+  "Payment cancelled"
+  CANCELLED
 }
 
 type PaymentConnection {
@@ -920,6 +927,13 @@ input CreateOutgoingPaymentInput {
   metadata: JSONObject
   "Unique key to ensure duplicate or retried requests are processed only once. See [idempotence](https://en.wikipedia.org/wiki/Idempotence)"
   idempotencyKey: String
+}
+
+input CancelOutgoingPaymentInput {
+  "Outgoing payment id"
+  id: ID!
+  "Reason why this Outgoing Payment has been cancelled"
+  reason: String!
 }
 
 input CreateOutgoingPaymentFromIncomingPaymentInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -933,7 +933,7 @@ input CancelOutgoingPaymentInput {
   "Outgoing payment id"
   id: ID!
   "Reason why this Outgoing Payment has been cancelled"
-  reason: String!
+  reason: String
 }
 
 input CreateOutgoingPaymentFromIncomingPaymentInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -932,7 +932,7 @@ input CreateOutgoingPaymentInput {
 input CancelOutgoingPaymentInput {
   "Outgoing payment id"
   id: ID!
-  "Reason why this Outgoing Payment has been cancelled"
+  "Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments."
   reason: String
 }
 

--- a/packages/backend/src/open_payments/payment/outgoing/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/model.ts
@@ -81,7 +81,7 @@ export class OutgoingPayment
   }
 
   public get failed(): boolean {
-    return this.state === OutgoingPaymentState.Failed
+    return [OutgoingPaymentState.Cancelled, OutgoingPaymentState.Failed].includes(this.state)
   }
 
   // Outgoing peer
@@ -176,6 +176,7 @@ export enum OutgoingPaymentState {
   // Awaiting money from the user's wallet account to be deposited to the payment account to reserve it for the payment.
   // On success, transition to `SENDING`.
   // On failure, transition to `FAILED`.
+  // Can also go to CANCELLED state if cancelOutgoingPayment mutation is called
   Funding = 'FUNDING',
   // Pay from the account to the destination.
   // On success, transition to `COMPLETED`.
@@ -183,7 +184,9 @@ export enum OutgoingPaymentState {
   // The payment failed. (Though some money may have been delivered).
   Failed = 'FAILED',
   // Successful completion.
-  Completed = 'COMPLETED'
+  Completed = 'COMPLETED',
+  // Transaction has been cancelled by ASE
+  Cancelled = "CANCELLED"
 }
 
 export enum OutgoingPaymentDepositType {

--- a/packages/backend/src/open_payments/payment/outgoing/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/model.ts
@@ -81,7 +81,10 @@ export class OutgoingPayment
   }
 
   public get failed(): boolean {
-    return [OutgoingPaymentState.Cancelled, OutgoingPaymentState.Failed].includes(this.state)
+    return [
+      OutgoingPaymentState.Cancelled,
+      OutgoingPaymentState.Failed
+    ].includes(this.state)
   }
 
   // Outgoing peer
@@ -186,7 +189,7 @@ export enum OutgoingPaymentState {
   // Successful completion.
   Completed = 'COMPLETED',
   // Transaction has been cancelled by ASE
-  Cancelled = "CANCELLED"
+  Cancelled = 'CANCELLED'
 }
 
 export enum OutgoingPaymentDepositType {

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -444,9 +444,9 @@ describe('OutgoingPaymentService', (): void => {
 
         if (!outgoingPaymentError) {
           assert.ok(response instanceof OutgoingPayment)
-          expect(dataCheck.id).toBe(outgoingPayment.id)
-          expect(dataCheck.state).toBe(OutgoingPaymentState.Cancelled)
-          expect(dataCheck.metadata).toEqual({
+          expect(response.id).toBe(outgoingPayment.id)
+          expect(response.state).toBe(OutgoingPaymentState.Cancelled)
+          expect(response.metadata).toEqual({
             cancellationReason: reason
           })
         } else {

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -90,7 +90,8 @@ describe('OutgoingPaymentService', (): void => {
     [OutgoingPaymentState.Funding]: OutgoingPaymentEventType.PaymentCreated,
     [OutgoingPaymentState.Sending]: undefined,
     [OutgoingPaymentState.Failed]: OutgoingPaymentEventType.PaymentFailed,
-    [OutgoingPaymentState.Completed]: OutgoingPaymentEventType.PaymentCompleted
+    [OutgoingPaymentState.Completed]: OutgoingPaymentEventType.PaymentCompleted,
+    [OutgoingPaymentState.Cancelled]: OutgoingPaymentEventType.PaymentFailed
   }
 
   async function processNext(

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -443,7 +443,7 @@ describe('OutgoingPaymentService', (): void => {
         })
 
         if (!outgoingPaymentError) {
-          const dataCheck = response as OutgoingPayment
+          assert.ok(response instanceof OutgoingPayment)
           expect(dataCheck.id).toBe(outgoingPayment.id)
           expect(dataCheck.state).toBe(OutgoingPaymentState.Cancelled)
           expect(dataCheck.metadata).toEqual({

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -91,7 +91,7 @@ describe('OutgoingPaymentService', (): void => {
     [OutgoingPaymentState.Sending]: undefined,
     [OutgoingPaymentState.Failed]: OutgoingPaymentEventType.PaymentFailed,
     [OutgoingPaymentState.Completed]: OutgoingPaymentEventType.PaymentCompleted,
-    [OutgoingPaymentState.Cancelled]: OutgoingPaymentEventType.PaymentFailed
+    [OutgoingPaymentState.Cancelled]: undefined
   }
 
   async function processNext(

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -113,8 +113,8 @@ export interface CreateFromIncomingPayment extends BaseOptions {
 }
 
 export type CancelOutgoingPaymentOptions = {
-  id: string;
-  reason: string;
+  id: string
+  reason: string
 }
 
 export type CreateOutgoingPaymentOptions =
@@ -134,22 +134,23 @@ async function cancelOutgoingPayment(
   const { id } = options
 
   return deps.knex.transaction(async (trx) => {
-    let payment = await OutgoingPayment.query(trx)
-      .findById(id)
-      .forUpdate()
+    let payment = await OutgoingPayment.query(trx).findById(id).forUpdate()
 
     if (!payment) return OutgoingPaymentError.UnknownPayment
     if (payment.state !== OutgoingPaymentState.Funding) {
       return OutgoingPaymentError.WrongState
     }
 
-    payment = await payment.$query(trx).patchAndFetch({
-      state: OutgoingPaymentState.Cancelled,
-      metadata: {
-        ...payment.metadata,
-        cancellationReason: options.reason
-      }
-    }).withGraphFetched('[quote.asset, walletAddress]')
+    payment = await payment
+      .$query(trx)
+      .patchAndFetch({
+        state: OutgoingPaymentState.Cancelled,
+        metadata: {
+          ...payment.metadata,
+          cancellationReason: options.reason
+        }
+      })
+      .withGraphFetched('[quote.asset, walletAddress]')
 
     return addSentAmount(deps, payment)
   })

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -147,7 +147,7 @@ async function cancelOutgoingPayment(
         state: OutgoingPaymentState.Cancelled,
         metadata: {
           ...payment.metadata,
-          cancellationReason: options.reason
+          ...(options.reason ? { cancellationReason: options.reason } : {})
         }
       })
       .withGraphFetched('[quote.asset, walletAddress]')

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -149,7 +149,7 @@ async function cancelOutgoingPayment(
         ...payment.metadata,
         cancellationReason: options.reason
       }
-    })
+    }).withGraphFetched('[quote.asset, walletAddress]')
 
     return addSentAmount(deps, payment)
   })

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -114,7 +114,7 @@ export interface CreateFromIncomingPayment extends BaseOptions {
 
 export type CancelOutgoingPaymentOptions = {
   id: string
-  reason: string
+  reason?: string
 }
 
 export type CreateOutgoingPaymentOptions =

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -519,7 +519,11 @@ function validateSentAmount(
     return sentAmount
   }
 
-  if ([OutgoingPaymentState.Funding, OutgoingPaymentState.Cancelled].includes(payment.state)) {
+  if (
+    [OutgoingPaymentState.Funding, OutgoingPaymentState.Cancelled].includes(
+      payment.state
+    )
+  ) {
     return BigInt(0)
   }
 

--- a/packages/documentation/src/content/docs/integration/event-handlers.mdx
+++ b/packages/documentation/src/content/docs/integration/event-handlers.mdx
@@ -59,7 +59,9 @@ Example: An incoming payment has expired and received $2.55.
 
 ## `outgoing_payment.created`
 
-The `outgoing_payment.created` event indicates that an outgoing payment has been created and is awaiting liquidity. The Account Servicing Entity should put a hold on the sender's account and deposit the funds into Rafiki.
+The `outgoing_payment.created` event indicates that an outgoing payment has been created and is awaiting liquidity. The Account Servicing Entity should perform a check here to see if there is enough balance, or some other kind of checks that must pass in order to fullfill this outgoing payment.
+In case that outgoing payment should not be fullfilled, the Account Servicing Entity can cancel outgoing payment.
+Otherwise, the Account Servicing Entity should put a hold on the sender’s account and deposit the funds into Rafiki.
 
 Example: An outgoing payment for $12 has been created.
 
@@ -72,6 +74,18 @@ Example: An outgoing payment for $12 has been created.
     ASE->>ASE: put hold of $12 on sender's account
     ASE->>R: admin API call: DepositOutgoingPaymentLiquidity
 
+`}
+/>
+
+Example: Cancel outgoing payment due to low funds
+
+<Mermaid
+  graph={`sequenceDiagram
+    participant ASE as Account Servicing Entity
+    participant R as Rafiki
+    R->>ASE: webhook event: outgoing payment created,<br>debit amount: $12
+    ASE->>ASE: check if account has enough balance
+    ASE->>R: admin API call: CancelOutgoingPayment<br>reason: Not enough balance
 `}
 />
 

--- a/packages/documentation/src/content/docs/integration/event-handlers.mdx
+++ b/packages/documentation/src/content/docs/integration/event-handlers.mdx
@@ -59,7 +59,7 @@ Example: An incoming payment has expired and received $2.55.
 
 ## `outgoing_payment.created`
 
-The `outgoing_payment.created` event indicates that an outgoing payment has been created and is awaiting liquidity. The Account Servicing Entity should perform a check here to see if there is enough balance, or some other kind of checks that must pass in order to fullfill this outgoing payment.
+The `outgoing_payment.created` event indicates that an outgoing payment has been created and is awaiting liquidity. The Account Servicing Entity should verify the user account balance (and perform any other kinds of checks necessary) before funding or cancelling the outgoing payment.
 In case that outgoing payment should not be fullfilled, the Account Servicing Entity can cancel outgoing payment.
 Otherwise, the Account Servicing Entity should put a hold on the sender’s account and deposit the funds into Rafiki.
 

--- a/packages/documentation/src/content/docs/integration/event-handlers.mdx
+++ b/packages/documentation/src/content/docs/integration/event-handlers.mdx
@@ -69,23 +69,16 @@ Example: An outgoing payment for $12 has been created.
   graph={`sequenceDiagram
     participant ASE as Account Servicing Entity
     participant R as Rafiki
-
     R->>ASE: webhook event: outgoing payment created,<br>debitAmount: $12
+    ASE->>ASE: check if account has enough balance
+    alt Account has enough balance
     ASE->>ASE: put hold of $12 on sender's account
     ASE->>R: admin API call: DepositOutgoingPaymentLiquidity
-
-`}
-/>
-
-Example: Cancel outgoing payment due to low funds
-
-<Mermaid
-  graph={`sequenceDiagram
-    participant ASE as Account Servicing Entity
-    participant R as Rafiki
-    R->>ASE: webhook event: outgoing payment created,<br>debit amount: $12
-    ASE->>ASE: check if account has enough balance
+    end
+    alt Account does not have enough balance
     ASE->>R: admin API call: CancelOutgoingPayment<br>reason: Not enough balance
+    end
+
 `}
 />
 

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -101,6 +101,13 @@ export type BasePayment = {
   walletAddressId: Scalars['ID']['output'];
 };
 
+export type CancelOutgoingPaymentInput = {
+  /** Outgoing payment id */
+  id: Scalars['ID']['input'];
+  /** Reason why this Outgoing Payment has been cancelled */
+  reason: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217), e.g. `USD` */
   code: Scalars['String']['input'];
@@ -551,6 +558,8 @@ export type Model = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Cancel Outgoing Payment */
+  cancelOutgoingPayment: OutgoingPaymentResponse;
   /** Create an asset */
   createAsset: AssetMutationResponse;
   /** Withdraw asset liquidity */
@@ -615,6 +624,11 @@ export type Mutation = {
   withdrawIncomingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
   /** Withdraw outgoing payment liquidity */
   withdrawOutgoingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
+};
+
+
+export type MutationCancelOutgoingPaymentArgs = {
+  input: CancelOutgoingPaymentInput;
 };
 
 
@@ -819,6 +833,8 @@ export type OutgoingPaymentResponse = {
 };
 
 export enum OutgoingPaymentState {
+  /** Payment cancelled */
+  Cancelled = 'CANCELLED',
   /** Successful completion */
   Completed = 'COMPLETED',
   /** Payment failed */
@@ -1488,6 +1504,7 @@ export type ResolversTypes = {
   AssetsConnection: ResolverTypeWrapper<Partial<AssetsConnection>>;
   BasePayment: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['BasePayment']>;
   Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']['output']>>;
+  CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1607,6 +1624,7 @@ export type ResolversParentTypes = {
   AssetsConnection: Partial<AssetsConnection>;
   BasePayment: ResolversInterfaceTypes<ResolversParentTypes>['BasePayment'];
   Boolean: Partial<Scalars['Boolean']['output']>;
+  CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -1899,6 +1917,7 @@ export type ModelResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  cancelOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCancelOutgoingPaymentArgs, 'input'>>;
   createAsset?: Resolver<ResolversTypes['AssetMutationResponse'], ParentType, ContextType, RequireFields<MutationCreateAssetArgs, 'input'>>;
   createAssetLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationCreateAssetLiquidityWithdrawalArgs, 'input'>>;
   createIncomingPayment?: Resolver<ResolversTypes['IncomingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCreateIncomingPaymentArgs, 'input'>>;

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -105,7 +105,7 @@ export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
   /** Reason why this Outgoing Payment has been cancelled */
-  reason: Scalars['String']['input'];
+  reason?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateAssetInput = {

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -104,7 +104,7 @@ export type BasePayment = {
 export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
-  /** Reason why this Outgoing Payment has been cancelled */
+  /** Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/packages/frontend/app/shared/utils.ts
+++ b/packages/frontend/app/shared/utils.ts
@@ -78,7 +78,8 @@ export const badgeColorByPaymentState: {
   PROCESSING: BadgeColor.Yellow,
   FAILED: BadgeColor.Red,
   FUNDING: BadgeColor.Yellow,
-  SENDING: BadgeColor.Yellow
+  SENDING: BadgeColor.Yellow,
+  CANCELLED: BadgeColor.Red
 }
 
 export const badgeColorByWalletAddressStatus: Record<

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -101,6 +101,13 @@ export type BasePayment = {
   walletAddressId: Scalars['ID']['output'];
 };
 
+export type CancelOutgoingPaymentInput = {
+  /** Outgoing payment id */
+  id: Scalars['ID']['input'];
+  /** Reason why this Outgoing Payment has been cancelled */
+  reason: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217), e.g. `USD` */
   code: Scalars['String']['input'];
@@ -551,6 +558,8 @@ export type Model = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Cancel Outgoing Payment */
+  cancelOutgoingPayment: OutgoingPaymentResponse;
   /** Create an asset */
   createAsset: AssetMutationResponse;
   /** Withdraw asset liquidity */
@@ -615,6 +624,11 @@ export type Mutation = {
   withdrawIncomingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
   /** Withdraw outgoing payment liquidity */
   withdrawOutgoingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
+};
+
+
+export type MutationCancelOutgoingPaymentArgs = {
+  input: CancelOutgoingPaymentInput;
 };
 
 
@@ -819,6 +833,8 @@ export type OutgoingPaymentResponse = {
 };
 
 export enum OutgoingPaymentState {
+  /** Payment cancelled */
+  Cancelled = 'CANCELLED',
   /** Successful completion */
   Completed = 'COMPLETED',
   /** Payment failed */
@@ -1488,6 +1504,7 @@ export type ResolversTypes = {
   AssetsConnection: ResolverTypeWrapper<Partial<AssetsConnection>>;
   BasePayment: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['BasePayment']>;
   Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']['output']>>;
+  CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1607,6 +1624,7 @@ export type ResolversParentTypes = {
   AssetsConnection: Partial<AssetsConnection>;
   BasePayment: ResolversInterfaceTypes<ResolversParentTypes>['BasePayment'];
   Boolean: Partial<Scalars['Boolean']['output']>;
+  CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -1899,6 +1917,7 @@ export type ModelResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  cancelOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCancelOutgoingPaymentArgs, 'input'>>;
   createAsset?: Resolver<ResolversTypes['AssetMutationResponse'], ParentType, ContextType, RequireFields<MutationCreateAssetArgs, 'input'>>;
   createAssetLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationCreateAssetLiquidityWithdrawalArgs, 'input'>>;
   createIncomingPayment?: Resolver<ResolversTypes['IncomingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCreateIncomingPaymentArgs, 'input'>>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -105,7 +105,7 @@ export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
   /** Reason why this Outgoing Payment has been cancelled */
-  reason: Scalars['String']['input'];
+  reason?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateAssetInput = {

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -104,7 +104,7 @@ export type BasePayment = {
 export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
-  /** Reason why this Outgoing Payment has been cancelled */
+  /** Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -101,6 +101,13 @@ export type BasePayment = {
   walletAddressId: Scalars['ID']['output'];
 };
 
+export type CancelOutgoingPaymentInput = {
+  /** Outgoing payment id */
+  id: Scalars['ID']['input'];
+  /** Reason why this Outgoing Payment has been cancelled */
+  reason: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217), e.g. `USD` */
   code: Scalars['String']['input'];
@@ -551,6 +558,8 @@ export type Model = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  /** Cancel Outgoing Payment */
+  cancelOutgoingPayment: OutgoingPaymentResponse;
   /** Create an asset */
   createAsset: AssetMutationResponse;
   /** Withdraw asset liquidity */
@@ -615,6 +624,11 @@ export type Mutation = {
   withdrawIncomingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
   /** Withdraw outgoing payment liquidity */
   withdrawOutgoingPaymentLiquidity?: Maybe<LiquidityMutationResponse>;
+};
+
+
+export type MutationCancelOutgoingPaymentArgs = {
+  input: CancelOutgoingPaymentInput;
 };
 
 
@@ -819,6 +833,8 @@ export type OutgoingPaymentResponse = {
 };
 
 export enum OutgoingPaymentState {
+  /** Payment cancelled */
+  Cancelled = 'CANCELLED',
   /** Successful completion */
   Completed = 'COMPLETED',
   /** Payment failed */
@@ -1488,6 +1504,7 @@ export type ResolversTypes = {
   AssetsConnection: ResolverTypeWrapper<Partial<AssetsConnection>>;
   BasePayment: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['BasePayment']>;
   Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']['output']>>;
+  CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1607,6 +1624,7 @@ export type ResolversParentTypes = {
   AssetsConnection: Partial<AssetsConnection>;
   BasePayment: ResolversInterfaceTypes<ResolversParentTypes>['BasePayment'];
   Boolean: Partial<Scalars['Boolean']['output']>;
+  CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -1899,6 +1917,7 @@ export type ModelResolvers<ContextType = any, ParentType extends ResolversParent
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  cancelOutgoingPayment?: Resolver<ResolversTypes['OutgoingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCancelOutgoingPaymentArgs, 'input'>>;
   createAsset?: Resolver<ResolversTypes['AssetMutationResponse'], ParentType, ContextType, RequireFields<MutationCreateAssetArgs, 'input'>>;
   createAssetLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationCreateAssetLiquidityWithdrawalArgs, 'input'>>;
   createIncomingPayment?: Resolver<ResolversTypes['IncomingPaymentResponse'], ParentType, ContextType, RequireFields<MutationCreateIncomingPaymentArgs, 'input'>>;

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -105,7 +105,7 @@ export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
   /** Reason why this Outgoing Payment has been cancelled */
-  reason: Scalars['String']['input'];
+  reason?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateAssetInput = {

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -104,7 +104,7 @@ export type BasePayment = {
 export type CancelOutgoingPaymentInput = {
   /** Outgoing payment id */
   id: Scalars['ID']['input'];
-  /** Reason why this Outgoing Payment has been cancelled */
+  /** Reason why this Outgoing Payment has been cancelled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 


### PR DESCRIPTION
- feat(localenv): cancel outgoing payment on created webhook
- feat(graphql): cancel outgoing payment api
- feat(outgoing-payment): cancel outgoing payment service implementation

<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
Add an API for canceling outgoing payment. This can be possible only if outgoing payment is in funding state. Normally, this API would be called by ASE to cancel the outgoing payment. It can be canceled due too numerous reasons like account not having enough balance or like his KYC is not valid, etc. ASE can also specify cancelation reason, and it will be written in meta under cancellationReason key. 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
fixes #2688

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Documentation added
- [x] Make sure that all checks pass
- [x] Bruno collection updated
