### PR TITLE
refactor: standardize default a link styling

### DIFF
--- a/packages/frontend/app/routes/payments.incoming.$incomingPaymentId.tsx
+++ b/packages/frontend/app/routes/payments.incoming.$incomingPaymentId.tsx
@@ -83,7 +83,7 @@ export default function ViewIncomingPaymentPage() {
                 <p className='font-medium'>Wallet Address ID </p>
                 <Link
                   to={`/wallet-addresses/${incomingPayment.walletAddressId}`}
-                  className='mt-1 underline text-blue-600 hover:text-blue-800 visited:text-purple-600'
+                  className='default-link'
                 >
                   {incomingPayment.walletAddressId}
                 </Link>

--- a/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.tsx
+++ b/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.tsx
@@ -86,7 +86,7 @@ export default function ViewOutgoingPaymentPage() {
                 <p className='font-medium'>Wallet Address ID </p>
                 <Link
                   to={`/wallet-addresses/${outgoingPayment.walletAddressId}`}
-                  className='mt-1 underline text-blue-600 hover:text-blue-800 visited:text-purple-600'
+                  className='default-link'
                 >
                   {outgoingPayment.walletAddressId}
                 </Link>
@@ -99,10 +99,7 @@ export default function ViewOutgoingPaymentPage() {
               </div>
               <div>
                 <p className='font-medium'>Receiver</p>
-                <Link
-                  className='underline text-blue-600 hover:text-blue-800 visited:text-purple-600'
-                  to={outgoingPayment.receiver}
-                >
+                <Link className='default-link' to={outgoingPayment.receiver}>
                   {outgoingPayment.receiver}
                 </Link>
               </div>

--- a/packages/frontend/app/routes/peers.$peerId.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.tsx
@@ -125,7 +125,7 @@ export default function ViewPeerPage() {
                       <>
                         The name of the{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/peering/'
                         >
                           peer
@@ -147,7 +147,7 @@ export default function ViewPeerPage() {
                       <>
                         {"The peer's "}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://interledger.org/developers/rfcs/ilp-addresses/'
                         >
                           address on the Interledger network.
@@ -168,7 +168,7 @@ export default function ViewPeerPage() {
                       <>
                         The maximum amount of value that can be sent in a single{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://interledger.org/developers/rfcs/stream-protocol/#35-packets-and-frames'
                         >
                           Interledger STREAM Packet
@@ -213,7 +213,7 @@ export default function ViewPeerPage() {
                       <>
                         List of valid tokens to accept when receiving{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/connector/#incoming-http'
                         >
                           incoming ILP packets from the peer.
@@ -232,7 +232,7 @@ export default function ViewPeerPage() {
                       <>
                         List of valid tokens to present when sending{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/connector/#outgoing-http'
                         >
                           outgoing ILP packets to the peer.
@@ -251,7 +251,7 @@ export default function ViewPeerPage() {
                       <>
                         Endpoint on the peer to which{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/connector/#outgoing-http'
                         >
                           outgoing ILP packets

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -63,7 +63,7 @@ export default function CreatePeerPage() {
                       <>
                         The name of the{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/peering/'
                         >
                           peer
@@ -82,7 +82,7 @@ export default function CreatePeerPage() {
                       <>
                         {"The peer's "}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://interledger.org/developers/rfcs/ilp-addresses/'
                         >
                           address on the Interledger network.
@@ -99,7 +99,7 @@ export default function CreatePeerPage() {
                       <>
                         The maximum amount of value that can be sent in a single{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://interledger.org/developers/rfcs/stream-protocol/#35-packets-and-frames'
                         >
                           Interledger STREAM Packet
@@ -128,7 +128,7 @@ export default function CreatePeerPage() {
                       <>
                         List of valid tokens to accept when receiving{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/connector/#incoming-http'
                         >
                           incoming ILP packets from the peer.
@@ -146,7 +146,7 @@ export default function CreatePeerPage() {
                       <>
                         List of valid tokens to present when sending{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/connector/#outgoing-http'
                         >
                           outgoing ILP packets to the peer.
@@ -164,7 +164,7 @@ export default function CreatePeerPage() {
                       <>
                         Endpoint on the peer to which{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/interledger-protocol/connector/#outgoing-http'
                         >
                           outgoing ILP packets
@@ -197,7 +197,7 @@ export default function CreatePeerPage() {
                       <>
                         The type of{' '}
                         <a
-                          className='tooltip'
+                          className='default-link'
                           href='https://rafiki.dev/concepts/asset/'
                         >
                           asset

--- a/packages/frontend/app/styles/tailwind.css
+++ b/packages/frontend/app/styles/tailwind.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-a.tooltip {
+a.default-link {
   color: revert;
   text-decoration: revert;
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- renames `tooltip` css class to `default-link`
- applies to pre-existing `a` elements that used a different method to achieve default(ish) styling

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

Suggestion for PR https://github.com/interledger/rafiki/pull/2716

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated
