### PR TITLE
chore(workflows): bump prerequisite timeout from 1 to 5 minutes

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   prerequisite:
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/workflows/rafiki/env-setup


### PR DESCRIPTION
This will just update timeout value for prerequisite job in workflow.
I noticed that this job is sometime failing due to running just about 1 min so 5 minutes should be more than enough to not fail anymore
