### PR TITLE
fix: put additional properties resolver under wallet address

### DIFF
--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
@@ -29,6 +29,11 @@ body:graphql {
           scale
           withdrawalThreshold
         }
+        additionalProperties {
+          key
+          value
+          visibleInOpenPayments
+        }
       }
     }
   }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Get Wallet Address.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Get Wallet Address.bru
@@ -66,6 +66,11 @@ body:graphql {
             }
           }
           status
+          additionalProperties {
+            key
+            value
+            visibleInOpenPayments
+          }
       }
   }
 }

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -1306,7 +1306,7 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
-  /** List additional properties associated with the wallet address. */
+  /** List additional properties associated with this wallet address. */
   additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -26,11 +26,6 @@ export type AdditionalProperty = {
   visibleInOpenPayments: Scalars['Boolean']['output'];
 };
 
-export type AdditionalPropertyConnection = {
-  __typename?: 'AdditionalPropertyConnection';
-  properties: Array<AdditionalProperty>;
-};
-
 export type AdditionalPropertyInput = {
   key: Scalars['String']['input'];
   value: Scalars['String']['input'];
@@ -1007,8 +1002,6 @@ export type PostLiquidityWithdrawalInput = {
 
 export type Query = {
   __typename?: 'Query';
-  /** Get the list of of additional properties associated with [walletAddressId] wallet address. */
-  additionalProperties?: Maybe<AdditionalPropertyConnection>;
   /** Fetch an asset */
   asset?: Maybe<Asset>;
   /** Fetch a page of assets. */
@@ -1033,11 +1026,6 @@ export type Query = {
   walletAddresses: WalletAddressesConnection;
   /** Fetch a page of webhook events */
   webhookEvents: WebhookEventsConnection;
-};
-
-
-export type QueryAdditionalPropertiesArgs = {
-  walletAddressId: Scalars['String']['input'];
 };
 
 
@@ -1318,6 +1306,8 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
+  /** List additional properties associated with the wallet address. */
+  additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -1555,7 +1545,6 @@ export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AdditionalProperty: ResolverTypeWrapper<Partial<AdditionalProperty>>;
-  AdditionalPropertyConnection: ResolverTypeWrapper<Partial<AdditionalPropertyConnection>>;
   AdditionalPropertyInput: ResolverTypeWrapper<Partial<AdditionalPropertyInput>>;
   Alg: ResolverTypeWrapper<Partial<Alg>>;
   Amount: ResolverTypeWrapper<Partial<Amount>>;
@@ -1681,7 +1670,6 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   AdditionalProperty: Partial<AdditionalProperty>;
-  AdditionalPropertyConnection: Partial<AdditionalPropertyConnection>;
   AdditionalPropertyInput: Partial<AdditionalPropertyInput>;
   Amount: Partial<Amount>;
   AmountInput: Partial<AmountInput>;
@@ -1798,11 +1786,6 @@ export type AdditionalPropertyResolvers<ContextType = any, ParentType extends Re
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   visibleInOpenPayments?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type AdditionalPropertyConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AdditionalPropertyConnection'] = ResolversParentTypes['AdditionalPropertyConnection']> = {
-  properties?: Resolver<Array<ResolversTypes['AdditionalProperty']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2141,7 +2124,6 @@ export type PeersConnectionResolvers<ContextType = any, ParentType extends Resol
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  additionalProperties?: Resolver<Maybe<ResolversTypes['AdditionalPropertyConnection']>, ParentType, ContextType, RequireFields<QueryAdditionalPropertiesArgs, 'walletAddressId'>>;
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType, RequireFields<QueryAssetArgs, 'id'>>;
   assets?: Resolver<ResolversTypes['AssetsConnection'], ParentType, ContextType, Partial<QueryAssetsArgs>>;
   incomingPayment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType, RequireFields<QueryIncomingPaymentArgs, 'id'>>;
@@ -2260,6 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
+  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2345,7 +2328,6 @@ export type WebhookEventsEdgeResolvers<ContextType = any, ParentType extends Res
 
 export type Resolvers<ContextType = any> = {
   AdditionalProperty?: AdditionalPropertyResolvers<ContextType>;
-  AdditionalPropertyConnection?: AdditionalPropertyConnectionResolvers<ContextType>;
   Amount?: AmountResolvers<ContextType>;
   Asset?: AssetResolvers<ContextType>;
   AssetEdge?: AssetEdgeResolvers<ContextType>;

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -1307,7 +1307,7 @@ export type VoidLiquidityWithdrawalInput = {
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** List additional properties associated with this wallet address. */
-  additionalProperties: Array<Maybe<AdditionalProperty>>;
+  additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -2242,7 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
-  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
+  additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -374,14 +374,14 @@ export class App {
       }
     )
 
-    // if (this.config.apiSecret) {
-    //   koa.use(async (ctx, next: Koa.Next): Promise<void> => {
-    //     if (!verifyApiSignature(ctx, this.config)) {
-    //       ctx.throw(401, 'Unauthorized')
-    //     }
-    //     return next()
-    //   })
-    // }
+    if (this.config.apiSecret) {
+      koa.use(async (ctx, next: Koa.Next): Promise<void> => {
+        if (!verifyApiSignature(ctx, this.config)) {
+          ctx.throw(401, 'Unauthorized')
+        }
+        return next()
+      })
+    }
 
     koa.use(
       koaMiddleware(this.apolloServer, {

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -374,14 +374,14 @@ export class App {
       }
     )
 
-    if (this.config.apiSecret) {
-      koa.use(async (ctx, next: Koa.Next): Promise<void> => {
-        if (!verifyApiSignature(ctx, this.config)) {
-          ctx.throw(401, 'Unauthorized')
-        }
-        return next()
-      })
-    }
+    // if (this.config.apiSecret) {
+    //   koa.use(async (ctx, next: Koa.Next): Promise<void> => {
+    //     if (!verifyApiSignature(ctx, this.config)) {
+    //       ctx.throw(401, 'Unauthorized')
+    //     }
+    //     return next()
+    //   })
+    // }
 
     koa.use(
       koaMiddleware(this.apolloServer, {

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -8400,16 +8400,12 @@
             "description": "List additional properties associated with this wallet address.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AdditionalProperty",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "AdditionalProperty",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -8397,7 +8397,7 @@
         "fields": [
           {
             "name": "additionalProperties",
-            "description": "List additional properties associated with the wallet address.",
+            "description": "List additional properties associated with this wallet address.",
             "args": [],
             "type": {
               "kind": "NON_NULL",

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -68,41 +68,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "AdditionalPropertyConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "properties",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AdditionalProperty",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "AdditionalPropertyInput",
         "description": null,
@@ -6397,35 +6362,6 @@
         "description": null,
         "fields": [
           {
-            "name": "additionalProperties",
-            "description": "Get the list of of additional properties associated with [walletAddressId] wallet address.",
-            "args": [
-              {
-                "name": "walletAddressId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "AdditionalPropertyConnection",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "asset",
             "description": "Fetch an asset",
             "args": [
@@ -8459,6 +8395,26 @@
         "name": "WalletAddress",
         "description": null,
         "fields": [
+          {
+            "name": "additionalProperties",
+            "description": "List additional properties associated with the wallet address.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AdditionalProperty",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "asset",
             "description": "Asset of the wallet address",

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -1306,7 +1306,7 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
-  /** List additional properties associated with the wallet address. */
+  /** List additional properties associated with this wallet address. */
   additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -26,11 +26,6 @@ export type AdditionalProperty = {
   visibleInOpenPayments: Scalars['Boolean']['output'];
 };
 
-export type AdditionalPropertyConnection = {
-  __typename?: 'AdditionalPropertyConnection';
-  properties: Array<AdditionalProperty>;
-};
-
 export type AdditionalPropertyInput = {
   key: Scalars['String']['input'];
   value: Scalars['String']['input'];
@@ -1007,8 +1002,6 @@ export type PostLiquidityWithdrawalInput = {
 
 export type Query = {
   __typename?: 'Query';
-  /** Get the list of of additional properties associated with [walletAddressId] wallet address. */
-  additionalProperties?: Maybe<AdditionalPropertyConnection>;
   /** Fetch an asset */
   asset?: Maybe<Asset>;
   /** Fetch a page of assets. */
@@ -1033,11 +1026,6 @@ export type Query = {
   walletAddresses: WalletAddressesConnection;
   /** Fetch a page of webhook events */
   webhookEvents: WebhookEventsConnection;
-};
-
-
-export type QueryAdditionalPropertiesArgs = {
-  walletAddressId: Scalars['String']['input'];
 };
 
 
@@ -1318,6 +1306,8 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
+  /** List additional properties associated with the wallet address. */
+  additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -1555,7 +1545,6 @@ export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AdditionalProperty: ResolverTypeWrapper<Partial<AdditionalProperty>>;
-  AdditionalPropertyConnection: ResolverTypeWrapper<Partial<AdditionalPropertyConnection>>;
   AdditionalPropertyInput: ResolverTypeWrapper<Partial<AdditionalPropertyInput>>;
   Alg: ResolverTypeWrapper<Partial<Alg>>;
   Amount: ResolverTypeWrapper<Partial<Amount>>;
@@ -1681,7 +1670,6 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   AdditionalProperty: Partial<AdditionalProperty>;
-  AdditionalPropertyConnection: Partial<AdditionalPropertyConnection>;
   AdditionalPropertyInput: Partial<AdditionalPropertyInput>;
   Amount: Partial<Amount>;
   AmountInput: Partial<AmountInput>;
@@ -1798,11 +1786,6 @@ export type AdditionalPropertyResolvers<ContextType = any, ParentType extends Re
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   visibleInOpenPayments?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type AdditionalPropertyConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AdditionalPropertyConnection'] = ResolversParentTypes['AdditionalPropertyConnection']> = {
-  properties?: Resolver<Array<ResolversTypes['AdditionalProperty']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2141,7 +2124,6 @@ export type PeersConnectionResolvers<ContextType = any, ParentType extends Resol
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  additionalProperties?: Resolver<Maybe<ResolversTypes['AdditionalPropertyConnection']>, ParentType, ContextType, RequireFields<QueryAdditionalPropertiesArgs, 'walletAddressId'>>;
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType, RequireFields<QueryAssetArgs, 'id'>>;
   assets?: Resolver<ResolversTypes['AssetsConnection'], ParentType, ContextType, Partial<QueryAssetsArgs>>;
   incomingPayment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType, RequireFields<QueryIncomingPaymentArgs, 'id'>>;
@@ -2260,6 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
+  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2345,7 +2328,6 @@ export type WebhookEventsEdgeResolvers<ContextType = any, ParentType extends Res
 
 export type Resolvers<ContextType = any> = {
   AdditionalProperty?: AdditionalPropertyResolvers<ContextType>;
-  AdditionalPropertyConnection?: AdditionalPropertyConnectionResolvers<ContextType>;
   Amount?: AmountResolvers<ContextType>;
   Asset?: AssetResolvers<ContextType>;
   AssetEdge?: AssetEdgeResolvers<ContextType>;

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -1307,7 +1307,7 @@ export type VoidLiquidityWithdrawalInput = {
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** List additional properties associated with this wallet address. */
-  additionalProperties: Array<Maybe<AdditionalProperty>>;
+  additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -2242,7 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
-  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
+  additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -89,15 +89,15 @@ export const resolvers: Resolvers = {
     quote: getQuote,
     webhookEvents: getWebhookEvents,
     payments: getCombinedPayments,
-    receiver: getReceiver,
-    additionalProperties: getWalletAddressAdditionalProperties
+    receiver: getReceiver
   },
   WalletAddress: {
     liquidity: getWalletAddressLiquidity,
     incomingPayments: getWalletAddressIncomingPayments,
     outgoingPayments: getWalletAddressOutgoingPayments,
     quotes: getWalletAddressQuotes,
-    walletAddressKeys: getWalletAddressKeys
+    walletAddressKeys: getWalletAddressKeys,
+    additionalProperties: getWalletAddressAdditionalProperties
   },
   IncomingPayment: {
     liquidity: getIncomingPaymentLiquidity

--- a/packages/backend/src/graphql/resolvers/walletAddressAdditionalProperties.ts
+++ b/packages/backend/src/graphql/resolvers/walletAddressAdditionalProperties.ts
@@ -1,33 +1,31 @@
 import {
   ResolversTypes,
   AdditionalProperty,
-  QueryResolvers
+  WalletAddressResolvers
 } from '../generated/graphql'
 import { ApolloContext } from '../../app'
 import { WalletAddressAdditionalProperty } from '../../open_payments/wallet_address/additional_property/model'
 
-export const getWalletAddressAdditionalProperties: QueryResolvers<ApolloContext>['additionalProperties'] =
+export const getWalletAddressAdditionalProperties: WalletAddressResolvers<ApolloContext>['additionalProperties'] =
   async (
     parent,
     args,
     ctx
-  ): Promise<ResolversTypes['AdditionalPropertyConnection']> => {
-    if (!args.walletAddressId) {
+  ): Promise<Array<ResolversTypes['AdditionalProperty']>> => {
+    const { id: walletAddressId } = parent
+
+    if (!walletAddressId) {
       throw new Error('missing wallet address id')
     }
     const walletAddressService = await ctx.container.use('walletAddressService')
     const additionalProperties =
       await walletAddressService.getAdditionalProperties(
-        args.walletAddressId,
+        walletAddressId,
         false // Include all Additional Properties
       )
-    if (!additionalProperties) return { properties: [] }
+    if (!additionalProperties) return []
 
-    return {
-      properties: additionalProperties.map((itm) =>
-        additionalPropertyToGraphql(itm)
-      )
-    }
+    return additionalProperties.map((itm) => additionalPropertyToGraphql(itm))
   }
 
 export const additionalPropertyToGraphql = (

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -31,8 +31,7 @@ import {
   WalletAddress,
   WalletAddressStatus,
   UpdateWalletAddressMutationResponse,
-  WalletAddressesConnection,
-  AdditionalPropertyConnection
+  WalletAddressesConnection
 } from '../generated/graphql'
 import { getPageTests } from './page.test'
 import { WalletAddressAdditionalProperty } from '../../open_payments/wallet_address/additional_property/model'
@@ -479,6 +478,11 @@ describe('Wallet Address Resolvers', (): void => {
                   }
                   url
                   publicName
+                  additionalProperties {
+                    key
+                    value
+                    visibleInOpenPayments
+                  }
                 }
               }
             `,
@@ -504,47 +508,15 @@ describe('Wallet Address Resolvers', (): void => {
             scale: walletAddress.asset.scale
           },
           url: walletAddress.url,
-          publicName: publicName ?? null
-        })
-
-        // Now fetch with additional properties:
-        const queryAddProps = await appContainer.apolloClient
-          .query({
-            query: gql`
-              query Query($walletAddressId: String!) {
-                additionalProperties(walletAddressId: $walletAddressId) {
-                  properties {
-                    key
-                    value
-                    visibleInOpenPayments
-                  }
-                }
-              }
-            `,
-            variables: {
-              walletAddressId: walletAddress.id
+          publicName: publicName ?? null,
+          additionalProperties: [
+            {
+              __typename: 'AdditionalProperty',
+              key: walletProp.fieldKey,
+              value: walletProp.fieldValue,
+              visibleInOpenPayments: walletProp.visibleInOpenPayments
             }
-          })
-          .then((query): AdditionalPropertyConnection => {
-            if (query.data) {
-              return query.data
-            } else {
-              throw new Error('Data was empty')
-            }
-          })
-
-        expect(queryAddProps).toEqual({
-          additionalProperties: {
-            __typename: 'AdditionalPropertyConnection',
-            properties: [
-              {
-                __typename: 'AdditionalProperty',
-                key: walletProp.fieldKey,
-                value: walletProp.fieldValue,
-                visibleInOpenPayments: walletProp.visibleInOpenPayments
-              }
-            ]
-          }
+          ]
         })
       }
     )

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -697,7 +697,7 @@ type WalletAddress implements Model {
   ): WalletAddressKeyConnection
 
   "List additional properties associated with this wallet address."
-  additionalProperties: [AdditionalProperty]!
+  additionalProperties: [AdditionalProperty]
 }
 
 type AdditionalProperty {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -93,9 +93,6 @@ type Query {
 
   "Get an local or remote Open Payments Incoming Payment. The receiver has a wallet address on either this or another Open Payments resource server."
   receiver(id: String!): Receiver
-
-  "Get the list of of additional properties associated with [walletAddressId] wallet address."
-  additionalProperties(walletAddressId: String!): AdditionalPropertyConnection
 }
 
 type Mutation {
@@ -698,10 +695,9 @@ type WalletAddress implements Model {
     "Ascending or descending order of creation."
     sortOrder: SortOrder
   ): WalletAddressKeyConnection
-}
 
-type AdditionalPropertyConnection {
-  properties: [AdditionalProperty!]!
+  "List additional properties associated with this wallet address."
+  additionalProperties: [AdditionalProperty]!
 }
 
 type AdditionalProperty {

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -1306,7 +1306,7 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
-  /** List additional properties associated with the wallet address. */
+  /** List additional properties associated with this wallet address. */
   additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -26,11 +26,6 @@ export type AdditionalProperty = {
   visibleInOpenPayments: Scalars['Boolean']['output'];
 };
 
-export type AdditionalPropertyConnection = {
-  __typename?: 'AdditionalPropertyConnection';
-  properties: Array<AdditionalProperty>;
-};
-
 export type AdditionalPropertyInput = {
   key: Scalars['String']['input'];
   value: Scalars['String']['input'];
@@ -1007,8 +1002,6 @@ export type PostLiquidityWithdrawalInput = {
 
 export type Query = {
   __typename?: 'Query';
-  /** Get the list of of additional properties associated with [walletAddressId] wallet address. */
-  additionalProperties?: Maybe<AdditionalPropertyConnection>;
   /** Fetch an asset */
   asset?: Maybe<Asset>;
   /** Fetch a page of assets. */
@@ -1033,11 +1026,6 @@ export type Query = {
   walletAddresses: WalletAddressesConnection;
   /** Fetch a page of webhook events */
   webhookEvents: WebhookEventsConnection;
-};
-
-
-export type QueryAdditionalPropertiesArgs = {
-  walletAddressId: Scalars['String']['input'];
 };
 
 
@@ -1318,6 +1306,8 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
+  /** List additional properties associated with the wallet address. */
+  additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -1555,7 +1545,6 @@ export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AdditionalProperty: ResolverTypeWrapper<Partial<AdditionalProperty>>;
-  AdditionalPropertyConnection: ResolverTypeWrapper<Partial<AdditionalPropertyConnection>>;
   AdditionalPropertyInput: ResolverTypeWrapper<Partial<AdditionalPropertyInput>>;
   Alg: ResolverTypeWrapper<Partial<Alg>>;
   Amount: ResolverTypeWrapper<Partial<Amount>>;
@@ -1681,7 +1670,6 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   AdditionalProperty: Partial<AdditionalProperty>;
-  AdditionalPropertyConnection: Partial<AdditionalPropertyConnection>;
   AdditionalPropertyInput: Partial<AdditionalPropertyInput>;
   Amount: Partial<Amount>;
   AmountInput: Partial<AmountInput>;
@@ -1798,11 +1786,6 @@ export type AdditionalPropertyResolvers<ContextType = any, ParentType extends Re
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   visibleInOpenPayments?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type AdditionalPropertyConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AdditionalPropertyConnection'] = ResolversParentTypes['AdditionalPropertyConnection']> = {
-  properties?: Resolver<Array<ResolversTypes['AdditionalProperty']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2141,7 +2124,6 @@ export type PeersConnectionResolvers<ContextType = any, ParentType extends Resol
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  additionalProperties?: Resolver<Maybe<ResolversTypes['AdditionalPropertyConnection']>, ParentType, ContextType, RequireFields<QueryAdditionalPropertiesArgs, 'walletAddressId'>>;
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType, RequireFields<QueryAssetArgs, 'id'>>;
   assets?: Resolver<ResolversTypes['AssetsConnection'], ParentType, ContextType, Partial<QueryAssetsArgs>>;
   incomingPayment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType, RequireFields<QueryIncomingPaymentArgs, 'id'>>;
@@ -2260,6 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
+  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2345,7 +2328,6 @@ export type WebhookEventsEdgeResolvers<ContextType = any, ParentType extends Res
 
 export type Resolvers<ContextType = any> = {
   AdditionalProperty?: AdditionalPropertyResolvers<ContextType>;
-  AdditionalPropertyConnection?: AdditionalPropertyConnectionResolvers<ContextType>;
   Amount?: AmountResolvers<ContextType>;
   Asset?: AssetResolvers<ContextType>;
   AssetEdge?: AssetEdgeResolvers<ContextType>;

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -1307,7 +1307,7 @@ export type VoidLiquidityWithdrawalInput = {
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** List additional properties associated with this wallet address. */
-  additionalProperties: Array<Maybe<AdditionalProperty>>;
+  additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -2242,7 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
-  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
+  additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -1306,7 +1306,7 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
-  /** List additional properties associated with the wallet address. */
+  /** List additional properties associated with this wallet address. */
   additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -26,11 +26,6 @@ export type AdditionalProperty = {
   visibleInOpenPayments: Scalars['Boolean']['output'];
 };
 
-export type AdditionalPropertyConnection = {
-  __typename?: 'AdditionalPropertyConnection';
-  properties: Array<AdditionalProperty>;
-};
-
 export type AdditionalPropertyInput = {
   key: Scalars['String']['input'];
   value: Scalars['String']['input'];
@@ -1007,8 +1002,6 @@ export type PostLiquidityWithdrawalInput = {
 
 export type Query = {
   __typename?: 'Query';
-  /** Get the list of of additional properties associated with [walletAddressId] wallet address. */
-  additionalProperties?: Maybe<AdditionalPropertyConnection>;
   /** Fetch an asset */
   asset?: Maybe<Asset>;
   /** Fetch a page of assets. */
@@ -1033,11 +1026,6 @@ export type Query = {
   walletAddresses: WalletAddressesConnection;
   /** Fetch a page of webhook events */
   webhookEvents: WebhookEventsConnection;
-};
-
-
-export type QueryAdditionalPropertiesArgs = {
-  walletAddressId: Scalars['String']['input'];
 };
 
 
@@ -1318,6 +1306,8 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
+  /** List additional properties associated with the wallet address. */
+  additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -1555,7 +1545,6 @@ export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AdditionalProperty: ResolverTypeWrapper<Partial<AdditionalProperty>>;
-  AdditionalPropertyConnection: ResolverTypeWrapper<Partial<AdditionalPropertyConnection>>;
   AdditionalPropertyInput: ResolverTypeWrapper<Partial<AdditionalPropertyInput>>;
   Alg: ResolverTypeWrapper<Partial<Alg>>;
   Amount: ResolverTypeWrapper<Partial<Amount>>;
@@ -1681,7 +1670,6 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   AdditionalProperty: Partial<AdditionalProperty>;
-  AdditionalPropertyConnection: Partial<AdditionalPropertyConnection>;
   AdditionalPropertyInput: Partial<AdditionalPropertyInput>;
   Amount: Partial<Amount>;
   AmountInput: Partial<AmountInput>;
@@ -1798,11 +1786,6 @@ export type AdditionalPropertyResolvers<ContextType = any, ParentType extends Re
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   visibleInOpenPayments?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type AdditionalPropertyConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AdditionalPropertyConnection'] = ResolversParentTypes['AdditionalPropertyConnection']> = {
-  properties?: Resolver<Array<ResolversTypes['AdditionalProperty']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2141,7 +2124,6 @@ export type PeersConnectionResolvers<ContextType = any, ParentType extends Resol
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  additionalProperties?: Resolver<Maybe<ResolversTypes['AdditionalPropertyConnection']>, ParentType, ContextType, RequireFields<QueryAdditionalPropertiesArgs, 'walletAddressId'>>;
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType, RequireFields<QueryAssetArgs, 'id'>>;
   assets?: Resolver<ResolversTypes['AssetsConnection'], ParentType, ContextType, Partial<QueryAssetsArgs>>;
   incomingPayment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType, RequireFields<QueryIncomingPaymentArgs, 'id'>>;
@@ -2260,6 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
+  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2345,7 +2328,6 @@ export type WebhookEventsEdgeResolvers<ContextType = any, ParentType extends Res
 
 export type Resolvers<ContextType = any> = {
   AdditionalProperty?: AdditionalPropertyResolvers<ContextType>;
-  AdditionalPropertyConnection?: AdditionalPropertyConnectionResolvers<ContextType>;
   Amount?: AmountResolvers<ContextType>;
   Asset?: AssetResolvers<ContextType>;
   AssetEdge?: AssetEdgeResolvers<ContextType>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -1307,7 +1307,7 @@ export type VoidLiquidityWithdrawalInput = {
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** List additional properties associated with this wallet address. */
-  additionalProperties: Array<Maybe<AdditionalProperty>>;
+  additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -2242,7 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
-  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
+  additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -1306,7 +1306,7 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
-  /** List additional properties associated with the wallet address. */
+  /** List additional properties associated with this wallet address. */
   additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -26,11 +26,6 @@ export type AdditionalProperty = {
   visibleInOpenPayments: Scalars['Boolean']['output'];
 };
 
-export type AdditionalPropertyConnection = {
-  __typename?: 'AdditionalPropertyConnection';
-  properties: Array<AdditionalProperty>;
-};
-
 export type AdditionalPropertyInput = {
   key: Scalars['String']['input'];
   value: Scalars['String']['input'];
@@ -1007,8 +1002,6 @@ export type PostLiquidityWithdrawalInput = {
 
 export type Query = {
   __typename?: 'Query';
-  /** Get the list of of additional properties associated with [walletAddressId] wallet address. */
-  additionalProperties?: Maybe<AdditionalPropertyConnection>;
   /** Fetch an asset */
   asset?: Maybe<Asset>;
   /** Fetch a page of assets. */
@@ -1033,11 +1026,6 @@ export type Query = {
   walletAddresses: WalletAddressesConnection;
   /** Fetch a page of webhook events */
   webhookEvents: WebhookEventsConnection;
-};
-
-
-export type QueryAdditionalPropertiesArgs = {
-  walletAddressId: Scalars['String']['input'];
 };
 
 
@@ -1318,6 +1306,8 @@ export type VoidLiquidityWithdrawalInput = {
 
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
+  /** List additional properties associated with the wallet address. */
+  additionalProperties: Array<Maybe<AdditionalProperty>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -1555,7 +1545,6 @@ export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   AdditionalProperty: ResolverTypeWrapper<Partial<AdditionalProperty>>;
-  AdditionalPropertyConnection: ResolverTypeWrapper<Partial<AdditionalPropertyConnection>>;
   AdditionalPropertyInput: ResolverTypeWrapper<Partial<AdditionalPropertyInput>>;
   Alg: ResolverTypeWrapper<Partial<Alg>>;
   Amount: ResolverTypeWrapper<Partial<Amount>>;
@@ -1681,7 +1670,6 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   AdditionalProperty: Partial<AdditionalProperty>;
-  AdditionalPropertyConnection: Partial<AdditionalPropertyConnection>;
   AdditionalPropertyInput: Partial<AdditionalPropertyInput>;
   Amount: Partial<Amount>;
   AmountInput: Partial<AmountInput>;
@@ -1798,11 +1786,6 @@ export type AdditionalPropertyResolvers<ContextType = any, ParentType extends Re
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   visibleInOpenPayments?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type AdditionalPropertyConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['AdditionalPropertyConnection'] = ResolversParentTypes['AdditionalPropertyConnection']> = {
-  properties?: Resolver<Array<ResolversTypes['AdditionalProperty']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2141,7 +2124,6 @@ export type PeersConnectionResolvers<ContextType = any, ParentType extends Resol
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  additionalProperties?: Resolver<Maybe<ResolversTypes['AdditionalPropertyConnection']>, ParentType, ContextType, RequireFields<QueryAdditionalPropertiesArgs, 'walletAddressId'>>;
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType, RequireFields<QueryAssetArgs, 'id'>>;
   assets?: Resolver<ResolversTypes['AssetsConnection'], ParentType, ContextType, Partial<QueryAssetsArgs>>;
   incomingPayment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType, RequireFields<QueryIncomingPaymentArgs, 'id'>>;
@@ -2260,6 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
+  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2345,7 +2328,6 @@ export type WebhookEventsEdgeResolvers<ContextType = any, ParentType extends Res
 
 export type Resolvers<ContextType = any> = {
   AdditionalProperty?: AdditionalPropertyResolvers<ContextType>;
-  AdditionalPropertyConnection?: AdditionalPropertyConnectionResolvers<ContextType>;
   Amount?: AmountResolvers<ContextType>;
   Asset?: AssetResolvers<ContextType>;
   AssetEdge?: AssetEdgeResolvers<ContextType>;

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -1307,7 +1307,7 @@ export type VoidLiquidityWithdrawalInput = {
 export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** List additional properties associated with this wallet address. */
-  additionalProperties: Array<Maybe<AdditionalProperty>>;
+  additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
   /** Asset of the wallet address */
   asset: Asset;
   /** Date-time of creation */
@@ -2242,7 +2242,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 };
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
-  additionalProperties?: Resolver<Array<Maybe<ResolversTypes['AdditionalProperty']>>, ParentType, ContextType>;
+  additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;


### PR DESCRIPTION
Moves the `additionalProperties` resolver under the `WalletAddress` resolver. This allows us to query this field on wallet address as opposed to calling it separately with the wallet address id, but keeps the fetching outside of the wallet address resolver/service method itself. This means we can specify it anywhere the wallet address is returned (the get wallet address query, create wallet address mutation, etc.)

See test and bruno collection changes to see how its called.

To be merged into https://github.com/interledger/rafiki/pull/2752