### PR TITLE
feat(backend)!: logging plugin for graphql resolvers, remove error resolver responses

### DIFF
--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Cross Currency Payment/Create Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Cross Currency Payment/Create Outgoing Payment.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateOutgoingPayment($input: CreateOutgoingPaymentInput!) {
     createOutgoingPayment(input: $input) {
-      code
-      message
       payment {
         createdAt
         error
@@ -40,7 +38,6 @@ body:graphql {
         state
         stateAttempts
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Cross Currency Payment/Create Quote.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Cross Currency Payment/Create Quote.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateQuote($input: CreateQuoteInput!) {
     createQuote(input: $input) {
-      code
-      message
       quote {
         createdAt
         expiresAt

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Cross Currency Payment/Create Receiver (remote Incoming Payment).bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Cross Currency Payment/Create Receiver (remote Incoming Payment).bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateReceiver($input: CreateReceiverInput!) {
     createReceiver(input: $input) {
-      code
-      message
       receiver {
         completed
         createdAt
@@ -34,7 +32,6 @@ body:graphql {
         }
         updatedAt
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Outgoing Payment.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateOutgoingPayment($input: CreateOutgoingPaymentInput!) {
     createOutgoingPayment(input: $input) {
-      code
-      message
       payment {
         createdAt
         error
@@ -40,7 +38,6 @@ body:graphql {
         state
         stateAttempts
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Quote.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Quote.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateQuote($input: CreateQuoteInput!) {
     createQuote(input: $input) {
-      code
-      message
       quote {
         createdAt
         expiresAt

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Receiver -remote Incoming Payment-.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Receiver -remote Incoming Payment-.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateReceiver($input: CreateReceiverInput!) {
     createReceiver(input: $input) {
-      code
-      message
       receiver {
         completed
         createdAt
@@ -34,7 +32,6 @@ body:graphql {
         }
         updatedAt
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Cancel Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Cancel Outgoing Payment.bru
@@ -13,9 +13,52 @@ post {
 body:graphql {
   mutation CancelOutgoingPayment($input: CancelOutgoingPaymentInput!) {
     cancelOutgoingPayment(input: $input) {
-      code
-      message
-      success
+      payment {
+        createdAt
+        error
+        metadata
+        id
+        walletAddressId
+        quote {
+          createdAt
+          expiresAt
+          highEstimatedExchangeRate
+          id
+          lowEstimatedExchangeRate
+          maxPacketAmount
+          minExchangeRate
+          walletAddressId
+          receiveAmount {
+            assetCode
+            assetScale
+            value
+          }
+          receiver
+          debitAmount {
+            assetCode
+            assetScale
+            value
+          }
+        }
+        receiveAmount {
+          assetCode
+          assetScale
+          value
+        }
+        receiver
+        debitAmount {
+          assetCode
+          assetScale
+          value
+        }
+        sentAmount {
+          assetCode
+          assetScale
+          value
+        }
+        state
+        stateAttempts
+      }
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Asset Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Asset Liquidity Withdrawal.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation CreateAssetLiquidityWithdrawal ($input: CreateAssetLiquidityWithdrawalInput!) {
     createAssetLiquidityWithdrawal(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Asset Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Asset Liquidity Withdrawal.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation CreateAssetLiquidityWithdrawal ($input: CreateAssetLiquidityWithdrawalInput!) {
     createAssetLiquidityWithdrawal(input: $input) {
-      code
-      success
-      message
-      error
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Asset.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Asset.bru
@@ -21,9 +21,6 @@ body:graphql {
         withdrawalThreshold
         liquidityThreshold
       }
-      code
-      message
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Incoming Payment Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Incoming Payment Withdrawal.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation CreateIncomingPaymentWithdrawal($input: CreateIncomingPaymentWithdrawalInput!) {  
       createIncomingPaymentWithdrawal(input: $input) {    
-          code    
-          error    
-          message    
-          success  
+      	id
+      	liquidity
       }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Incoming Payment Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Incoming Payment Withdrawal.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation CreateIncomingPaymentWithdrawal($input: CreateIncomingPaymentWithdrawalInput!) {  
       createIncomingPaymentWithdrawal(input: $input) {    
-      	id
-      	liquidity
+      	success
       }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Incoming Payment.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Incoming Payment.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateIncomingPayment ($input: CreateIncomingPaymentInput!) {
       createIncomingPayment(input: $input) {
-      code
-      message
       payment {
         createdAt
         expiresAt
@@ -33,7 +31,6 @@ body:graphql {
         }
         state
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Or Update Peer By Url.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Or Update Peer By Url.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation CreateOrUpdatePeerByUrl ($input: CreateOrUpdatePeerByUrlInput!) {
       createOrUpdatePeerByUrl (input: $input) {
-          code
-          message
-          success
           peer {
               id
               name

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment From Incoming Payment.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment From Incoming Payment.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateOutgoingPaymentFromIncomingPayment($input: CreateOutgoingPaymentFromIncomingPaymentInput!) {
     createOutgoingPaymentFromIncomingPayment(input: $input) {
-      code
-      message
       payment {
         createdAt
         error
@@ -61,7 +59,6 @@ body:graphql {
         state
         stateAttempts
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment Withdrawal.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation CreateOutgoingPaymentWithdrawal($input: CreateOutgoingPaymentWithdrawalInput!) {  
       createOutgoingPaymentWithdrawal(input: $input) {
-          id
-      		liquidity
+      	success
       }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment Withdrawal.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation CreateOutgoingPaymentWithdrawal($input: CreateOutgoingPaymentWithdrawalInput!) {  
       createOutgoingPaymentWithdrawal(input: $input) {
-          code    
-          error    
-          message    
-          success  
+          id
+      		liquidity
       }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Outgoing Payment.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateOutgoingPayment($input: CreateOutgoingPaymentInput!) {
     createOutgoingPayment(input: $input) {
-      code
-      message
       payment {
         createdAt
         error
@@ -61,7 +59,6 @@ body:graphql {
         state
         stateAttempts
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Peer Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Peer Liquidity Withdrawal.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation CreatePeerLiquidityWithdrawal ($input: CreatePeerLiquidityWithdrawalInput!) {
     createPeerLiquidityWithdrawal(input: $input) {
-      code
-      success
-      message
-      error
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Peer Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Peer Liquidity Withdrawal.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation CreatePeerLiquidityWithdrawal ($input: CreatePeerLiquidityWithdrawalInput!) {
     createPeerLiquidityWithdrawal(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Peer.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Peer.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation CreatePeer ($input: CreatePeerInput!) {
       createPeer (input: $input) {
-          code
-          message
-          success
           peer {
               id
               name

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Quote.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Quote.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateQuote($input: CreateQuoteInput!) {
     createQuote(input: $input) {
-      code
-      message
       quote {
         createdAt
         expiresAt

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Receiver (remote Incoming Payment).bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Receiver (remote Incoming Payment).bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation CreateReceiver($input: CreateReceiverInput!) {
     createReceiver(input: $input) {
-      code
-      message
       receiver {
         completed
         createdAt
@@ -34,7 +32,6 @@ body:graphql {
         }
         updatedAt
       }
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address Key.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address Key.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation CreateWalletAddressKey ($input: CreateWalletAddressKeyInput!) {
       createWalletAddressKey(input: $input) {
-          code
-          message
-          success
           walletAddressKey {
               id
               revoked

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address Withdrawal.bru
@@ -13,10 +13,6 @@ post {
 body:graphql {
   mutation CreateWalletAddressWithdrawal($input: CreateWalletAddressWithdrawalInput!) {
     createWalletAddressWithdrawal(input: $input) {
-      code
-      error
-      message
-      success
       withdrawal {
         amount
         id

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation CreateWalletAddres($input: CreateWalletAddressInput!) {
     createWalletAddress(input: $input) {
-      code
-      success
-      message
       walletAddress {
         id
         createdAt
@@ -57,7 +54,7 @@ script:pre-request {
   const { nanoid } = require("nanoid");
   const scripts = require('./scripts');
   
-  bru.setVar('randomId', nanoid());
+  bru.setVar("randomId", nanoid());
   
   scripts.addApiSignatureHeader();
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Delete Asset.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Delete Asset.bru
@@ -13,9 +13,14 @@ post {
 body:graphql {
   mutation DeleteAsset($input: DeleteAssetInput!) {
     deleteAsset(input: $input) {
-      code
-      message
-      success
+      asset {
+        code
+        createdAt
+        id
+        scale
+        withdrawalThreshold
+        liquidityThreshold
+      }
     }
   }
   

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Delete Peer.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Delete Peer.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation DeletePeer($input: DeletePeerInput!) {
     deletePeer(input: $input) {
-      code
-      message
       success
     }
   }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Asset Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Asset Liquidity.bru
@@ -15,8 +15,6 @@ body:graphql {
     depositAssetLiquidity(input: $input) {
       code
       success
-      message
-      error
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Asset Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Asset Liquidity.bru
@@ -13,8 +13,8 @@ post {
 body:graphql {
   mutation DepositAssetLiquidity ($input: DepositAssetLiquidityInput!) {
     depositAssetLiquidity(input: $input) {
-      code
-      success
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Asset Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Asset Liquidity.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation DepositAssetLiquidity ($input: DepositAssetLiquidityInput!) {
     depositAssetLiquidity(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Event Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Event Liquidity.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation DepositEventLiquidity($input: DepositEventLiquidityInput!) {
     depositEventLiquidity(input: $input) {
-      code
-      error
-      message
-      success
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Event Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Event Liquidity.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation DepositEventLiquidity($input: DepositEventLiquidityInput!) {
     depositEventLiquidity(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Outgoing Payment Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Outgoing Payment Liquidity.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation DepositOutgoingPaymentLiquidity($input: DepositOutgoingPaymentLiquidityInput!) {
     depositOutgoingPaymentLiquidity(input: $input) {
-      code
-      error
-      message
-      success
+      id
+      liquidity
     }
   }
   

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Outgoing Payment Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Outgoing Payment Liquidity.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation DepositOutgoingPaymentLiquidity($input: DepositOutgoingPaymentLiquidityInput!) {
     depositOutgoingPaymentLiquidity(input: $input) {
-      id
-      liquidity
+      success
     }
   }
   

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Peer Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Peer Liquidity.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation DepositPeerLiquidity ($input: DepositPeerLiquidityInput!) {
     depositPeerLiquidity(input: $input) {
-      code
-      success
-      message
-      error
+    	id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Peer Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Deposit Peer Liquidity.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation DepositPeerLiquidity ($input: DepositPeerLiquidityInput!) {
     depositPeerLiquidity(input: $input) {
-    	id
-      liquidity
+    	success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Post Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Post Liquidity Withdrawal.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation PostLiquidityWithdrawal($input: PostLiquidityWithdrawalInput!) {
     postLiquidityWithdrawal(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Post Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Post Liquidity Withdrawal.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation PostLiquidityWithdrawal($input: PostLiquidityWithdrawalInput!) {
     postLiquidityWithdrawal(input: $input) {
-      code
-      error
-      message
-      success
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Revoke Wallet Address Key.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Revoke Wallet Address Key.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation RevokeWalletAddressKey ($input: RevokeWalletAddressKeyInput!) {
       revokeWalletAddressKey (input: $input) {
-          code
-          message
-          success
           walletAddressKey {
               id
               revoked

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Set Fee.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Set Fee.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation SetFee($input: SetFeeInput!) {
       setFee(input: $input) {
-          code
-          success
-          message
           fee {
               id
               assetId

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Trigger Wallet Address Events.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Trigger Wallet Address Events.bru
@@ -13,10 +13,7 @@ post {
 body:graphql {
   mutation TriggerWalletAddressEvents($input: TriggerWalletAddressEventsInput!) {
     triggerWalletAddressEvents(input: $input) {
-      code
       count
-      message
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Update Asset.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Update Asset.bru
@@ -21,9 +21,6 @@ body:graphql {
         withdrawalThreshold
         liquidityThreshold
       }
-      code
-      message
-      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Update Peer.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Update Peer.bru
@@ -13,9 +13,6 @@ post {
 body:graphql {
   mutation UpdatePeer ($input: UpdatePeerInput!){  
     updatePeer(input: $input) {
-      code
-      success
-      message
       peer {
         id
         name

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Update Wallet Address.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Update Wallet Address.bru
@@ -13,8 +13,6 @@ post {
 body:graphql {
   mutation UpdateWalletAddress($input: UpdateWalletAddressInput!) {
       updateWalletAddress(input: $input) {
-          code
-          message
           walletAddress {
               id
               asset {
@@ -29,7 +27,6 @@ body:graphql {
               createdAt
               status
           }
-          success
       }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Void Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Void Liquidity Withdrawal.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation VoidLiquidityWithdrawal($input: VoidLiquidityWithdrawalInput!) {
     voidLiquidityWithdrawal(input: $input) {
-      code
-      error
-      message
-      success
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Void Liquidity Withdrawal.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Void Liquidity Withdrawal.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation VoidLiquidityWithdrawal($input: VoidLiquidityWithdrawalInput!) {
     voidLiquidityWithdrawal(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Withdraw Event Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Withdraw Event Liquidity.bru
@@ -13,10 +13,8 @@ post {
 body:graphql {
   mutation WithdrawEventLiquidity($input: WithdrawEventLiquidityInput!) {
     withdrawEventLiquidity(input: $input) {
-      code
-      error
-      message
-      success
+      id
+      liquidity
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Withdraw Event Liquidity.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Withdraw Event Liquidity.bru
@@ -13,8 +13,7 @@ post {
 body:graphql {
   mutation WithdrawEventLiquidity($input: WithdrawEventLiquidityInput!) {
     withdrawEventLiquidity(input: $input) {
-      id
-      liquidity
+      success
     }
   }
 }

--- a/bruno/collections/Rafiki/Rafiki Admin Auth APIs/Revoke Grant.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin Auth APIs/Revoke Grant.bru
@@ -13,9 +13,7 @@ post {
 body:graphql {
   mutation revokeGrant($input: RevokeGrantInput!) {
       revokeGrant(input: $input) {
-          code
-          message
-          success
+          id
       }
   }
 }

--- a/localenv/mock-account-servicing-entity/app/lib/requesters.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/requesters.ts
@@ -18,10 +18,8 @@ export async function depositPeerLiquidity(
   const depositPeerLiquidityMutation = gql`
     mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
       depositPeerLiquidity(input: $input) {
-        code
-        success
-        message
-        error
+        id
+        liquidity
       }
     }
   `
@@ -40,7 +38,7 @@ export async function depositPeerLiquidity(
     })
     .then(({ data }): LiquidityMutationResponse => {
       console.log(data)
-      if (!data.depositPeerLiquidity.success) {
+      if (!data.depositPeerLiquidity) {
         throw new Error('Data was empty')
       }
       return data.depositPeerLiquidity
@@ -55,10 +53,8 @@ export async function depositAssetLiquidity(
   const depositAssetLiquidityMutation = gql`
     mutation DepositAssetLiquidity($input: DepositAssetLiquidityInput!) {
       depositAssetLiquidity(input: $input) {
-        code
-        success
-        message
-        error
+        id
+        liquidity
       }
     }
   `
@@ -77,7 +73,7 @@ export async function depositAssetLiquidity(
     })
     .then(({ data }): LiquidityMutationResponse => {
       console.log(data)
-      if (!data.depositAssetLiquidity.success) {
+      if (!data.depositAssetLiquidity) {
         throw new Error('Data was empty')
       }
       return data.depositAssetLiquidity
@@ -92,9 +88,6 @@ export async function createWalletAddress(
   const createWalletAddressMutation = gql`
     mutation CreateWalletAddress($input: CreateWalletAddressInput!) {
       createWalletAddress(input: $input) {
-        code
-        success
-        message
         walletAddress {
           id
           url
@@ -120,10 +113,7 @@ export async function createWalletAddress(
     .then(({ data }) => {
       console.log(data)
 
-      if (
-        !data.createWalletAddress.success ||
-        !data.createWalletAddress.walletAddress
-      ) {
+      if (!data.createWalletAddress.walletAddress) {
         throw new Error('Data was empty')
       }
 

--- a/localenv/mock-account-servicing-entity/app/lib/requesters.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/requesters.ts
@@ -18,8 +18,7 @@ export async function depositPeerLiquidity(
   const depositPeerLiquidityMutation = gql`
     mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
       depositPeerLiquidity(input: $input) {
-        id
-        liquidity
+        success
       }
     }
   `
@@ -53,8 +52,7 @@ export async function depositAssetLiquidity(
   const depositAssetLiquidityMutation = gql`
     mutation DepositAssetLiquidity($input: DepositAssetLiquidityInput!) {
       depositAssetLiquidity(input: $input) {
-        id
-        liquidity
+        success
       }
     }
   `

--- a/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
@@ -83,9 +83,9 @@ export async function handleOutgoingPaymentCreated(wh: Webhook) {
       mutation: gql`
         mutation CancelOutgoingPayment($input: CancelOutgoingPaymentInput!) {
           cancelOutgoingPayment(input: $input) {
-            code
-            success
-            message
+            payment {
+              id
+            }
           }
         }
       `,
@@ -107,8 +107,7 @@ export async function handleOutgoingPaymentCreated(wh: Webhook) {
           $input: DepositOutgoingPaymentLiquidityInput!
         ) {
           depositOutgoingPaymentLiquidity(input: $input) {
-            id
-            liquidity
+            success
           }
         }
       `,
@@ -157,8 +156,7 @@ export async function handleIncomingPaymentCompletedExpired(wh: Webhook) {
           $input: CreateIncomingPaymentWithdrawalInput!
         ) {
           createIncomingPaymentWithdrawal(input: $input) {
-            id
-            liquidity
+            success
           }
         }
       `,
@@ -204,10 +202,6 @@ export async function handleWalletAddressWebMonetization(wh: Webhook) {
           $input: CreateWalletAddressWithdrawalInput!
         ) {
           createWalletAddressWithdrawal(input: $input) {
-            code
-            error
-            message
-            success
             withdrawal {
               amount
               id
@@ -243,10 +237,7 @@ export async function handleWalletAddressWebMonetization(wh: Webhook) {
           $input: PostLiquidityWithdrawalInput!
         ) {
           postLiquidityWithdrawal(input: $input) {
-            code
             success
-            message
-            error
           }
         }
       `,

--- a/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
@@ -107,10 +107,8 @@ export async function handleOutgoingPaymentCreated(wh: Webhook) {
           $input: DepositOutgoingPaymentLiquidityInput!
         ) {
           depositOutgoingPaymentLiquidity(input: $input) {
-            code
-            success
-            message
-            error
+            id
+            liquidity
           }
         }
       `,
@@ -159,10 +157,8 @@ export async function handleIncomingPaymentCompletedExpired(wh: Webhook) {
           $input: CreateIncomingPaymentWithdrawalInput!
         ) {
           createIncomingPaymentWithdrawal(input: $input) {
-            code
-            success
-            message
-            error
+            id
+            liquidity
           }
         }
       `,

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -573,8 +573,7 @@ export enum LiquidityError {
 
 export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  id: Scalars['ID']['output'];
-  liquidity?: Maybe<Scalars['UInt64']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type Model = {
@@ -1881,8 +1880,7 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -92,12 +92,9 @@ export type AssetEdge = {
   node: Asset;
 };
 
-export type AssetMutationResponse = MutationResponse & {
+export type AssetMutationResponse = {
   __typename?: 'AssetMutationResponse';
   asset?: Maybe<Asset>;
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type AssetsConnection = {
@@ -186,12 +183,9 @@ export type CreateOrUpdatePeerByUrlInput = {
   peerUrl: Scalars['String']['input'];
 };
 
-export type CreateOrUpdatePeerByUrlMutationResponse = MutationResponse & {
+export type CreateOrUpdatePeerByUrlMutationResponse = {
   __typename?: 'CreateOrUpdatePeerByUrlMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateOutgoingPaymentFromIncomingPaymentInput = {
@@ -259,12 +253,9 @@ export type CreatePeerLiquidityWithdrawalInput = {
   timeoutSeconds: Scalars['UInt64']['input'];
 };
 
-export type CreatePeerMutationResponse = MutationResponse & {
+export type CreatePeerMutationResponse = {
   __typename?: 'CreatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateQuoteInput = {
@@ -322,19 +313,13 @@ export type CreateWalletAddressKeyInput = {
   walletAddressId: Scalars['String']['input'];
 };
 
-export type CreateWalletAddressKeyMutationResponse = MutationResponse & {
+export type CreateWalletAddressKeyMutationResponse = {
   __typename?: 'CreateWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
-export type CreateWalletAddressMutationResponse = MutationResponse & {
+export type CreateWalletAddressMutationResponse = {
   __typename?: 'CreateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -360,11 +345,9 @@ export type DeleteAssetInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeleteAssetMutationResponse = MutationResponse & {
+export type DeleteAssetMutationResponse = {
   __typename?: 'DeleteAssetMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  asset?: Maybe<Asset>;
 };
 
 export type DeletePeerInput = {
@@ -373,10 +356,8 @@ export type DeletePeerInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeletePeerMutationResponse = MutationResponse & {
+export type DeletePeerMutationResponse = {
   __typename?: 'DeletePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   success: Scalars['Boolean']['output'];
 };
 
@@ -596,12 +577,10 @@ export enum LiquidityError {
   UnknownWalletAddress = 'UnknownWalletAddress'
 }
 
-export type LiquidityMutationResponse = MutationResponse & {
+export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
 };
 
 export type Model = {
@@ -834,12 +813,6 @@ export type MutationVoidLiquidityWithdrawalArgs = {
 
 export type MutationWithdrawEventLiquidityArgs = {
   input: WithdrawEventLiquidityInput;
-};
-
-export type MutationResponse = {
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type OutgoingPayment = BasePayment & Model & {
@@ -1185,11 +1158,8 @@ export type RevokeWalletAddressKeyInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type RevokeWalletAddressKeyMutationResponse = MutationResponse & {
+export type RevokeWalletAddressKeyMutationResponse = {
   __typename?: 'RevokeWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
@@ -1204,12 +1174,9 @@ export type SetFeeInput = {
   type: FeeType;
 };
 
-export type SetFeeResponse = MutationResponse & {
+export type SetFeeResponse = {
   __typename?: 'SetFeeResponse';
-  code: Scalars['String']['output'];
   fee?: Maybe<Fee>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export enum SortOrder {
@@ -1219,13 +1186,6 @@ export enum SortOrder {
   Desc = 'DESC'
 }
 
-export type TransferMutationResponse = MutationResponse & {
-  __typename?: 'TransferMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 export type TriggerWalletAddressEventsInput = {
   /** Unique key to ensure duplicate or retried requests are processed only once. See [idempotence](https://en.wikipedia.org/wiki/Idempotence) */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1233,13 +1193,10 @@ export type TriggerWalletAddressEventsInput = {
   limit: Scalars['Int']['input'];
 };
 
-export type TriggerWalletAddressEventsMutationResponse = MutationResponse & {
+export type TriggerWalletAddressEventsMutationResponse = {
   __typename?: 'TriggerWalletAddressEventsMutationResponse';
-  code: Scalars['String']['output'];
   /** Number of events triggered */
   count?: Maybe<Scalars['Int']['output']>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateAssetInput = {
@@ -1270,12 +1227,9 @@ export type UpdatePeerInput = {
   staticIlpAddress?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdatePeerMutationResponse = MutationResponse & {
+export type UpdatePeerMutationResponse = {
   __typename?: 'UpdatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateWalletAddressInput = {
@@ -1291,11 +1245,8 @@ export type UpdateWalletAddressInput = {
   status?: InputMaybe<WalletAddressStatus>;
 };
 
-export type UpdateWalletAddressMutationResponse = MutationResponse & {
+export type UpdateWalletAddressMutationResponse = {
   __typename?: 'UpdateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -1419,12 +1370,8 @@ export type WalletAddressWithdrawal = {
   walletAddress: WalletAddress;
 };
 
-export type WalletAddressWithdrawalMutationResponse = MutationResponse & {
+export type WalletAddressWithdrawalMutationResponse = {
   __typename?: 'WalletAddressWithdrawalMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   withdrawal?: Maybe<WalletAddressWithdrawal>;
 };
 
@@ -1541,7 +1488,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
-  MutationResponse: ( Partial<AssetMutationResponse> ) | ( Partial<CreateOrUpdatePeerByUrlMutationResponse> ) | ( Partial<CreatePeerMutationResponse> ) | ( Partial<CreateWalletAddressKeyMutationResponse> ) | ( Partial<CreateWalletAddressMutationResponse> ) | ( Partial<DeleteAssetMutationResponse> ) | ( Partial<DeletePeerMutationResponse> ) | ( Partial<LiquidityMutationResponse> ) | ( Partial<RevokeWalletAddressKeyMutationResponse> ) | ( Partial<SetFeeResponse> ) | ( Partial<TransferMutationResponse> ) | ( Partial<TriggerWalletAddressEventsMutationResponse> ) | ( Partial<UpdatePeerMutationResponse> ) | ( Partial<UpdateWalletAddressMutationResponse> ) | ( Partial<WalletAddressWithdrawalMutationResponse> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1614,7 +1560,6 @@ export type ResolversTypes = {
   LiquidityMutationResponse: ResolverTypeWrapper<Partial<LiquidityMutationResponse>>;
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
-  MutationResponse: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['MutationResponse']>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
@@ -1642,7 +1587,6 @@ export type ResolversTypes = {
   SetFeeResponse: ResolverTypeWrapper<Partial<SetFeeResponse>>;
   SortOrder: ResolverTypeWrapper<Partial<SortOrder>>;
   String: ResolverTypeWrapper<Partial<Scalars['String']['output']>>;
-  TransferMutationResponse: ResolverTypeWrapper<Partial<TransferMutationResponse>>;
   TriggerWalletAddressEventsInput: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsInput>>;
   TriggerWalletAddressEventsMutationResponse: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsMutationResponse>>;
   UInt8: ResolverTypeWrapper<Partial<Scalars['UInt8']['output']>>;
@@ -1733,7 +1677,6 @@ export type ResolversParentTypes = {
   LiquidityMutationResponse: Partial<LiquidityMutationResponse>;
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
-  MutationResponse: ResolversInterfaceTypes<ResolversParentTypes>['MutationResponse'];
   OutgoingPayment: Partial<OutgoingPayment>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
@@ -1758,7 +1701,6 @@ export type ResolversParentTypes = {
   SetFeeInput: Partial<SetFeeInput>;
   SetFeeResponse: Partial<SetFeeResponse>;
   String: Partial<Scalars['String']['output']>;
-  TransferMutationResponse: Partial<TransferMutationResponse>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
   UInt8: Partial<Scalars['UInt8']['output']>;
@@ -1820,9 +1762,6 @@ export type AssetEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type AssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AssetMutationResponse'] = ResolversParentTypes['AssetMutationResponse']> = {
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1842,18 +1781,12 @@ export type BasePaymentResolvers<ContextType = any, ParentType extends Resolvers
 };
 
 export type CreateOrUpdatePeerByUrlMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse'] = ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreatePeerMutationResponse'] = ResolversParentTypes['CreatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1866,31 +1799,21 @@ export type CreateReceiverResponseResolvers<ContextType = any, ParentType extend
 };
 
 export type CreateWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressKeyMutationResponse'] = ResolversParentTypes['CreateWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressMutationResponse'] = ResolversParentTypes['CreateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeleteAssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteAssetMutationResponse'] = ResolversParentTypes['DeleteAssetMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeletePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeletePeerMutationResponse'] = ResolversParentTypes['DeletePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1976,10 +1899,8 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2021,13 +1942,6 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateWalletAddress?: Resolver<ResolversTypes['UpdateWalletAddressMutationResponse'], ParentType, ContextType, RequireFields<MutationUpdateWalletAddressArgs, 'input'>>;
   voidLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationVoidLiquidityWithdrawalArgs, 'input'>>;
   withdrawEventLiquidity?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationWithdrawEventLiquidityArgs, 'input'>>;
-};
-
-export type MutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutationResponse'] = ResolversParentTypes['MutationResponse']> = {
-  __resolveType: TypeResolveFn<'AssetMutationResponse' | 'CreateOrUpdatePeerByUrlMutationResponse' | 'CreatePeerMutationResponse' | 'CreateWalletAddressKeyMutationResponse' | 'CreateWalletAddressMutationResponse' | 'DeleteAssetMutationResponse' | 'DeletePeerMutationResponse' | 'LiquidityMutationResponse' | 'RevokeWalletAddressKeyMutationResponse' | 'SetFeeResponse' | 'TransferMutationResponse' | 'TriggerWalletAddressEventsMutationResponse' | 'UpdatePeerMutationResponse' | 'UpdateWalletAddressMutationResponse' | 'WalletAddressWithdrawalMutationResponse', ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
@@ -2189,33 +2103,17 @@ export type ReceiverResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type RevokeWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['RevokeWalletAddressKeyMutationResponse'] = ResolversParentTypes['RevokeWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SetFeeResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetFeeResponse'] = ResolversParentTypes['SetFeeResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   fee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TransferMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransferMutationResponse'] = ResolversParentTypes['TransferMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type TriggerWalletAddressEventsMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TriggerWalletAddressEventsMutationResponse'] = ResolversParentTypes['TriggerWalletAddressEventsMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2228,17 +2126,11 @@ export interface UInt64ScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 }
 
 export type UpdatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdatePeerMutationResponse'] = ResolversParentTypes['UpdatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateWalletAddressMutationResponse'] = ResolversParentTypes['UpdateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2294,10 +2186,6 @@ export type WalletAddressWithdrawalResolvers<ContextType = any, ParentType exten
 };
 
 export type WalletAddressWithdrawalMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddressWithdrawalMutationResponse'] = ResolversParentTypes['WalletAddressWithdrawalMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   withdrawal?: Resolver<Maybe<ResolversTypes['WalletAddressWithdrawal']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2357,7 +2245,6 @@ export type Resolvers<ContextType = any> = {
   LiquidityMutationResponse?: LiquidityMutationResponseResolvers<ContextType>;
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
-  MutationResponse?: MutationResponseResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
@@ -2377,7 +2264,6 @@ export type Resolvers<ContextType = any> = {
   Receiver?: ReceiverResolvers<ContextType>;
   RevokeWalletAddressKeyMutationResponse?: RevokeWalletAddressKeyMutationResponseResolvers<ContextType>;
   SetFeeResponse?: SetFeeResponseResolvers<ContextType>;
-  TransferMutationResponse?: TransferMutationResponseResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;
   UInt64?: GraphQLScalarType;

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -286,10 +286,7 @@ export type CreateReceiverInput = {
 
 export type CreateReceiverResponse = {
   __typename?: 'CreateReceiverResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   receiver?: Maybe<Receiver>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateWalletAddressInput = {
@@ -514,10 +511,7 @@ export type IncomingPaymentEdge = {
 
 export type IncomingPaymentResponse = {
   __typename?: 'IncomingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<IncomingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum IncomingPaymentState {
@@ -859,10 +853,7 @@ export type OutgoingPaymentEdge = {
 
 export type OutgoingPaymentResponse = {
   __typename?: 'OutgoingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<OutgoingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum OutgoingPaymentState {
@@ -1123,10 +1114,7 @@ export type QuoteEdge = {
 
 export type QuoteResponse = {
   __typename?: 'QuoteResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   quote?: Maybe<Quote>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type Receiver = {
@@ -1791,10 +1779,7 @@ export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType ex
 };
 
 export type CreateReceiverResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateReceiverResponse'] = ResolversParentTypes['CreateReceiverResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receiver?: Resolver<Maybe<ResolversTypes['Receiver']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1878,10 +1863,7 @@ export type IncomingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type IncomingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['IncomingPaymentResponse'] = ResolversParentTypes['IncomingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1975,10 +1957,7 @@ export type OutgoingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type OutgoingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentResponse'] = ResolversParentTypes['OutgoingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['OutgoingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2082,10 +2061,7 @@ export type QuoteEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 };
 
 export type QuoteResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['QuoteResponse'] = ResolversParentTypes['QuoteResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/backend/src/accounting/errors.ts
+++ b/packages/backend/src/accounting/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../graphql/errors'
+
 export class CreateAccountError extends Error {
   constructor(public code: number) {
     super('CreateAccountError code=' + code)
@@ -31,6 +33,55 @@ export enum TransferError {
   UnknownError = 'UnknownError',
   UnknownSourceAccount = 'UnknownSourceAccount',
   UnknownDestinationAccount = 'UnknownDestinationAccount'
+}
+
+export const errorToCode: {
+  [key in TransferError]: string
+} = {
+  [TransferError.AlreadyPosted]: GraphQLErrorCode.Conflict,
+  [TransferError.AlreadyVoided]: GraphQLErrorCode.Conflict,
+  [TransferError.DifferentAssets]: GraphQLErrorCode.Forbidden,
+  [TransferError.InsufficientBalance]: GraphQLErrorCode.Forbidden,
+  [TransferError.InsufficientDebitBalance]: GraphQLErrorCode.Forbidden,
+  [TransferError.InsufficientLiquidity]: GraphQLErrorCode.Forbidden,
+  [TransferError.InvalidAmount]: GraphQLErrorCode.BadUserInput,
+  [TransferError.InvalidId]: GraphQLErrorCode.BadUserInput,
+  [TransferError.InvalidSourceAmount]: GraphQLErrorCode.BadUserInput,
+  [TransferError.InvalidDestinationAmount]: GraphQLErrorCode.BadUserInput,
+  [TransferError.InvalidTimeout]: GraphQLErrorCode.BadUserInput,
+  [TransferError.SameAccounts]: GraphQLErrorCode.Forbidden,
+  [TransferError.TransferExists]: GraphQLErrorCode.Duplicate,
+  [TransferError.TransferExpired]: GraphQLErrorCode.Forbidden,
+  [TransferError.UnknownTransfer]: GraphQLErrorCode.NotFound,
+  [TransferError.UnknownError]: GraphQLErrorCode.InternalServerError,
+  [TransferError.UnknownSourceAccount]: GraphQLErrorCode.NotFound,
+  [TransferError.UnknownDestinationAccount]: GraphQLErrorCode.NotFound
+}
+
+export const errorToMessage: {
+  [key in TransferError]: string
+} = {
+  [TransferError.AlreadyPosted]: 'Transfer already posted',
+  [TransferError.AlreadyVoided]: 'Transfer already voided',
+  [TransferError.DifferentAssets]: 'Transfer accounts have different assets',
+  [TransferError.InsufficientBalance]: 'Insufficient transfer balance',
+  [TransferError.InsufficientDebitBalance]:
+    'Insufficient transfer debit balance',
+  [TransferError.InsufficientLiquidity]:
+    'Insufficient transfer liquidity available',
+  [TransferError.InvalidAmount]: 'Invalid transfer amount',
+  [TransferError.InvalidId]: 'Invalid transfer id',
+  [TransferError.InvalidSourceAmount]: 'Invalid source account amount',
+  [TransferError.InvalidDestinationAmount]:
+    'Invalid destination account amount',
+  [TransferError.InvalidTimeout]: 'Invalid transfer timeout provided',
+  [TransferError.SameAccounts]: 'Transfer is between the same accounts',
+  [TransferError.TransferExists]: 'Transfer already exists',
+  [TransferError.TransferExpired]: 'Transfer already expired',
+  [TransferError.UnknownTransfer]: 'Unknown transfer',
+  [TransferError.UnknownError]: 'Internal server error',
+  [TransferError.UnknownSourceAccount]: 'Unknown source account',
+  [TransferError.UnknownDestinationAccount]: 'Unknown destination account'
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types

--- a/packages/backend/src/accounting/errors.ts
+++ b/packages/backend/src/accounting/errors.ts
@@ -36,7 +36,7 @@ export enum TransferError {
 }
 
 export const errorToCode: {
-  [key in TransferError]: string
+  [key in TransferError]: GraphQLErrorCode
 } = {
   [TransferError.AlreadyPosted]: GraphQLErrorCode.Conflict,
   [TransferError.AlreadyVoided]: GraphQLErrorCode.Conflict,

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -97,6 +97,7 @@ import {
   getWalletAddressUrlFromPath
 } from './open_payments/wallet_address/middleware'
 
+import { LoggingPlugin } from './graphql/plugin'
 export interface AppContextData {
   logger: Logger
   container: AppContainer
@@ -341,12 +342,15 @@ export class App {
     })
     const protection = armor.protect()
 
+    const loggingPlugin = new LoggingPlugin(this.logger)
+
     // Setup Apollo
     this.apolloServer = new ApolloServer({
       schema: schemaWithMiddleware,
       ...protection,
       plugins: [
         ...protection.plugins,
+        loggingPlugin,
         ApolloServerPluginDrainHttpServer({ httpServer })
       ],
       introspection: this.config.env !== 'production'

--- a/packages/backend/src/asset/errors.ts
+++ b/packages/backend/src/asset/errors.ts
@@ -11,7 +11,7 @@ export const isAssetError = (o: any): o is AssetError =>
   Object.values(AssetError).includes(o)
 
 export const errorToCode: {
-  [key in AssetError]: string
+  [key in AssetError]: GraphQLErrorCode
 } = {
   [AssetError.UnknownAsset]: GraphQLErrorCode.NotFound,
   [AssetError.DuplicateAsset]: GraphQLErrorCode.Duplicate,

--- a/packages/backend/src/asset/errors.ts
+++ b/packages/backend/src/asset/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../graphql/errors'
+
 export enum AssetError {
   DuplicateAsset = 'DuplicateAsset',
   UnknownAsset = 'UnknownAsset',
@@ -9,11 +11,11 @@ export const isAssetError = (o: any): o is AssetError =>
   Object.values(AssetError).includes(o)
 
 export const errorToCode: {
-  [key in AssetError]: number
+  [key in AssetError]: string
 } = {
-  [AssetError.UnknownAsset]: 404,
-  [AssetError.DuplicateAsset]: 400,
-  [AssetError.CannotDeleteInUseAsset]: 400
+  [AssetError.UnknownAsset]: GraphQLErrorCode.NotFound,
+  [AssetError.DuplicateAsset]: GraphQLErrorCode.Duplicate,
+  [AssetError.CannotDeleteInUseAsset]: GraphQLErrorCode.Forbidden
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/asset/errors.ts
+++ b/packages/backend/src/asset/errors.ts
@@ -21,7 +21,7 @@ export const errorToCode: {
 export const errorToMessage: {
   [key in AssetError]: string
 } = {
-  [AssetError.UnknownAsset]: 'unknown asset',
+  [AssetError.UnknownAsset]: 'Asset not found',
   [AssetError.DuplicateAsset]: 'Asset already exists',
   [AssetError.CannotDeleteInUseAsset]: 'Cannot delete! Asset in use.'
 }

--- a/packages/backend/src/fee/errors.ts
+++ b/packages/backend/src/fee/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../graphql/errors'
+
 export enum FeeError {
   UnknownAsset = 'UnknownAsset',
   InvalidBasisPointFee = 'InvalidBasisPointFee',
@@ -9,17 +11,17 @@ export const isFeeError = (o: any): o is FeeError =>
   Object.values(FeeError).includes(o)
 
 export const errorToCode: {
-  [key in FeeError]: number
+  [key in FeeError]: string
 } = {
-  [FeeError.UnknownAsset]: 404,
-  [FeeError.InvalidBasisPointFee]: 400,
-  [FeeError.InvalidFixedFee]: 400
+  [FeeError.UnknownAsset]: GraphQLErrorCode.NotFound,
+  [FeeError.InvalidBasisPointFee]: GraphQLErrorCode.BadUserInput,
+  [FeeError.InvalidFixedFee]: GraphQLErrorCode.BadUserInput
 }
 
 export const errorToMessage: {
   [key in FeeError]: string
 } = {
-  [FeeError.UnknownAsset]: 'unknown asset',
+  [FeeError.UnknownAsset]: 'Unknown asset',
   [FeeError.InvalidBasisPointFee]:
     'Basis point fee must be between 0 and 10000',
   [FeeError.InvalidFixedFee]: 'Fixed fee must be greater than or equal to 0'

--- a/packages/backend/src/fee/errors.ts
+++ b/packages/backend/src/fee/errors.ts
@@ -11,7 +11,7 @@ export const isFeeError = (o: any): o is FeeError =>
   Object.values(FeeError).includes(o)
 
 export const errorToCode: {
-  [key in FeeError]: string
+  [key in FeeError]: GraphQLErrorCode
 } = {
   [FeeError.UnknownAsset]: GraphQLErrorCode.NotFound,
   [FeeError.InvalidBasisPointFee]: GraphQLErrorCode.BadUserInput,

--- a/packages/backend/src/graphql/errors/index.ts
+++ b/packages/backend/src/graphql/errors/index.ts
@@ -1,6 +1,7 @@
 export enum GraphQLErrorCode {
   BadUserInput = 'BAD_USER_INPUT',
   Duplicate = 'DUPLICATE',
+  Inactive = 'INACTIVE',
   InternalServerError = 'INTERNAL_SERVER_ERROR',
   NotFound = 'NOT_FOUND'
 }

--- a/packages/backend/src/graphql/errors/index.ts
+++ b/packages/backend/src/graphql/errors/index.ts
@@ -1,6 +1,7 @@
 export enum GraphQLErrorCode {
   BadUserInput = 'BAD_USER_INPUT',
   Duplicate = 'DUPLICATE',
+  Forbidden = 'FORBIDDEN',
   Inactive = 'INACTIVE',
   InternalServerError = 'INTERNAL_SERVER_ERROR',
   NotFound = 'NOT_FOUND'

--- a/packages/backend/src/graphql/errors/index.ts
+++ b/packages/backend/src/graphql/errors/index.ts
@@ -1,0 +1,6 @@
+export enum GraphQLErrorCode {
+  BadUserInput = 'BAD_USER_INPUT',
+  Duplicate = 'DUPLICATE',
+  InternalServerError = 'INTERNAL_SERVER_ERROR',
+  NotFound = 'NOT_FOUND'
+}

--- a/packages/backend/src/graphql/errors/index.ts
+++ b/packages/backend/src/graphql/errors/index.ts
@@ -4,5 +4,6 @@ export enum GraphQLErrorCode {
   Forbidden = 'FORBIDDEN',
   Inactive = 'INACTIVE',
   InternalServerError = 'INTERNAL_SERVER_ERROR',
-  NotFound = 'NOT_FOUND'
+  NotFound = 'NOT_FOUND',
+  Conflict = 'CONFLICT'
 }

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -534,64 +534,10 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1207,38 +1153,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "peer",
             "description": null,
             "args": [],
@@ -1249,32 +1163,10 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -1703,38 +1595,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "peer",
             "description": null,
             "args": [],
@@ -1745,32 +1605,10 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -2143,54 +1981,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "walletAddressKey",
             "description": null,
             "args": [],
@@ -2204,13 +1994,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -2219,54 +2003,6 @@
         "name": "CreateWalletAddressMutationResponse",
         "description": null,
         "fields": [
-          {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
           {
             "name": "walletAddress",
             "description": null,
@@ -2281,13 +2017,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -2428,62 +2158,20 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
+            "name": "asset",
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -2532,38 +2220,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "success",
             "description": null,
             "args": [],
@@ -2581,13 +2237,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -4012,7 +3662,7 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
+            "name": "id",
             "description": null,
             "args": [],
             "type": {
@@ -4020,7 +3670,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ID",
                 "ofType": null
               }
             },
@@ -4028,58 +3678,20 @@
             "deprecationReason": null
           },
           {
-            "name": "error",
+            "name": "liquidity",
             "description": null,
             "args": [],
             "type": {
-              "kind": "ENUM",
-              "name": "LiquidityError",
+              "kind": "SCALAR",
+              "name": "UInt64",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -5149,141 +4761,6 @@
         "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
-      },
-      {
-        "kind": "INTERFACE",
-        "name": "MutationResponse",
-        "description": null,
-        "fields": [
-          {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": [
-          {
-            "kind": "OBJECT",
-            "name": "AssetMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "CreateOrUpdatePeerByUrlMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "CreatePeerMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "CreateWalletAddressKeyMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "CreateWalletAddressMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "DeleteAssetMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "DeletePeerMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "LiquidityMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "RevokeWalletAddressKeyMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "SetFeeResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "TransferMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "TriggerWalletAddressEventsMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "UpdatePeerMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "UpdateWalletAddressMutationResponse",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "WalletAddressWithdrawalMutationResponse",
-            "ofType": null
-          }
-        ]
       },
       {
         "kind": "OBJECT",
@@ -7511,54 +6988,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "walletAddressKey",
             "description": null,
             "args": [],
@@ -7572,13 +7001,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -7659,22 +7082,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "fee",
             "description": null,
             "args": [],
@@ -7685,48 +7092,10 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -7760,71 +7129,6 @@
         "fields": null,
         "inputFields": null,
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "TransferMutationResponse",
-        "description": null,
-        "fields": [
-          {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -7873,22 +7177,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "count",
             "description": "Number of events triggered",
             "args": [],
@@ -7899,48 +7187,10 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8132,38 +7382,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "peer",
             "description": null,
             "args": [],
@@ -8174,32 +7392,10 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8292,54 +7488,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "walletAddress",
             "description": null,
             "args": [],
@@ -8353,13 +7501,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -9157,66 +8299,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "error",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "LiquidityError",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "withdrawal",
             "description": null,
             "args": [],
@@ -9230,13 +8312,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "MutationResponse",
-            "ofType": null
-          }
-        ],
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -3574,7 +3574,7 @@
         "description": null,
         "fields": [
           {
-            "name": "id",
+            "name": "success",
             "description": null,
             "args": [],
             "type": {
@@ -3582,21 +3582,9 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "ID",
+                "name": "Boolean",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "liquidity",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "UInt64",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1772,34 +1772,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "receiver",
             "description": null,
             "args": [],
@@ -1807,22 +1779,6 @@
               "kind": "OBJECT",
               "name": "Receiver",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3258,34 +3214,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "payment",
             "description": null,
             "args": [],
@@ -3293,22 +3221,6 @@
               "kind": "OBJECT",
               "name": "IncomingPayment",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5088,34 +5000,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "payment",
             "description": null,
             "args": [],
@@ -5123,22 +5007,6 @@
               "kind": "OBJECT",
               "name": "OutgoingPayment",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6739,34 +6607,6 @@
         "description": null,
         "fields": [
           {
-            "name": "code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "message",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "quote",
             "description": null,
             "args": [],
@@ -6774,22 +6614,6 @@
               "kind": "OBJECT",
               "name": "Quote",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "success",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -573,8 +573,7 @@ export enum LiquidityError {
 
 export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  id: Scalars['ID']['output'];
-  liquidity?: Maybe<Scalars['UInt64']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type Model = {
@@ -1881,8 +1880,7 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -92,12 +92,9 @@ export type AssetEdge = {
   node: Asset;
 };
 
-export type AssetMutationResponse = MutationResponse & {
+export type AssetMutationResponse = {
   __typename?: 'AssetMutationResponse';
   asset?: Maybe<Asset>;
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type AssetsConnection = {
@@ -186,12 +183,9 @@ export type CreateOrUpdatePeerByUrlInput = {
   peerUrl: Scalars['String']['input'];
 };
 
-export type CreateOrUpdatePeerByUrlMutationResponse = MutationResponse & {
+export type CreateOrUpdatePeerByUrlMutationResponse = {
   __typename?: 'CreateOrUpdatePeerByUrlMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateOutgoingPaymentFromIncomingPaymentInput = {
@@ -259,12 +253,9 @@ export type CreatePeerLiquidityWithdrawalInput = {
   timeoutSeconds: Scalars['UInt64']['input'];
 };
 
-export type CreatePeerMutationResponse = MutationResponse & {
+export type CreatePeerMutationResponse = {
   __typename?: 'CreatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateQuoteInput = {
@@ -322,19 +313,13 @@ export type CreateWalletAddressKeyInput = {
   walletAddressId: Scalars['String']['input'];
 };
 
-export type CreateWalletAddressKeyMutationResponse = MutationResponse & {
+export type CreateWalletAddressKeyMutationResponse = {
   __typename?: 'CreateWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
-export type CreateWalletAddressMutationResponse = MutationResponse & {
+export type CreateWalletAddressMutationResponse = {
   __typename?: 'CreateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -360,11 +345,9 @@ export type DeleteAssetInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeleteAssetMutationResponse = MutationResponse & {
+export type DeleteAssetMutationResponse = {
   __typename?: 'DeleteAssetMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  asset?: Maybe<Asset>;
 };
 
 export type DeletePeerInput = {
@@ -373,10 +356,8 @@ export type DeletePeerInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeletePeerMutationResponse = MutationResponse & {
+export type DeletePeerMutationResponse = {
   __typename?: 'DeletePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   success: Scalars['Boolean']['output'];
 };
 
@@ -596,12 +577,10 @@ export enum LiquidityError {
   UnknownWalletAddress = 'UnknownWalletAddress'
 }
 
-export type LiquidityMutationResponse = MutationResponse & {
+export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
 };
 
 export type Model = {
@@ -834,12 +813,6 @@ export type MutationVoidLiquidityWithdrawalArgs = {
 
 export type MutationWithdrawEventLiquidityArgs = {
   input: WithdrawEventLiquidityInput;
-};
-
-export type MutationResponse = {
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type OutgoingPayment = BasePayment & Model & {
@@ -1185,11 +1158,8 @@ export type RevokeWalletAddressKeyInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type RevokeWalletAddressKeyMutationResponse = MutationResponse & {
+export type RevokeWalletAddressKeyMutationResponse = {
   __typename?: 'RevokeWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
@@ -1204,12 +1174,9 @@ export type SetFeeInput = {
   type: FeeType;
 };
 
-export type SetFeeResponse = MutationResponse & {
+export type SetFeeResponse = {
   __typename?: 'SetFeeResponse';
-  code: Scalars['String']['output'];
   fee?: Maybe<Fee>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export enum SortOrder {
@@ -1219,13 +1186,6 @@ export enum SortOrder {
   Desc = 'DESC'
 }
 
-export type TransferMutationResponse = MutationResponse & {
-  __typename?: 'TransferMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 export type TriggerWalletAddressEventsInput = {
   /** Unique key to ensure duplicate or retried requests are processed only once. See [idempotence](https://en.wikipedia.org/wiki/Idempotence) */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1233,13 +1193,10 @@ export type TriggerWalletAddressEventsInput = {
   limit: Scalars['Int']['input'];
 };
 
-export type TriggerWalletAddressEventsMutationResponse = MutationResponse & {
+export type TriggerWalletAddressEventsMutationResponse = {
   __typename?: 'TriggerWalletAddressEventsMutationResponse';
-  code: Scalars['String']['output'];
   /** Number of events triggered */
   count?: Maybe<Scalars['Int']['output']>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateAssetInput = {
@@ -1270,12 +1227,9 @@ export type UpdatePeerInput = {
   staticIlpAddress?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdatePeerMutationResponse = MutationResponse & {
+export type UpdatePeerMutationResponse = {
   __typename?: 'UpdatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateWalletAddressInput = {
@@ -1291,11 +1245,8 @@ export type UpdateWalletAddressInput = {
   status?: InputMaybe<WalletAddressStatus>;
 };
 
-export type UpdateWalletAddressMutationResponse = MutationResponse & {
+export type UpdateWalletAddressMutationResponse = {
   __typename?: 'UpdateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -1419,12 +1370,8 @@ export type WalletAddressWithdrawal = {
   walletAddress: WalletAddress;
 };
 
-export type WalletAddressWithdrawalMutationResponse = MutationResponse & {
+export type WalletAddressWithdrawalMutationResponse = {
   __typename?: 'WalletAddressWithdrawalMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   withdrawal?: Maybe<WalletAddressWithdrawal>;
 };
 
@@ -1541,7 +1488,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
-  MutationResponse: ( Partial<AssetMutationResponse> ) | ( Partial<CreateOrUpdatePeerByUrlMutationResponse> ) | ( Partial<CreatePeerMutationResponse> ) | ( Partial<CreateWalletAddressKeyMutationResponse> ) | ( Partial<CreateWalletAddressMutationResponse> ) | ( Partial<DeleteAssetMutationResponse> ) | ( Partial<DeletePeerMutationResponse> ) | ( Partial<LiquidityMutationResponse> ) | ( Partial<RevokeWalletAddressKeyMutationResponse> ) | ( Partial<SetFeeResponse> ) | ( Partial<TransferMutationResponse> ) | ( Partial<TriggerWalletAddressEventsMutationResponse> ) | ( Partial<UpdatePeerMutationResponse> ) | ( Partial<UpdateWalletAddressMutationResponse> ) | ( Partial<WalletAddressWithdrawalMutationResponse> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1614,7 +1560,6 @@ export type ResolversTypes = {
   LiquidityMutationResponse: ResolverTypeWrapper<Partial<LiquidityMutationResponse>>;
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
-  MutationResponse: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['MutationResponse']>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
@@ -1642,7 +1587,6 @@ export type ResolversTypes = {
   SetFeeResponse: ResolverTypeWrapper<Partial<SetFeeResponse>>;
   SortOrder: ResolverTypeWrapper<Partial<SortOrder>>;
   String: ResolverTypeWrapper<Partial<Scalars['String']['output']>>;
-  TransferMutationResponse: ResolverTypeWrapper<Partial<TransferMutationResponse>>;
   TriggerWalletAddressEventsInput: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsInput>>;
   TriggerWalletAddressEventsMutationResponse: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsMutationResponse>>;
   UInt8: ResolverTypeWrapper<Partial<Scalars['UInt8']['output']>>;
@@ -1733,7 +1677,6 @@ export type ResolversParentTypes = {
   LiquidityMutationResponse: Partial<LiquidityMutationResponse>;
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
-  MutationResponse: ResolversInterfaceTypes<ResolversParentTypes>['MutationResponse'];
   OutgoingPayment: Partial<OutgoingPayment>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
@@ -1758,7 +1701,6 @@ export type ResolversParentTypes = {
   SetFeeInput: Partial<SetFeeInput>;
   SetFeeResponse: Partial<SetFeeResponse>;
   String: Partial<Scalars['String']['output']>;
-  TransferMutationResponse: Partial<TransferMutationResponse>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
   UInt8: Partial<Scalars['UInt8']['output']>;
@@ -1820,9 +1762,6 @@ export type AssetEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type AssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AssetMutationResponse'] = ResolversParentTypes['AssetMutationResponse']> = {
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1842,18 +1781,12 @@ export type BasePaymentResolvers<ContextType = any, ParentType extends Resolvers
 };
 
 export type CreateOrUpdatePeerByUrlMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse'] = ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreatePeerMutationResponse'] = ResolversParentTypes['CreatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1866,31 +1799,21 @@ export type CreateReceiverResponseResolvers<ContextType = any, ParentType extend
 };
 
 export type CreateWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressKeyMutationResponse'] = ResolversParentTypes['CreateWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressMutationResponse'] = ResolversParentTypes['CreateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeleteAssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteAssetMutationResponse'] = ResolversParentTypes['DeleteAssetMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeletePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeletePeerMutationResponse'] = ResolversParentTypes['DeletePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1976,10 +1899,8 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2021,13 +1942,6 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateWalletAddress?: Resolver<ResolversTypes['UpdateWalletAddressMutationResponse'], ParentType, ContextType, RequireFields<MutationUpdateWalletAddressArgs, 'input'>>;
   voidLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationVoidLiquidityWithdrawalArgs, 'input'>>;
   withdrawEventLiquidity?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationWithdrawEventLiquidityArgs, 'input'>>;
-};
-
-export type MutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutationResponse'] = ResolversParentTypes['MutationResponse']> = {
-  __resolveType: TypeResolveFn<'AssetMutationResponse' | 'CreateOrUpdatePeerByUrlMutationResponse' | 'CreatePeerMutationResponse' | 'CreateWalletAddressKeyMutationResponse' | 'CreateWalletAddressMutationResponse' | 'DeleteAssetMutationResponse' | 'DeletePeerMutationResponse' | 'LiquidityMutationResponse' | 'RevokeWalletAddressKeyMutationResponse' | 'SetFeeResponse' | 'TransferMutationResponse' | 'TriggerWalletAddressEventsMutationResponse' | 'UpdatePeerMutationResponse' | 'UpdateWalletAddressMutationResponse' | 'WalletAddressWithdrawalMutationResponse', ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
@@ -2189,33 +2103,17 @@ export type ReceiverResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type RevokeWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['RevokeWalletAddressKeyMutationResponse'] = ResolversParentTypes['RevokeWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SetFeeResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetFeeResponse'] = ResolversParentTypes['SetFeeResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   fee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TransferMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransferMutationResponse'] = ResolversParentTypes['TransferMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type TriggerWalletAddressEventsMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TriggerWalletAddressEventsMutationResponse'] = ResolversParentTypes['TriggerWalletAddressEventsMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2228,17 +2126,11 @@ export interface UInt64ScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 }
 
 export type UpdatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdatePeerMutationResponse'] = ResolversParentTypes['UpdatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateWalletAddressMutationResponse'] = ResolversParentTypes['UpdateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2294,10 +2186,6 @@ export type WalletAddressWithdrawalResolvers<ContextType = any, ParentType exten
 };
 
 export type WalletAddressWithdrawalMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddressWithdrawalMutationResponse'] = ResolversParentTypes['WalletAddressWithdrawalMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   withdrawal?: Resolver<Maybe<ResolversTypes['WalletAddressWithdrawal']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2357,7 +2245,6 @@ export type Resolvers<ContextType = any> = {
   LiquidityMutationResponse?: LiquidityMutationResponseResolvers<ContextType>;
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
-  MutationResponse?: MutationResponseResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
@@ -2377,7 +2264,6 @@ export type Resolvers<ContextType = any> = {
   Receiver?: ReceiverResolvers<ContextType>;
   RevokeWalletAddressKeyMutationResponse?: RevokeWalletAddressKeyMutationResponseResolvers<ContextType>;
   SetFeeResponse?: SetFeeResponseResolvers<ContextType>;
-  TransferMutationResponse?: TransferMutationResponseResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;
   UInt64?: GraphQLScalarType;

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -286,10 +286,7 @@ export type CreateReceiverInput = {
 
 export type CreateReceiverResponse = {
   __typename?: 'CreateReceiverResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   receiver?: Maybe<Receiver>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateWalletAddressInput = {
@@ -514,10 +511,7 @@ export type IncomingPaymentEdge = {
 
 export type IncomingPaymentResponse = {
   __typename?: 'IncomingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<IncomingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum IncomingPaymentState {
@@ -859,10 +853,7 @@ export type OutgoingPaymentEdge = {
 
 export type OutgoingPaymentResponse = {
   __typename?: 'OutgoingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<OutgoingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum OutgoingPaymentState {
@@ -1123,10 +1114,7 @@ export type QuoteEdge = {
 
 export type QuoteResponse = {
   __typename?: 'QuoteResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   quote?: Maybe<Quote>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type Receiver = {
@@ -1791,10 +1779,7 @@ export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType ex
 };
 
 export type CreateReceiverResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateReceiverResponse'] = ResolversParentTypes['CreateReceiverResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receiver?: Resolver<Maybe<ResolversTypes['Receiver']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1878,10 +1863,7 @@ export type IncomingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type IncomingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['IncomingPaymentResponse'] = ResolversParentTypes['IncomingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1975,10 +1957,7 @@ export type OutgoingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type OutgoingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentResponse'] = ResolversParentTypes['OutgoingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['OutgoingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2082,10 +2061,7 @@ export type QuoteEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 };
 
 export type QuoteResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['QuoteResponse'] = ResolversParentTypes['QuoteResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/backend/src/graphql/middleware/index.test.ts
+++ b/packages/backend/src/graphql/middleware/index.test.ts
@@ -10,7 +10,11 @@ import { Config } from '../../config/app'
 import { truncateTables } from '../../tests/tableManager'
 import { AssetService } from '../../asset/service'
 import { randomAsset } from '../../tests/asset'
-import { AssetMutationResponse, CreateAssetInput } from '../generated/graphql'
+import {
+  AssetMutationResponse,
+  CreateAssetInput,
+  UpdateAssetInput
+} from '../generated/graphql'
 import { GraphQLError } from 'graphql'
 
 describe('GraphQL Middleware', (): void => {
@@ -39,9 +43,6 @@ describe('GraphQL Middleware', (): void => {
         mutation: gql`
           mutation CreateAsset($input: CreateAssetInput!) {
             createAsset(input: $input) {
-              code
-              success
-              message
               asset {
                 id
                 code
@@ -64,59 +65,96 @@ describe('GraphQL Middleware', (): void => {
       })
   }
 
+  const callUpdateAssetMutation = async (input: UpdateAssetInput) => {
+    return appContainer.apolloClient
+      .mutate({
+        mutation: gql`
+          mutation UpdateAsset($input: UpdateAssetInput!) {
+            updateAsset(input: $input) {
+              asset {
+                id
+                code
+                scale
+                withdrawalThreshold
+              }
+            }
+          }
+        `,
+        variables: {
+          input
+        }
+      })
+      .then((query): AssetMutationResponse => {
+        if (query.data) {
+          return query.data.updateAsset
+        } else {
+          throw new Error('Data was empty')
+        }
+      })
+  }
+
   describe('idempotencyGraphQLMiddleware', (): void => {
+    let createInput: CreateAssetInput
+    let createResponse: AssetMutationResponse
+
+    beforeEach(async (): Promise<void> => {
+      createInput = {
+        ...randomAsset(),
+        idempotencyKey: uuid()
+      }
+
+      createResponse = await callCreateAssetMutation(createInput)
+      assert.ok(createResponse.asset)
+    })
+
     test('returns original response on repeat call with same idempotency key', async (): Promise<void> => {
       const idempotencyKey = uuid()
-      const input: CreateAssetInput = {
-        ...randomAsset(),
+      assert.ok(createResponse.asset)
+      const input: UpdateAssetInput = {
+        id: createResponse.asset.id,
+        withdrawalThreshold: BigInt(10),
         idempotencyKey
       }
 
-      const createAssetSpy = jest.spyOn(assetService, 'create')
+      const updateAssetSpy = jest.spyOn(assetService, 'update')
 
-      const initialResponse = await callCreateAssetMutation(input)
+      const initialResponse = await callUpdateAssetMutation(input)
 
-      expect(createAssetSpy).toHaveBeenCalledTimes(1)
+      expect(updateAssetSpy).toHaveBeenCalledTimes(1)
       assert.ok(initialResponse.asset)
       expect(initialResponse).toEqual({
         __typename: 'AssetMutationResponse',
-        message: 'Created Asset',
-        success: true,
-        code: '200',
         asset: {
           __typename: 'Asset',
           id: initialResponse.asset.id,
-          code: input.code,
-          scale: input.scale,
-          withdrawalThreshold: null
+          code: createInput.code,
+          scale: createInput.scale,
+          withdrawalThreshold: '10'
         }
       })
       await expect(
         assetService.get(initialResponse.asset.id)
       ).resolves.toMatchObject({
         id: initialResponse.asset.id,
-        code: input.code,
-        scale: input.scale,
-        withdrawalThreshold: null
+        code: createInput.code,
+        scale: createInput.scale,
+        withdrawalThreshold: BigInt(10)
       })
 
-      createAssetSpy.mockClear()
+      updateAssetSpy.mockClear()
 
-      const repeatResponse = await callCreateAssetMutation(input)
+      const repeatResponse = await callUpdateAssetMutation(input)
 
-      expect(createAssetSpy).not.toHaveBeenCalled()
+      expect(updateAssetSpy).not.toHaveBeenCalled()
       assert.ok(repeatResponse.asset)
       expect(repeatResponse).toEqual({
         __typename: 'AssetMutationResponse',
-        message: 'Created Asset',
-        success: true,
-        code: '200',
         asset: {
           __typename: 'Asset',
           id: initialResponse.asset.id,
           code: initialResponse.asset.code,
           scale: initialResponse.asset.scale,
-          withdrawalThreshold: null
+          withdrawalThreshold: '10'
         }
       })
       await expect(
@@ -125,50 +163,7 @@ describe('GraphQL Middleware', (): void => {
         id: initialResponse.asset.id,
         code: initialResponse.asset.code,
         scale: initialResponse.asset.scale,
-        withdrawalThreshold: null
-      })
-    })
-
-    test('does not return original response on repeat call with different idempotency key', async (): Promise<void> => {
-      const input: CreateAssetInput = {
-        ...randomAsset(),
-        idempotencyKey: uuid()
-      }
-
-      const createAssetSpy = jest.spyOn(assetService, 'create')
-
-      const initialResponse = await callCreateAssetMutation(input)
-
-      expect(createAssetSpy).toHaveBeenCalledTimes(1)
-      assert.ok(initialResponse.asset)
-      expect(initialResponse).toEqual({
-        __typename: 'AssetMutationResponse',
-        message: 'Created Asset',
-        success: true,
-        code: '200',
-        asset: {
-          __typename: 'Asset',
-          id: initialResponse.asset.id,
-          code: input.code,
-          scale: input.scale,
-          withdrawalThreshold: null
-        }
-      })
-
-      createAssetSpy.mockClear()
-
-      const repeatResponse = await callCreateAssetMutation({
-        ...input,
-        idempotencyKey: uuid()
-      })
-
-      expect(createAssetSpy).toHaveBeenCalledTimes(1)
-      expect(repeatResponse).toEqual({
-        __typename: 'AssetMutationResponse',
-        message: 'Asset already exists',
-        success: false,
-        code: '409',
-        asset: null
+        withdrawalThreshold: BigInt(10)
       })
     })
 
@@ -184,9 +179,6 @@ describe('GraphQL Middleware', (): void => {
       assert.ok(initialResponse.asset)
       expect(initialResponse).toEqual({
         __typename: 'AssetMutationResponse',
-        message: 'Created Asset',
-        success: true,
-        code: '200',
         asset: {
           __typename: 'Asset',
           id: initialResponse.asset.id,
@@ -198,8 +190,8 @@ describe('GraphQL Middleware', (): void => {
 
       await expect(
         callCreateAssetMutation({
-          ...input,
-          scale: (input.scale + 1) % 256
+          ...randomAsset(),
+          idempotencyKey
         })
       ).rejects.toThrow(
         `Incoming arguments are different than the original request for idempotencyKey: ${idempotencyKey}`
@@ -229,9 +221,6 @@ describe('GraphQL Middleware', (): void => {
         status: 'fulfilled',
         value: {
           __typename: 'AssetMutationResponse',
-          message: 'Created Asset',
-          success: true,
-          code: '200',
           asset: {
             __typename: 'Asset',
             id: firstRequest.value?.asset?.id,

--- a/packages/backend/src/graphql/plugin/index.ts
+++ b/packages/backend/src/graphql/plugin/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@apollo/server'
 import { Logger } from 'pino'
 import { v4 as uuid } from 'uuid'
+import { GraphQLErrorCode } from '../errors'
 
 export class LoggingPlugin implements ApolloServerPlugin {
   private logger
@@ -34,7 +35,7 @@ export class LoggingPlugin implements ApolloServerPlugin {
       ): Promise<void> {
         if (context.errors) {
           context.errors.forEach((error) => {
-            if (error.extensions.code === 'INTERNAL_SERVER_ERROR') {
+            if (error.extensions.code === GraphQLErrorCode.InternalServerError) {
               logger.error({
                 requestId,
                 variables: context.request.variables,

--- a/packages/backend/src/graphql/plugin/index.ts
+++ b/packages/backend/src/graphql/plugin/index.ts
@@ -35,7 +35,9 @@ export class LoggingPlugin implements ApolloServerPlugin {
       ): Promise<void> {
         if (context.errors) {
           context.errors.forEach((error) => {
-            if (error.extensions.code === GraphQLErrorCode.InternalServerError) {
+            if (
+              error.extensions.code === GraphQLErrorCode.InternalServerError
+            ) {
               logger.error({
                 requestId,
                 variables: context.request.variables,

--- a/packages/backend/src/graphql/plugin/index.ts
+++ b/packages/backend/src/graphql/plugin/index.ts
@@ -1,0 +1,55 @@
+import {
+  ApolloServerPlugin,
+  GraphQLRequestContextDidEncounterErrors,
+  GraphQLRequestContextDidResolveOperation,
+  GraphQLRequestListener
+} from '@apollo/server'
+import { Logger } from 'pino'
+import { v4 as uuid } from 'uuid'
+
+export class LoggingPlugin implements ApolloServerPlugin {
+  private logger
+
+  constructor(logger: Logger) {
+    this.logger = logger
+  }
+
+  async requestDidStart(): Promise<GraphQLRequestListener<never>> {
+    const requestId = uuid()
+    const logger = this.logger
+    let operation: string | null
+
+    return {
+      async didResolveOperation(
+        context: GraphQLRequestContextDidResolveOperation<never>
+      ) {
+        operation = context.operationName
+        logger.info({
+          requestId,
+          operation
+        })
+      },
+      async didEncounterErrors(
+        context: GraphQLRequestContextDidEncounterErrors<never>
+      ): Promise<void> {
+        if (context.errors) {
+          context.errors.forEach((error) => {
+            if (error.extensions.code === 'INTERNAL_SERVER_ERROR') {
+              logger.error({
+                requestId,
+                variables: context.request.variables,
+                error
+              })
+            } else {
+              logger.info({
+                requestId,
+                variables: context.request.variables,
+                error
+              })
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/backend/src/graphql/resolvers/asset.test.ts
+++ b/packages/backend/src/graphql/resolvers/asset.test.ts
@@ -1,7 +1,6 @@
 import { gql } from '@apollo/client'
 import assert from 'assert'
 import { v4 as uuid } from 'uuid'
-import { ApolloError } from '@apollo/client'
 
 import { getPageTests } from './page.test'
 import { createTestApp, TestContainer } from '../../tests/app'
@@ -33,6 +32,7 @@ import { isFeeError } from '../../fee/errors'
 import { createFee } from '../../tests/fee'
 import { createAsset } from '../../tests/asset'
 import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 describe('Asset Resolvers', (): void => {
   let deps: IocContract<AppServices>
@@ -156,11 +156,14 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
-      await expect(gqlQuery).rejects.toThrow('Asset already exists')
+      await expect(gqlQuery).rejects.toThrow(new GraphQLError(errorToMessage[AssetError.DuplicateAsset], {
+        extensions: {
+          code: errorToCode[AssetError.DuplicateAsset]
+        }
+      }))
     })
 
-    test('500', async (): Promise<void> => {
+    test('handles unexpected error', async (): Promise<void> => {
       jest
         .spyOn(assetService, 'create')
         .mockRejectedValueOnce(new Error('unexpected'))
@@ -187,7 +190,11 @@ describe('Asset Resolvers', (): void => {
             throw new Error('Data was empty')
           }
         })
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow(new GraphQLError('unexpected', {
+        extensions: {
+          code: GraphQLErrorCode.InternalServerError
+        }
+      }))
     })
   })
 
@@ -361,7 +368,11 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow(new GraphQLError(errorToMessage[AssetError.UnknownAsset], {
+        extensions: {
+          code: errorToCode[AssetError.UnknownAsset]
+        }
+      }))
     })
   })
 
@@ -734,7 +745,11 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow(new GraphQLError('unexpected', {
+        extensions: {
+          code: GraphQLErrorCode.InternalServerError
+        }
+      }))
     })
   })
 })

--- a/packages/backend/src/graphql/resolvers/asset.test.ts
+++ b/packages/backend/src/graphql/resolvers/asset.test.ts
@@ -86,9 +86,6 @@ describe('Asset Resolvers', (): void => {
             mutation: gql`
               mutation CreateAsset($input: CreateAssetInput!) {
                 createAsset(input: $input) {
-                  code
-                  success
-                  message
                   asset {
                     id
                     code
@@ -112,8 +109,6 @@ describe('Asset Resolvers', (): void => {
             }
           })
 
-        expect(response.success).toBe(true)
-        expect(response.code).toEqual('200')
         assert.ok(response.asset)
         expect(response.asset).toEqual({
           __typename: 'Asset',
@@ -137,14 +132,11 @@ describe('Asset Resolvers', (): void => {
     test('Returns error for duplicate asset', async (): Promise<void> => {
       const input = randomAsset()
       await expect(assetService.create(input)).resolves.toMatchObject(input)
-      const response = await appContainer.apolloClient
+      const gqlQuery = appContainer.apolloClient
         .mutate({
           mutation: gql`
             mutation CreateAsset($input: CreateAssetInput!) {
               createAsset(input: $input) {
-                code
-                success
-                message
                 asset {
                   id
                 }
@@ -163,9 +155,8 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      expect(response.success).toBe(false)
-      expect(response.code).toEqual('409')
-      expect(response.message).toEqual('Asset already exists')
+      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow('Asset already exists')
     })
 
     test('500', async (): Promise<void> => {
@@ -173,14 +164,11 @@ describe('Asset Resolvers', (): void => {
         .spyOn(assetService, 'create')
         .mockRejectedValueOnce(new Error('unexpected'))
 
-      const response = await appContainer.apolloClient
+      const gqlQuery = appContainer.apolloClient
         .mutate({
           mutation: gql`
             mutation CreateAsset($input: CreateAssetInput!) {
               createAsset(input: $input) {
-                code
-                success
-                message
                 asset {
                   id
                 }
@@ -198,9 +186,7 @@ describe('Asset Resolvers', (): void => {
             throw new Error('Data was empty')
           }
         })
-      expect(response.code).toBe('500')
-      expect(response.success).toBe(false)
-      expect(response.message).toBe('Error trying to create asset')
+      await expect(gqlQuery).rejects.toThrow(ApolloError)
     })
   })
 
@@ -558,9 +544,6 @@ describe('Asset Resolvers', (): void => {
                 mutation: gql`
                   mutation updateAsset($input: UpdateAssetInput!) {
                     updateAsset(input: $input) {
-                      code
-                      success
-                      message
                       asset {
                         id
                         code
@@ -587,8 +570,6 @@ describe('Asset Resolvers', (): void => {
                 }
               })
 
-            expect(response.success).toBe(true)
-            expect(response.code).toEqual('200')
             expect(response.asset).toEqual({
               __typename: 'Asset',
               id: asset.id,
@@ -613,14 +594,11 @@ describe('Asset Resolvers', (): void => {
     )
 
     test('Returns error for unknown asset', async (): Promise<void> => {
-      const response = await appContainer.apolloClient
+      const gqlQuery = appContainer.apolloClient
         .mutate({
           mutation: gql`
             mutation updateAsset($input: UpdateAssetInput!) {
               updateAsset(input: $input) {
-                code
-                success
-                message
                 asset {
                   id
                 }
@@ -643,9 +621,8 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      expect(response.success).toBe(false)
-      expect(response.code).toEqual('404')
-      expect(response.message).toEqual('Unknown asset')
+      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow('Asset not found')
     })
   })
 

--- a/packages/backend/src/graphql/resolvers/asset.test.ts
+++ b/packages/backend/src/graphql/resolvers/asset.test.ts
@@ -156,11 +156,13 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(new GraphQLError(errorToMessage[AssetError.DuplicateAsset], {
-        extensions: {
-          code: errorToCode[AssetError.DuplicateAsset]
-        }
-      }))
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError(errorToMessage[AssetError.DuplicateAsset], {
+          extensions: {
+            code: errorToCode[AssetError.DuplicateAsset]
+          }
+        })
+      )
     })
 
     test('handles unexpected error', async (): Promise<void> => {
@@ -190,11 +192,13 @@ describe('Asset Resolvers', (): void => {
             throw new Error('Data was empty')
           }
         })
-      await expect(gqlQuery).rejects.toThrow(new GraphQLError('unexpected', {
-        extensions: {
-          code: GraphQLErrorCode.InternalServerError
-        }
-      }))
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
     })
   })
 
@@ -368,11 +372,13 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(new GraphQLError(errorToMessage[AssetError.UnknownAsset], {
-        extensions: {
-          code: errorToCode[AssetError.UnknownAsset]
-        }
-      }))
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError(errorToMessage[AssetError.UnknownAsset], {
+          extensions: {
+            code: errorToCode[AssetError.UnknownAsset]
+          }
+        })
+      )
     })
   })
 
@@ -745,11 +751,13 @@ describe('Asset Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(new GraphQLError('unexpected', {
-        extensions: {
-          code: GraphQLErrorCode.InternalServerError
-        }
-      }))
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
     })
   })
 })

--- a/packages/backend/src/graphql/resolvers/asset.ts
+++ b/packages/backend/src/graphql/resolvers/asset.ts
@@ -6,12 +6,7 @@ import {
   AssetResolvers
 } from '../generated/graphql'
 import { Asset } from '../../asset/model'
-import {
-  AssetError,
-  isAssetError,
-  errorToCode,
-  errorToMessage
-} from '../../asset/errors'
+import { errorToCode, errorToMessage, isAssetError } from '../../asset/errors'
 import { ApolloContext } from '../../app'
 import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
@@ -54,7 +49,7 @@ export const getAsset: QueryResolvers<ApolloContext>['asset'] = async (
   if (!asset) {
     throw new GraphQLError('Asset not found', {
       extensions: {
-        code: 'NOT_FOUND'
+        code: GraphQLErrorCode.NotFound
       }
     })
   }
@@ -70,21 +65,11 @@ export const createAsset: MutationResolvers<ApolloContext>['createAsset'] =
     const assetService = await ctx.container.use('assetService')
     const assetOrError = await assetService.create(args.input)
     if (isAssetError(assetOrError)) {
-      switch (assetOrError) {
-        case AssetError.DuplicateAsset:
-          throw new GraphQLError('Asset already exists', {
-            extensions: {
-              code: GraphQLErrorCode.Duplicate
-            }
-          })
-        default:
-          throw new GraphQLError('Internal Server Error', {
-            extensions: {
-              code: GraphQLErrorCode.InternalServerError,
-              error: assetOrError
-            }
-          })
-      }
+      throw new GraphQLError(errorToMessage[assetOrError], {
+        extensions: {
+          code: errorToCode[assetOrError]
+        }
+      })
     }
     return {
       asset: assetToGraphql(assetOrError)
@@ -104,21 +89,11 @@ export const updateAsset: MutationResolvers<ApolloContext>['updateAsset'] =
       liquidityThreshold: args.input.liquidityThreshold ?? null
     })
     if (isAssetError(assetOrError)) {
-      switch (assetOrError) {
-        case AssetError.UnknownAsset:
-          throw new GraphQLError('Asset not found', {
-            extensions: {
-              code: GraphQLErrorCode.NotFound
-            }
-          })
-        default:
-          throw new GraphQLError('Internal Server Error', {
-            extensions: {
-              code: GraphQLErrorCode.InternalServerError,
-              error: assetOrError
-            }
-          })
-      }
+      throw new GraphQLError(errorToMessage[assetOrError], {
+        extensions: {
+          code: errorToCode[assetOrError]
+        }
+      })
     }
     return {
       asset: assetToGraphql(assetOrError)

--- a/packages/backend/src/graphql/resolvers/asset.ts
+++ b/packages/backend/src/graphql/resolvers/asset.ts
@@ -17,6 +17,8 @@ import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 import { feeToGraphql } from './fee'
 import { Fee, FeeType } from '../../fee/model'
+import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 export const getAssets: QueryResolvers<ApolloContext>['assets'] = async (
   parent,
@@ -50,7 +52,11 @@ export const getAsset: QueryResolvers<ApolloContext>['asset'] = async (
   const assetService = await ctx.container.use('assetService')
   const asset = await assetService.get(args.id)
   if (!asset) {
-    throw new Error('No asset')
+    throw new GraphQLError('Asset not found', {
+      extensions: {
+        code: 'NOT_FOUND'
+      }
+    })
   }
   return assetToGraphql(asset)
 }
@@ -61,40 +67,27 @@ export const createAsset: MutationResolvers<ApolloContext>['createAsset'] =
     args,
     ctx
   ): Promise<ResolversTypes['AssetMutationResponse']> => {
-    try {
-      const assetService = await ctx.container.use('assetService')
-      const assetOrError = await assetService.create(args.input)
-      if (isAssetError(assetOrError)) {
-        switch (assetOrError) {
-          case AssetError.DuplicateAsset:
-            return {
-              code: '409',
-              message: 'Asset already exists',
-              success: false
+    const assetService = await ctx.container.use('assetService')
+    const assetOrError = await assetService.create(args.input)
+    if (isAssetError(assetOrError)) {
+      switch (assetOrError) {
+        case AssetError.DuplicateAsset:
+          throw new GraphQLError('Asset already exists', {
+            extensions: {
+              code: GraphQLErrorCode.Duplicate
             }
-          default:
-            throw new Error(`AssetError: ${assetOrError}`)
-        }
+          })
+        default:
+          throw new GraphQLError('Internal Server Error', {
+            extensions: {
+              code: GraphQLErrorCode.InternalServerError,
+              error: assetOrError
+            }
+          })
       }
-      return {
-        code: '200',
-        success: true,
-        message: 'Created Asset',
-        asset: assetToGraphql(assetOrError)
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          options: args.input,
-          err
-        },
-        'error creating asset'
-      )
-      return {
-        code: '500',
-        message: 'Error trying to create asset',
-        success: false
-      }
+    }
+    return {
+      asset: assetToGraphql(assetOrError)
     }
   }
 
@@ -104,44 +97,31 @@ export const updateAsset: MutationResolvers<ApolloContext>['updateAsset'] =
     args,
     ctx
   ): Promise<ResolversTypes['AssetMutationResponse']> => {
-    try {
-      const assetService = await ctx.container.use('assetService')
-      const assetOrError = await assetService.update({
-        id: args.input.id,
-        withdrawalThreshold: args.input.withdrawalThreshold ?? null,
-        liquidityThreshold: args.input.liquidityThreshold ?? null
-      })
-      if (isAssetError(assetOrError)) {
-        switch (assetOrError) {
-          case AssetError.UnknownAsset:
-            return {
-              code: '404',
-              message: 'Unknown asset',
-              success: false
+    const assetService = await ctx.container.use('assetService')
+    const assetOrError = await assetService.update({
+      id: args.input.id,
+      withdrawalThreshold: args.input.withdrawalThreshold ?? null,
+      liquidityThreshold: args.input.liquidityThreshold ?? null
+    })
+    if (isAssetError(assetOrError)) {
+      switch (assetOrError) {
+        case AssetError.UnknownAsset:
+          throw new GraphQLError('Asset not found', {
+            extensions: {
+              code: GraphQLErrorCode.NotFound
             }
-          default:
-            throw new Error(`AssetError: ${assetOrError}`)
-        }
+          })
+        default:
+          throw new GraphQLError('Internal Server Error', {
+            extensions: {
+              code: GraphQLErrorCode.InternalServerError,
+              error: assetOrError
+            }
+          })
       }
-      return {
-        code: '200',
-        success: true,
-        message: 'Updated Asset',
-        asset: assetToGraphql(assetOrError)
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          options: args.input,
-          err
-        },
-        'error updating asset'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to update asset',
-        success: false
-      }
+    }
+    return {
+      asset: assetToGraphql(assetOrError)
     }
   }
 

--- a/packages/backend/src/graphql/resolvers/asset.ts
+++ b/packages/backend/src/graphql/resolvers/asset.ts
@@ -158,38 +158,21 @@ export const deleteAsset: MutationResolvers<ApolloContext>['deleteAsset'] =
     args,
     ctx
   ): Promise<ResolversTypes['DeleteAssetMutationResponse']> => {
-    try {
-      const assetService = await ctx.container.use('assetService')
-      const assetOrError = await assetService.delete({
-        id: args.input.id,
-        deletedAt: new Date()
-      })
+    const assetService = await ctx.container.use('assetService')
+    const assetOrError = await assetService.delete({
+      id: args.input.id,
+      deletedAt: new Date()
+    })
 
-      if (isAssetError(assetOrError)) {
-        return {
-          code: errorToCode[assetOrError].toString(),
-          message: errorToMessage[assetOrError],
-          success: false
+    if (isAssetError(assetOrError)) {
+      throw new GraphQLError(errorToMessage[assetOrError], {
+        extensions: {
+          code: errorToCode[assetOrError]
         }
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Asset deleted'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          id: args.input.id,
-          err
-        },
-        'error deleting asset'
-      )
-      return {
-        code: '500',
-        message: 'Error trying to delete asset',
-        success: false
-      }
+      })
+    }
+    return {
+      asset: assetToGraphql(assetOrError)
     }
   }
 

--- a/packages/backend/src/graphql/resolvers/auto-peering.test.ts
+++ b/packages/backend/src/graphql/resolvers/auto-peering.test.ts
@@ -45,9 +45,6 @@ describe('Auto Peering Resolvers', (): void => {
             $input: CreateOrUpdatePeerByUrlInput!
           ) {
             createOrUpdatePeerByUrl(input: $input) {
-              code
-              success
-              message
               peer {
                 id
                 asset {
@@ -167,8 +164,6 @@ describe('Auto Peering Resolvers', (): void => {
 
       const response = await callCreateOrUpdatePeerByUrl(input)
 
-      expect(response.success).toBe(true)
-      expect(response.code).toEqual('200')
       assert.ok(response.peer)
       expect(response.peer).toEqual({
         __typename: 'Peer',
@@ -201,8 +196,6 @@ describe('Auto Peering Resolvers', (): void => {
 
       const secondResponse = await callCreateOrUpdatePeerByUrl(secondInput)
 
-      expect(secondResponse.success).toBe(true)
-      expect(secondResponse.code).toEqual('200')
       assert.ok(secondResponse.peer)
       expect(secondResponse.peer).toEqual({
         __typename: 'Peer',
@@ -252,9 +245,6 @@ describe('Auto Peering Resolvers', (): void => {
               $input: CreateOrUpdatePeerByUrlInput!
             ) {
               createOrUpdatePeerByUrl(input: $input) {
-                code
-                success
-                message
                 peer {
                   id
                 }
@@ -291,9 +281,6 @@ describe('Auto Peering Resolvers', (): void => {
               $input: CreateOrUpdatePeerByUrlInput!
             ) {
               createOrUpdatePeerByUrl(input: $input) {
-                code
-                success
-                message
                 peer {
                   id
                 }

--- a/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
@@ -185,7 +185,7 @@ describe('Incoming Payment Resolver', (): void => {
       }
     )
 
-    test('400', async (): Promise<void> => {
+    test('Errors when unknown wallet address', async (): Promise<void> => {
       const createSpy = jest
         .spyOn(incomingPaymentService, 'create')
         .mockResolvedValueOnce(IncomingPaymentError.UnknownWalletAddress)
@@ -218,7 +218,7 @@ describe('Incoming Payment Resolver', (): void => {
       await expect(createSpy).toHaveBeenCalledWith(input)
     })
 
-    test('500', async (): Promise<void> => {
+    test('Internal server error', async (): Promise<void> => {
       const createSpy = jest
         .spyOn(incomingPaymentService, 'create')
         .mockRejectedValueOnce(new Error('unexpected'))

--- a/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/incoming_payment.test.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { ApolloError, gql } from '@apollo/client'
 import { getPageTests } from './page.test'
 import { createTestApp, TestContainer } from '../../tests/app'
 import { IocContract } from '@adonisjs/fold'
@@ -22,10 +22,7 @@ import {
   IncomingPaymentResponse,
   IncomingPaymentState as SchemaPaymentState
 } from '../generated/graphql'
-import {
-  IncomingPaymentError,
-  errorToMessage
-} from '../../open_payments/payment/incoming/errors'
+import { IncomingPaymentError } from '../../open_payments/payment/incoming/errors'
 import { Amount, serializeAmount } from '../../open_payments/amount'
 
 describe('Incoming Payment Resolver', (): void => {
@@ -100,7 +97,7 @@ describe('Incoming Payment Resolver', (): void => {
       ${undefined}                                      | ${new Date(Date.now() + 30_000)} | ${false}   | ${'expiresAt'}
       ${undefined}                                      | ${undefined}                     | ${true}    | ${'incomingAmount'}
     `(
-      '200 ($desc)',
+      'Successfully creates an incoming payment with $desc',
       async ({ metadata, expiresAt, withAmount }): Promise<void> => {
         const incomingAmount = withAmount ? amount : undefined
         const { id: walletAddressId } = await createWalletAddress(deps, {
@@ -132,9 +129,6 @@ describe('Incoming Payment Resolver', (): void => {
                 $input: CreateIncomingPaymentInput!
               ) {
                 createIncomingPayment(input: $input) {
-                  code
-                  success
-                  message
                   payment {
                     id
                     walletAddressId
@@ -166,9 +160,6 @@ describe('Incoming Payment Resolver', (): void => {
         expect(createSpy).toHaveBeenCalledWith(input)
         expect(query).toEqual({
           __typename: 'IncomingPaymentResponse',
-          code: '200',
-          success: true,
-          message: null,
           payment: {
             __typename: 'IncomingPayment',
             id: payment.id,
@@ -203,16 +194,13 @@ describe('Incoming Payment Resolver', (): void => {
         walletAddressId: uuid()
       }
 
-      const query = await appContainer.apolloClient
+      const gqlQuery = appContainer.apolloClient
         .query({
           query: gql`
             mutation CreateIncomingPayment(
               $input: CreateIncomingPaymentInput!
             ) {
               createIncomingPayment(input: $input) {
-                code
-                success
-                message
                 payment {
                   id
                   state
@@ -225,13 +213,9 @@ describe('Incoming Payment Resolver', (): void => {
         .then(
           (query): IncomingPaymentResponse => query.data?.createIncomingPayment
         )
-      expect(query.code).toBe('404')
-      expect(query.success).toBe(false)
-      expect(query.message).toBe(
-        errorToMessage[IncomingPaymentError.UnknownWalletAddress]
-      )
-      expect(query.payment).toBeNull()
-      expect(createSpy).toHaveBeenCalledWith(input)
+      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow('unknown wallet address')
+      await expect(createSpy).toHaveBeenCalledWith(input)
     })
 
     test('500', async (): Promise<void> => {
@@ -243,16 +227,13 @@ describe('Incoming Payment Resolver', (): void => {
         walletAddressId: uuid()
       }
 
-      const query = await appContainer.apolloClient
+      const gqlQuery = appContainer.apolloClient
         .query({
           query: gql`
             mutation CreateIncomingPayment(
               $input: CreateIncomingPaymentInput!
             ) {
               createIncomingPayment(input: $input) {
-                code
-                success
-                message
                 payment {
                   id
                   state
@@ -265,11 +246,8 @@ describe('Incoming Payment Resolver', (): void => {
         .then(
           (query): IncomingPaymentResponse => query.data?.createIncomingPayment
         )
-      expect(createSpy).toHaveBeenCalledWith(input)
-      expect(query.code).toBe('500')
-      expect(query.success).toBe(false)
-      expect(query.message).toBe('Error trying to create incoming payment')
-      expect(query.payment).toBeNull()
+      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(createSpy).toHaveBeenCalledWith(input)
     })
   })
 

--- a/packages/backend/src/graphql/resolvers/incoming_payment.ts
+++ b/packages/backend/src/graphql/resolvers/incoming_payment.ts
@@ -15,6 +15,7 @@ import { ApolloContext } from '../../app'
 import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 export const getIncomingPayment: QueryResolvers<ApolloContext>['incomingPayment'] =
   async (parent, args, ctx): Promise<ResolversTypes['IncomingPayment']> => {
@@ -24,7 +25,13 @@ export const getIncomingPayment: QueryResolvers<ApolloContext>['incomingPayment'
     const payment = await incomingPaymentService.get({
       id: args.id
     })
-    if (!payment) throw new Error('payment does not exist')
+    if (!payment) {
+      throw new GraphQLError('payment does not exist', {
+        extensions: {
+          code: GraphQLErrorCode.NotFound
+        }
+      })
+    }
     return paymentToGraphql(payment)
   }
 
@@ -34,7 +41,13 @@ export const getWalletAddressIncomingPayments: WalletAddressResolvers<ApolloCont
     args,
     ctx
   ): Promise<ResolversTypes['IncomingPaymentConnection']> => {
-    if (!parent.id) throw new Error('missing wallet address id')
+    if (!parent.id) {
+      throw new GraphQLError('missing wallet address id', {
+        extensions: {
+          code: GraphQLErrorCode.BadUserInput
+        }
+      })
+    }
     const incomingPaymentService = await ctx.container.use(
       'incomingPaymentService'
     )

--- a/packages/backend/src/graphql/resolvers/liquidity.test.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.test.ts
@@ -80,8 +80,7 @@ describe('Liquidity Resolvers', (): void => {
           mutation: gql`
             mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
               depositPeerLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -102,8 +101,7 @@ describe('Liquidity Resolvers', (): void => {
           }
         })
 
-      expect(response.id).toEqual(id)
-      expect(response.liquidity).toEqual('100')
+      expect(response.success).toBe(true)
     })
 
     test('Returns an error for invalid id', async (): Promise<void> => {
@@ -112,8 +110,7 @@ describe('Liquidity Resolvers', (): void => {
           mutation: gql`
             mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
               depositPeerLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -149,8 +146,7 @@ describe('Liquidity Resolvers', (): void => {
           mutation: gql`
             mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
               depositPeerLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -194,8 +190,7 @@ describe('Liquidity Resolvers', (): void => {
           mutation: gql`
             mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
               depositPeerLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -231,8 +226,7 @@ describe('Liquidity Resolvers', (): void => {
           mutation: gql`
             mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
               depositPeerLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -279,8 +273,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: DepositAssetLiquidityInput!
             ) {
               depositAssetLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -301,8 +294,7 @@ describe('Liquidity Resolvers', (): void => {
           }
         })
 
-      expect(response.id).toEqual(id)
-      expect(response.liquidity).toEqual('100')
+      expect(response.success).toBe(true)
     })
 
     test('Returns an error for invalid id', async (): Promise<void> => {
@@ -313,8 +305,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: DepositAssetLiquidityInput!
             ) {
               depositAssetLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -352,8 +343,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: DepositAssetLiquidityInput!
             ) {
               depositAssetLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -399,8 +389,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: DepositAssetLiquidityInput!
             ) {
               depositAssetLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -438,8 +427,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: DepositAssetLiquidityInput!
             ) {
               depositAssetLiquidity(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -494,8 +482,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreatePeerLiquidityWithdrawalInput!
             ) {
               createPeerLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -517,8 +504,7 @@ describe('Liquidity Resolvers', (): void => {
           }
         })
 
-      expect(response.id).toEqual(id)
-      expect(response.liquidity).toEqual(startingBalance.toString())
+      expect(response.success).toBe(true)
     })
 
     test('Returns an error for unknown peer', async (): Promise<void> => {
@@ -529,8 +515,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreatePeerLiquidityWithdrawalInput!
             ) {
               createPeerLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -569,8 +554,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreatePeerLiquidityWithdrawalInput!
             ) {
               createPeerLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -617,8 +601,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreatePeerLiquidityWithdrawalInput!
             ) {
               createPeerLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -662,8 +645,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: CreatePeerLiquidityWithdrawalInput!
               ) {
                 createPeerLiquidityWithdrawal(input: $input) {
-                  id
-                  liquidity
+                  success
                 }
               }
             `,
@@ -720,8 +702,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreateAssetLiquidityWithdrawalInput!
             ) {
               createAssetLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -743,8 +724,7 @@ describe('Liquidity Resolvers', (): void => {
           }
         })
 
-      expect(response.id).toEqual(id)
-      expect(response.liquidity).toEqual(startingBalance.toString())
+      expect(response.success).toBe(true)
     })
 
     test('Returns an error for unknown asset', async (): Promise<void> => {
@@ -755,8 +735,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreateAssetLiquidityWithdrawalInput!
             ) {
               createAssetLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -795,8 +774,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreateAssetLiquidityWithdrawalInput!
             ) {
               createAssetLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -843,8 +821,7 @@ describe('Liquidity Resolvers', (): void => {
               $input: CreateAssetLiquidityWithdrawalInput!
             ) {
               createAssetLiquidityWithdrawal(input: $input) {
-                id
-                liquidity
+                success
               }
             }
           `,
@@ -889,8 +866,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: CreateAssetLiquidityWithdrawalInput!
               ) {
                 createAssetLiquidityWithdrawal(input: $input) {
-                  id
-                  liquidity
+                  success
                 }
               }
             `,
@@ -1197,7 +1173,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: PostLiquidityWithdrawalInput!
               ) {
                 postLiquidityWithdrawal(input: $input) {
-                  id
+                  success
                 }
               }
             `,
@@ -1216,7 +1192,7 @@ describe('Liquidity Resolvers', (): void => {
             }
           })
 
-        expect(response.id).toEqual(withdrawalId)
+        expect(response.success).toBe(true)
       })
 
       test("Can't post non-existent withdrawal", async (): Promise<void> => {
@@ -1227,8 +1203,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: PostLiquidityWithdrawalInput!
               ) {
                 postLiquidityWithdrawal(input: $input) {
-                  id
-                  liquidity
+                  success
                 }
               }
             `,
@@ -1264,8 +1239,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: PostLiquidityWithdrawalInput!
               ) {
                 postLiquidityWithdrawal(input: $input) {
-                  id
-                  liquidity
+                  success
                 }
               }
             `,
@@ -1304,8 +1278,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: PostLiquidityWithdrawalInput!
               ) {
                 postLiquidityWithdrawal(input: $input) {
-                  id
-                  liquidity
+                  success
                 }
               }
             `,
@@ -1344,8 +1317,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: PostLiquidityWithdrawalInput!
               ) {
                 postLiquidityWithdrawal(input: $input) {
-                  id
-                  liquidity
+                  success
                 }
               }
             `,
@@ -1409,7 +1381,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: VoidLiquidityWithdrawalInput!
               ) {
                 voidLiquidityWithdrawal(input: $input) {
-                  id
+                  success
                 }
               }
             `,
@@ -1428,7 +1400,7 @@ describe('Liquidity Resolvers', (): void => {
             }
           })
 
-        expect(response.id).toEqual(withdrawalId)
+        expect(response.success).toBe(true)
       })
 
       test("Can't void non-existent withdrawal", async (): Promise<void> => {
@@ -1439,7 +1411,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: VoidLiquidityWithdrawalInput!
               ) {
                 voidLiquidityWithdrawal(input: $input) {
-                  id
+                  success
                 }
               }
             `,
@@ -1475,7 +1447,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: VoidLiquidityWithdrawalInput!
               ) {
                 voidLiquidityWithdrawal(input: $input) {
-                  id
+                  success
                 }
               }
             `,
@@ -1514,7 +1486,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: VoidLiquidityWithdrawalInput!
               ) {
                 voidLiquidityWithdrawal(input: $input) {
-                  id
+                  success
                 }
               }
             `,
@@ -1553,7 +1525,7 @@ describe('Liquidity Resolvers', (): void => {
                 $input: VoidLiquidityWithdrawalInput!
               ) {
                 voidLiquidityWithdrawal(input: $input) {
-                  id
+                  success
                 }
               }
             `,
@@ -1644,8 +1616,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: DepositEventLiquidityInput!
                   ) {
                     depositEventLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -1664,7 +1635,7 @@ describe('Liquidity Resolvers', (): void => {
                 }
               })
 
-            assert.ok(response.id)
+            expect(response.success).toBe(true)
             assert.ok(payment.debitAmount)
             await expect(depositSpy).toHaveBeenCalledWith({
               id: eventId,
@@ -1684,8 +1655,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: DepositEventLiquidityInput!
                   ) {
                     depositEventLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -1728,8 +1698,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: DepositEventLiquidityInput!
                   ) {
                     depositEventLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -1870,8 +1839,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: WithdrawEventLiquidityInput!
                   ) {
                     withdrawEventLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -1890,8 +1858,7 @@ describe('Liquidity Resolvers', (): void => {
                 }
               })
 
-            expect(response.id).toEqual(eventId)
-            expect(response.liquidity).toEqual('10')
+            expect(response.success).toBe(true)
           })
 
           test('Returns error for non-existent webhook event id', async (): Promise<void> => {
@@ -1902,8 +1869,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: WithdrawEventLiquidityInput!
                   ) {
                     withdrawEventLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -1942,8 +1908,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: WithdrawEventLiquidityInput!
                   ) {
                     withdrawEventLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -2053,8 +2018,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateIncomingPaymentWithdrawalInput!
                 ) {
                   createIncomingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2074,7 +2038,7 @@ describe('Liquidity Resolvers', (): void => {
               }
             })
 
-          assert.ok(response.id)
+          expect(response.success).toBe(true)
           expect(
             accountingService.getBalance(incomingPayment.id)
           ).resolves.toEqual(balance - amount)
@@ -2101,8 +2065,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateIncomingPaymentWithdrawalInput!
                 ) {
                   createIncomingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2139,8 +2102,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateIncomingPaymentWithdrawalInput!
                 ) {
                   createIncomingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2196,8 +2158,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateIncomingPaymentWithdrawalInput!
                 ) {
                   createIncomingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2271,8 +2232,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateOutgoingPaymentWithdrawalInput!
                 ) {
                   createOutgoingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2292,7 +2252,7 @@ describe('Liquidity Resolvers', (): void => {
               }
             })
 
-          assert.ok(response.id)
+          expect(response.success).toBe(true)
           expect(
             accountingService.getBalance(outgoingPayment.id)
           ).resolves.toEqual(balance - amount)
@@ -2308,8 +2268,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateOutgoingPaymentWithdrawalInput!
                 ) {
                   createOutgoingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2352,8 +2311,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateOutgoingPaymentWithdrawalInput!
                 ) {
                   createOutgoingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2408,8 +2366,7 @@ describe('Liquidity Resolvers', (): void => {
                   $input: CreateOutgoingPaymentWithdrawalInput!
                 ) {
                   createOutgoingPaymentWithdrawal(input: $input) {
-                    id
-                    liquidity
+                    success
                   }
                 }
               `,
@@ -2467,8 +2424,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: DepositOutgoingPaymentLiquidityInput!
                   ) {
                     depositOutgoingPaymentLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -2487,7 +2443,7 @@ describe('Liquidity Resolvers', (): void => {
                 }
               })
 
-            assert.ok(response.id)
+            expect(response.success).toBe(true)
             assert.ok(outgoingPayment.debitAmount)
             await expect(depositSpy).toHaveBeenCalledWith({
               id: eventId,
@@ -2507,8 +2463,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: DepositOutgoingPaymentLiquidityInput!
                   ) {
                     depositOutgoingPaymentLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,
@@ -2551,8 +2506,7 @@ describe('Liquidity Resolvers', (): void => {
                     $input: DepositOutgoingPaymentLiquidityInput!
                   ) {
                     depositOutgoingPaymentLiquidity(input: $input) {
-                      id
-                      liquidity
+                      success
                     }
                   }
                 `,

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -128,7 +128,7 @@ export const depositAssetLiquidity: MutationResolvers<ApolloContext>['depositAss
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-    if (args.input.amount === BigInt(0)) {
+    if (args.input.amount === 0n) {
       throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
         extensions: {
           code: errorToCode[LiquidityError.AmountZero]
@@ -211,7 +211,7 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
     const { amount, id, timeoutSeconds, assetId } = args.input
-    if (amount === BigInt(0)) {
+    if (amount === 0n) {
       throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
         extensions: {
           code: errorToCode[LiquidityError.AmountZero]
@@ -269,7 +269,7 @@ export const createWalletAddressWithdrawal: MutationResolvers<ApolloContext>['cr
     const amount = await accountingService.getBalance(walletAddress.id)
     if (amount === undefined)
       throw new Error('missing incoming payment wallet address')
-    if (amount === BigInt(0)) {
+    if (amount === 0n) {
       throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
         extensions: {
           code: errorToCode[LiquidityError.AmountZero]

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -170,34 +170,16 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-<<<<<<< HEAD
-    try {
-      const { amount, id, timeoutSeconds, peerId } = args.input
-      if (amount === BigInt(0)) {
-        return responses[LiquidityError.AmountZero]
-      }
-      const peerService = await ctx.container.use('peerService')
-      const peer = await peerService.get(peerId)
-      if (!peer) {
-        return responses[LiquidityError.UnknownPeer]
-      }
-      const accountingService = await ctx.container.use('accountingService')
-      const error = await accountingService.createWithdrawal({
-        id,
-        account: peer,
-        amount,
-        timeout: Number(timeoutSeconds)
-=======
+    const { amount, id, timeoutSeconds, peerId } = args.input
     if (args.input.amount === BigInt(0)) {
       throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
         extensions: {
           code: errorToCode[LiquidityError.AmountZero]
         }
->>>>>>> c702654c (feat(wip): backend graphql logs)
       })
     }
     const peerService = await ctx.container.use('peerService')
-    const peer = await peerService.get(args.input.peerId)
+    const peer = await peerService.get(peerId)
     if (!peer) {
       throw new GraphQLError(errorToMessage[LiquidityError.UnknownPeer], {
         extensions: {
@@ -207,10 +189,10 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
     }
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createWithdrawal({
-      id: args.input.id,
+      id,
       account: peer,
-      amount: args.input.amount,
-      timeout: 60
+      amount,
+      timeout: Number(timeoutSeconds)
     })
     if (error) {
       throw new GraphQLError(transferErrorToMessage[error], {
@@ -220,8 +202,8 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
       })
     }
     return {
-      id: args.input.id,
-      liquidity: args.input.amount
+      id,
+      liquidity: amount
     }
   }
 
@@ -231,34 +213,16 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-<<<<<<< HEAD
-    try {
-      const { amount, id, timeoutSeconds, assetId } = args.input
-      if (amount === 0n) {
-        return responses[LiquidityError.AmountZero]
-      }
-      const assetService = await ctx.container.use('assetService')
-      const asset = await assetService.get(assetId)
-      if (!asset) {
-        return responses[LiquidityError.UnknownAsset]
-      }
-      const accountingService = await ctx.container.use('accountingService')
-      const error = await accountingService.createWithdrawal({
-        id,
-        account: asset,
-        amount,
-        timeout: Number(timeoutSeconds)
-=======
-    if (args.input.amount === BigInt(0)) {
+    const { amount, id, timeoutSeconds, assetId } = args.input
+    if (amount === BigInt(0)) {
       throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
         extensions: {
           code: errorToCode[LiquidityError.AmountZero]
         }
->>>>>>> c702654c (feat(wip): backend graphql logs)
       })
     }
     const assetService = await ctx.container.use('assetService')
-    const asset = await assetService.get(args.input.assetId)
+    const asset = await assetService.get(assetId)
     if (!asset) {
       throw new GraphQLError(errorToMessage[LiquidityError.UnknownAsset], {
         extensions: {
@@ -268,10 +232,10 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
     }
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createWithdrawal({
-      id: args.input.id,
+      id,
       account: asset,
-      amount: args.input.amount,
-      timeout: 60
+      amount,
+      timeout: Number(timeoutSeconds)
     })
     if (error) {
       throw new GraphQLError(transferErrorToMessage[error], {
@@ -281,8 +245,8 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
       })
     }
     return {
-      id: args.input.id,
-      liquidity: args.input.amount
+      id,
+      liquidity: amount
     }
   }
 
@@ -292,62 +256,12 @@ export const createWalletAddressWithdrawal: MutationResolvers<ApolloContext>['cr
     args,
     ctx
   ): Promise<ResolversTypes['WalletAddressWithdrawalMutationResponse']> => {
-<<<<<<< HEAD
-    try {
-      const { id, walletAddressId, timeoutSeconds } = args.input
-      const walletAddressService = await ctx.container.use(
-        'walletAddressService'
-      )
-      const walletAddress = await walletAddressService.get(walletAddressId)
-      if (!walletAddress) {
-        return responses[
-          LiquidityError.UnknownWalletAddress
-        ] as unknown as WalletAddressWithdrawalMutationResponse
-      }
-      const accountingService = await ctx.container.use('accountingService')
-      const amount = await accountingService.getBalance(walletAddress.id)
-      if (amount === undefined)
-        throw new Error(
-          `Could not get balance for wallet address liquidity account. It's likely the liquidity account does not exist.`
-        )
-      else if (amount === 0n) {
-        return responses[
-          LiquidityError.AmountZero
-        ] as unknown as WalletAddressWithdrawalMutationResponse
-      }
-      const error = await accountingService.createWithdrawal({
-        id,
-        account: walletAddress,
-        amount,
-        timeout: Number(timeoutSeconds)
-      })
-
-      if (error) {
-        return errorToResponse(
-          error
-        ) as unknown as WalletAddressWithdrawalMutationResponse
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Created account withdrawal',
-        withdrawal: {
-          id,
-          amount,
-          walletAddress: walletAddressToGraphql(walletAddress)
-        }
-      }
-    } catch (err) {
-      ctx.logger.error(
-=======
+    const { id, walletAddressId, timeoutSeconds } = args.input
     const walletAddressService = await ctx.container.use('walletAddressService')
-    const walletAddress = await walletAddressService.get(
-      args.input.walletAddressId
-    )
+    const walletAddress = await walletAddressService.get(walletAddressId)
     if (!walletAddress) {
       throw new GraphQLError(
         errorToMessage[LiquidityError.UnknownWalletAddress],
->>>>>>> c702654c (feat(wip): backend graphql logs)
         {
           extensions: {
             code: errorToCode[LiquidityError.UnknownWalletAddress]
@@ -355,7 +269,6 @@ export const createWalletAddressWithdrawal: MutationResolvers<ApolloContext>['cr
         }
       )
     }
-    const id = args.input.id
     const accountingService = await ctx.container.use('accountingService')
     const amount = await accountingService.getBalance(walletAddress.id)
     if (amount === undefined)
@@ -371,7 +284,7 @@ export const createWalletAddressWithdrawal: MutationResolvers<ApolloContext>['cr
       id,
       account: walletAddress,
       amount,
-      timeout: 60
+      timeout: Number(timeoutSeconds)
     })
 
     if (error) {
@@ -577,16 +490,7 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-<<<<<<< HEAD
     const { incomingPaymentId, timeoutSeconds } = args.input
-    try {
-      const incomingPaymentService = await ctx.container.use(
-        'incomingPaymentService'
-      )
-      const incomingPayment = await incomingPaymentService.get({
-        id: incomingPaymentId
-=======
-    const { incomingPaymentId } = args.input
     const incomingPaymentService = await ctx.container.use(
       'incomingPaymentService'
     )
@@ -606,22 +510,9 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
         extensions: {
           code: errorToCode[LiquidityError.InvalidId]
         }
->>>>>>> c702654c (feat(wip): backend graphql logs)
       })
     }
 
-<<<<<<< HEAD
-      const accountingService = await ctx.container.use('accountingService')
-      const error = await accountingService.createWithdrawal({
-        id: event.id,
-        account: {
-          id: incomingPaymentId,
-          asset: incomingPayment.asset
-        },
-        amount: incomingPayment.receivedAmount.value,
-        timeout: Number(timeoutSeconds)
-      })
-=======
     const accountingService = await ctx.container.use('accountingService')
     const error = await accountingService.createWithdrawal({
       id: event.id,
@@ -629,9 +520,9 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
         id: incomingPaymentId,
         asset: incomingPayment.asset
       },
-      amount: incomingPayment.receivedAmount.value
+      amount: incomingPayment.receivedAmount.value,
+      timeout: Number(timeoutSeconds)
     })
->>>>>>> c702654c (feat(wip): backend graphql logs)
 
     if (error) {
       throw new GraphQLError(fundingErrorToMessage[error], {
@@ -652,16 +543,7 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-<<<<<<< HEAD
     const { outgoingPaymentId, timeoutSeconds } = args.input
-    try {
-      const outgoingPaymentService = await ctx.container.use(
-        'outgoingPaymentService'
-      )
-      const outgoingPayment = await outgoingPaymentService.get({
-        id: outgoingPaymentId
-=======
-    const { outgoingPaymentId } = args.input
     const outgoingPaymentService = await ctx.container.use(
       'outgoingPaymentService'
     )
@@ -681,44 +563,14 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
         extensions: {
           code: errorToCode[LiquidityError.InvalidId]
         }
->>>>>>> c702654c (feat(wip): backend graphql logs)
       })
     }
 
-<<<<<<< HEAD
-      const accountingService = await ctx.container.use('accountingService')
-      const balance = await accountingService.getBalance(outgoingPayment.id)
-      if (!balance) {
-        return responses[LiquidityError.InsufficientBalance]
-      }
-
-      const error = await accountingService.createWithdrawal({
-        id: event.id,
-        account: {
-          id: outgoingPaymentId,
-          asset: outgoingPayment.asset
-        },
-        amount: balance,
-        timeout: Number(timeoutSeconds)
-      })
-
-      if (error) {
-        return errorToResponse(error)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Withdrew liquidity'
-      }
-    } catch (error) {
-      ctx.logger.error(
-=======
     const accountingService = await ctx.container.use('accountingService')
     const balance = await accountingService.getBalance(outgoingPayment.id)
     if (!balance) {
       throw new GraphQLError(
         errorToMessage[LiquidityError.InsufficientBalance],
->>>>>>> c702654c (feat(wip): backend graphql logs)
         {
           extensions: {
             code: errorToCode[LiquidityError.InsufficientBalance]
@@ -733,7 +585,8 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
         id: outgoingPaymentId,
         asset: outgoingPayment.asset
       },
-      amount: balance
+      amount: balance,
+      timeout: Number(timeoutSeconds)
     })
 
     if (error) {

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -118,8 +118,7 @@ export const depositPeerLiquidity: MutationResolvers<ApolloContext>['depositPeer
     }
 
     return {
-      id: args.input.id,
-      liquidity: args.input.amount
+      success: true
     }
   }
 
@@ -159,8 +158,7 @@ export const depositAssetLiquidity: MutationResolvers<ApolloContext>['depositAss
       })
     }
     return {
-      id: args.input.id,
-      liquidity: args.input.amount
+      success: true
     }
   }
 
@@ -202,8 +200,7 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
       })
     }
     return {
-      id,
-      liquidity: amount
+      success: true
     }
   }
 
@@ -245,8 +242,7 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
       })
     }
     return {
-      id,
-      liquidity: amount
+      success: true
     }
   }
 
@@ -321,7 +317,7 @@ export const postLiquidityWithdrawal: MutationResolvers<ApolloContext>['postLiqu
       })
     }
     return {
-      id: args.input.withdrawalId
+      success: true
     }
   }
 
@@ -343,7 +339,7 @@ export const voidLiquidityWithdrawal: MutationResolvers<ApolloContext>['voidLiqu
       })
     }
     return {
-      id: args.input.withdrawalId
+      success: true
     }
   }
 
@@ -392,8 +388,7 @@ export const depositEventLiquidity: MutationResolvers<ApolloContext>['depositEve
       })
     }
     return {
-      id: event.data.id,
-      liquidity: BigInt(event.data.debitAmount.value)
+      success: true
     }
   }
 
@@ -435,8 +430,7 @@ export const withdrawEventLiquidity: MutationResolvers<ApolloContext>['withdrawE
     }
     // TODO: check for and handle leftover incoming payment or payment balance
     return {
-      id: event.id,
-      liquidity: event.withdrawal.amount
+      success: true
     }
   }
 
@@ -479,8 +473,7 @@ export const depositOutgoingPaymentLiquidity: MutationResolvers<ApolloContext>['
       })
     }
     return {
-      id: outgoingPaymentId,
-      liquidity: BigInt(event.data.debitAmount.value)
+      success: true
     }
   }
 
@@ -532,8 +525,7 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
       })
     }
     return {
-      id: event.id,
-      liquidity: incomingPayment.receivedAmount.value
+      success: true
     }
   }
 
@@ -597,8 +589,7 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
       })
     }
     return {
-      id: event.id,
-      liquidity: balance
+      success: true
     }
   }
 

--- a/packages/backend/src/graphql/resolvers/liquidity.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.ts
@@ -1,10 +1,10 @@
+import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 import { walletAddressToGraphql } from './wallet_address'
 import {
   ResolversTypes,
   MutationResolvers,
   LiquidityError,
-  LiquidityMutationResponse,
-  WalletAddressWithdrawalMutationResponse,
   AssetResolvers,
   PeerResolvers,
   WalletAddressResolvers,
@@ -14,15 +14,24 @@ import {
 } from '../generated/graphql'
 import { ApolloContext } from '../../app'
 import {
-  FundingError,
+  fundingErrorToMessage,
+  fundingErrorToCode,
   isFundingError
 } from '../../open_payments/payment/outgoing/errors'
+import {
+  errorToCode as transferErrorToCode,
+  errorToMessage as transferErrorToMessage
+} from '../../accounting/errors'
 import {
   isOutgoingPaymentEvent,
   OutgoingPaymentDepositType,
   OutgoingPaymentEventType
 } from '../../open_payments/payment/outgoing/model'
-import { PeerError } from '../../payment-method/ilp/peer/errors'
+import {
+  PeerError,
+  errorToMessage as peerErrorToMessage,
+  errorToCode as peerErrorToCode
+} from '../../payment-method/ilp/peer/errors'
 import { IncomingPaymentEventType } from '../../open_payments/payment/incoming/model'
 
 export const getAssetLiquidity: AssetResolvers<ApolloContext>['liquidity'] =
@@ -80,41 +89,37 @@ export const depositPeerLiquidity: MutationResolvers<ApolloContext>['depositPeer
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-    try {
-      if (args.input.amount === BigInt(0)) {
-        return responses[LiquidityError.AmountZero]
-      }
-      const peerService = await ctx.container.use('peerService')
-      const peerOrError = await peerService.depositLiquidity({
-        transferId: args.input.id,
-        peerId: args.input.peerId,
-        amount: args.input.amount
+    if (args.input.amount === BigInt(0)) {
+      throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
+        extensions: {
+          code: errorToCode[LiquidityError.AmountZero]
+        }
       })
+    }
+    const peerService = await ctx.container.use('peerService')
+    const peerOrError = await peerService.depositLiquidity({
+      transferId: args.input.id,
+      peerId: args.input.peerId,
+      amount: args.input.amount
+    })
 
-      if (peerOrError === PeerError.UnknownPeer) {
-        return responses[LiquidityError.UnknownPeer]
-      } else if (isLiquidityError(peerOrError)) {
-        return errorToResponse(peerOrError)
-      }
+    if (peerOrError === PeerError.UnknownPeer) {
+      throw new GraphQLError(peerErrorToMessage[peerOrError], {
+        extensions: {
+          code: peerErrorToCode[peerOrError]
+        }
+      })
+    } else if (isLiquidityError(peerOrError)) {
+      throw new GraphQLError(errorToMessage[peerOrError], {
+        extensions: {
+          code: errorToCode[peerOrError]
+        }
+      })
+    }
 
-      return {
-        code: '200',
-        success: true,
-        message: 'Added peer liquidity'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          input: args.input,
-          err
-        },
-        'error adding peer liquidity'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to deposit peer liquidity',
-        success: false
-      }
+    return {
+      id: args.input.id,
+      liquidity: args.input.amount
     }
   }
 
@@ -124,42 +129,38 @@ export const depositAssetLiquidity: MutationResolvers<ApolloContext>['depositAss
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-    try {
-      if (args.input.amount === BigInt(0)) {
-        return responses[LiquidityError.AmountZero]
-      }
-      const assetService = await ctx.container.use('assetService')
-      const asset = await assetService.get(args.input.assetId)
-      if (!asset) {
-        return responses[LiquidityError.UnknownAsset]
-      }
-      const accountingService = await ctx.container.use('accountingService')
-      const error = await accountingService.createDeposit({
-        id: args.input.id,
-        account: asset,
-        amount: args.input.amount
+    if (args.input.amount === BigInt(0)) {
+      throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
+        extensions: {
+          code: errorToCode[LiquidityError.AmountZero]
+        }
       })
-      if (error) {
-        return errorToResponse(error)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Added asset liquidity'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          input: args.input,
-          err
-        },
-        'error adding asset liquidity'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to deposit asset liquidity',
-        success: false
-      }
+    }
+    const assetService = await ctx.container.use('assetService')
+    const asset = await assetService.get(args.input.assetId)
+    if (!asset) {
+      throw new GraphQLError(errorToMessage[LiquidityError.UnknownAsset], {
+        extensions: {
+          code: errorToCode[LiquidityError.UnknownAsset]
+        }
+      })
+    }
+    const accountingService = await ctx.container.use('accountingService')
+    const error = await accountingService.createDeposit({
+      id: args.input.id,
+      account: asset,
+      amount: args.input.amount
+    })
+    if (error) {
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
+    }
+    return {
+      id: args.input.id,
+      liquidity: args.input.amount
     }
   }
 
@@ -169,6 +170,7 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
+<<<<<<< HEAD
     try {
       const { amount, id, timeoutSeconds, peerId } = args.input
       if (amount === BigInt(0)) {
@@ -185,28 +187,41 @@ export const createPeerLiquidityWithdrawal: MutationResolvers<ApolloContext>['cr
         account: peer,
         amount,
         timeout: Number(timeoutSeconds)
+=======
+    if (args.input.amount === BigInt(0)) {
+      throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
+        extensions: {
+          code: errorToCode[LiquidityError.AmountZero]
+        }
+>>>>>>> c702654c (feat(wip): backend graphql logs)
       })
-      if (error) {
-        return errorToResponse(error)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Created peer liquidity withdrawal'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          input: args.input,
-          err
-        },
-        'error creating peer liquidity withdrawal'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to create peer liquidity withdrawal',
-        success: false
-      }
+    }
+    const peerService = await ctx.container.use('peerService')
+    const peer = await peerService.get(args.input.peerId)
+    if (!peer) {
+      throw new GraphQLError(errorToMessage[LiquidityError.UnknownPeer], {
+        extensions: {
+          code: errorToCode[LiquidityError.UnknownPeer]
+        }
+      })
+    }
+    const accountingService = await ctx.container.use('accountingService')
+    const error = await accountingService.createWithdrawal({
+      id: args.input.id,
+      account: peer,
+      amount: args.input.amount,
+      timeout: 60
+    })
+    if (error) {
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
+    }
+    return {
+      id: args.input.id,
+      liquidity: args.input.amount
     }
   }
 
@@ -216,6 +231,7 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
+<<<<<<< HEAD
     try {
       const { amount, id, timeoutSeconds, assetId } = args.input
       if (amount === 0n) {
@@ -232,28 +248,41 @@ export const createAssetLiquidityWithdrawal: MutationResolvers<ApolloContext>['c
         account: asset,
         amount,
         timeout: Number(timeoutSeconds)
+=======
+    if (args.input.amount === BigInt(0)) {
+      throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
+        extensions: {
+          code: errorToCode[LiquidityError.AmountZero]
+        }
+>>>>>>> c702654c (feat(wip): backend graphql logs)
       })
-      if (error) {
-        return errorToResponse(error)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Created asset liquidity withdrawal'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          input: args.input,
-          err
-        },
-        'error creating asset liquidity withdrawal'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to create asset liquidity withdrawal',
-        success: false
-      }
+    }
+    const assetService = await ctx.container.use('assetService')
+    const asset = await assetService.get(args.input.assetId)
+    if (!asset) {
+      throw new GraphQLError(errorToMessage[LiquidityError.UnknownAsset], {
+        extensions: {
+          code: errorToCode[LiquidityError.UnknownAsset]
+        }
+      })
+    }
+    const accountingService = await ctx.container.use('accountingService')
+    const error = await accountingService.createWithdrawal({
+      id: args.input.id,
+      account: asset,
+      amount: args.input.amount,
+      timeout: 60
+    })
+    if (error) {
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
+    }
+    return {
+      id: args.input.id,
+      liquidity: args.input.amount
     }
   }
 
@@ -263,6 +292,7 @@ export const createWalletAddressWithdrawal: MutationResolvers<ApolloContext>['cr
     args,
     ctx
   ): Promise<ResolversTypes['WalletAddressWithdrawalMutationResponse']> => {
+<<<<<<< HEAD
     try {
       const { id, walletAddressId, timeoutSeconds } = args.input
       const walletAddressService = await ctx.container.use(
@@ -309,16 +339,53 @@ export const createWalletAddressWithdrawal: MutationResolvers<ApolloContext>['cr
       }
     } catch (err) {
       ctx.logger.error(
+=======
+    const walletAddressService = await ctx.container.use('walletAddressService')
+    const walletAddress = await walletAddressService.get(
+      args.input.walletAddressId
+    )
+    if (!walletAddress) {
+      throw new GraphQLError(
+        errorToMessage[LiquidityError.UnknownWalletAddress],
+>>>>>>> c702654c (feat(wip): backend graphql logs)
         {
-          input: args.input,
-          err
-        },
-        'error creating wallet address withdrawal'
+          extensions: {
+            code: errorToCode[LiquidityError.UnknownWalletAddress]
+          }
+        }
       )
-      return {
-        code: '500',
-        message: 'Error trying to create wallet address withdrawal',
-        success: false
+    }
+    const id = args.input.id
+    const accountingService = await ctx.container.use('accountingService')
+    const amount = await accountingService.getBalance(walletAddress.id)
+    if (amount === undefined)
+      throw new Error('missing incoming payment wallet address')
+    if (amount === BigInt(0)) {
+      throw new GraphQLError(errorToMessage[LiquidityError.AmountZero], {
+        extensions: {
+          code: errorToCode[LiquidityError.AmountZero]
+        }
+      })
+    }
+    const error = await accountingService.createWithdrawal({
+      id,
+      account: walletAddress,
+      amount,
+      timeout: 60
+    })
+
+    if (error) {
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
+    }
+    return {
+      withdrawal: {
+        id,
+        amount,
+        walletAddress: walletAddressToGraphql(walletAddress)
       }
     }
   }
@@ -334,12 +401,14 @@ export const postLiquidityWithdrawal: MutationResolvers<ApolloContext>['postLiqu
       args.input.withdrawalId
     )
     if (error) {
-      return errorToResponse(error)
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
     }
     return {
-      code: '200',
-      success: true,
-      message: 'Posted Withdrawal'
+      id: args.input.withdrawalId
     }
   }
 
@@ -354,12 +423,14 @@ export const voidLiquidityWithdrawal: MutationResolvers<ApolloContext>['voidLiqu
       args.input.withdrawalId
     )
     if (error) {
-      return errorToResponse(error)
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
     }
     return {
-      code: '200',
-      success: true,
-      message: 'Voided Withdrawal'
+      id: args.input.withdrawalId
     }
   }
 
@@ -376,48 +447,40 @@ export const depositEventLiquidity: MutationResolvers<ApolloContext>['depositEve
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-    try {
-      const webhookService = await ctx.container.use('webhookService')
-      const event = await webhookService.getEvent(args.input.eventId)
-      if (
-        !event ||
-        !isOutgoingPaymentEvent(event) ||
-        !isDepositEventType(event.type)
-      ) {
-        return responses[LiquidityError.InvalidId]
-      }
-      if (!event.data.debitAmount) {
-        throw new Error('missing debit amount')
-      }
-      const outgoingPaymentService = await ctx.container.use(
-        'outgoingPaymentService'
-      )
-      const paymentOrErr = await outgoingPaymentService.fund({
-        id: event.data.id,
-        amount: BigInt(event.data.debitAmount.value),
-        transferId: event.id
+    const webhookService = await ctx.container.use('webhookService')
+    const event = await webhookService.getEvent(args.input.eventId)
+    if (
+      !event ||
+      !isOutgoingPaymentEvent(event) ||
+      !isDepositEventType(event.type)
+    ) {
+      throw new GraphQLError(errorToMessage[LiquidityError.InvalidId], {
+        extensions: {
+          code: errorToCode[LiquidityError.InvalidId]
+        }
       })
-      if (isFundingError(paymentOrErr)) {
-        return errorToResponse(paymentOrErr)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Deposited liquidity'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          eventId: args.input.eventId,
-          err
-        },
-        'error depositing liquidity'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to deposit liquidity',
-        success: false
-      }
+    }
+    if (!event.data.debitAmount) {
+      throw new Error('missing debit amount')
+    }
+    const outgoingPaymentService = await ctx.container.use(
+      'outgoingPaymentService'
+    )
+    const paymentOrErr = await outgoingPaymentService.fund({
+      id: event.data.id,
+      amount: BigInt(event.data.debitAmount.value),
+      transferId: event.id
+    })
+    if (isFundingError(paymentOrErr)) {
+      throw new GraphQLError(fundingErrorToMessage[paymentOrErr], {
+        extensions: {
+          code: fundingErrorToCode[paymentOrErr]
+        }
+      })
+    }
+    return {
+      id: event.data.id,
+      liquidity: BigInt(event.data.debitAmount.value)
     }
   }
 
@@ -427,48 +490,40 @@ export const withdrawEventLiquidity: MutationResolvers<ApolloContext>['withdrawE
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-    try {
-      const webhookService = await ctx.container.use('webhookService')
-      const event = await webhookService.getEvent(args.input.eventId)
-      if (!event || !event.withdrawal) {
-        return responses[LiquidityError.InvalidId]
-      }
-      const assetService = await ctx.container.use('assetService')
-      const asset = await assetService.get(event.withdrawal.assetId)
-      if (!asset) {
-        throw new Error('asset id does not map to asset')
-      }
-      const accountingService = await ctx.container.use('accountingService')
-      const error = await accountingService.createWithdrawal({
-        id: event.id,
-        account: {
-          id: event.withdrawal.accountId,
-          asset
-        },
-        amount: event.withdrawal.amount
+    const webhookService = await ctx.container.use('webhookService')
+    const event = await webhookService.getEvent(args.input.eventId)
+    if (!event || !event.withdrawal) {
+      throw new GraphQLError(errorToMessage[LiquidityError.InvalidId], {
+        extensions: {
+          code: errorToCode[LiquidityError.InvalidId]
+        }
       })
-      if (error) {
-        return errorToResponse(error)
-      }
-      // TODO: check for and handle leftover incoming payment or payment balance
-      return {
-        code: '200',
-        success: true,
-        message: 'Withdrew liquidity'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          eventId: args.input.eventId,
-          err
-        },
-        'error withdrawing liquidity'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to withdraw liquidity',
-        success: false
-      }
+    }
+    const assetService = await ctx.container.use('assetService')
+    const asset = await assetService.get(event.withdrawal.assetId)
+    if (!asset) {
+      throw new Error('asset id does not map to asset')
+    }
+    const accountingService = await ctx.container.use('accountingService')
+    const error = await accountingService.createWithdrawal({
+      id: event.id,
+      account: {
+        id: event.withdrawal.accountId,
+        asset
+      },
+      amount: event.withdrawal.amount
+    })
+    if (error) {
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
+    }
+    // TODO: check for and handle leftover incoming payment or payment balance
+    return {
+      id: event.id,
+      liquidity: event.withdrawal.amount
     }
   }
 
@@ -478,49 +533,41 @@ export const depositOutgoingPaymentLiquidity: MutationResolvers<ApolloContext>['
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
-    try {
-      const { outgoingPaymentId } = args.input
-      const webhookService = await ctx.container.use('webhookService')
-      const event = await webhookService.getLatestByResourceId({
-        outgoingPaymentId,
-        types: [OutgoingPaymentDepositType.PaymentCreated]
+    const { outgoingPaymentId } = args.input
+    const webhookService = await ctx.container.use('webhookService')
+    const event = await webhookService.getLatestByResourceId({
+      outgoingPaymentId,
+      types: [OutgoingPaymentDepositType.PaymentCreated]
+    })
+    if (!event || !isOutgoingPaymentEvent(event)) {
+      throw new GraphQLError(errorToMessage[LiquidityError.InvalidId], {
+        extensions: {
+          code: errorToCode[LiquidityError.InvalidId]
+        }
       })
-      if (!event || !isOutgoingPaymentEvent(event)) {
-        return responses[LiquidityError.InvalidId]
-      }
+    }
 
-      if (!event.data.debitAmount) {
-        throw new Error('No debit amount')
-      }
-      const outgoingPaymentService = await ctx.container.use(
-        'outgoingPaymentService'
-      )
-      const paymentOrErr = await outgoingPaymentService.fund({
-        id: outgoingPaymentId,
-        amount: BigInt(event.data.debitAmount.value),
-        transferId: event.id
+    if (!event.data.debitAmount) {
+      throw new Error('No debit amount')
+    }
+    const outgoingPaymentService = await ctx.container.use(
+      'outgoingPaymentService'
+    )
+    const paymentOrErr = await outgoingPaymentService.fund({
+      id: outgoingPaymentId,
+      amount: BigInt(event.data.debitAmount.value),
+      transferId: event.id
+    })
+    if (isFundingError(paymentOrErr)) {
+      throw new GraphQLError(fundingErrorToMessage[paymentOrErr], {
+        extensions: {
+          code: fundingErrorToCode[paymentOrErr]
+        }
       })
-      if (isFundingError(paymentOrErr)) {
-        return errorToResponse(paymentOrErr)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Deposited liquidity'
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          outgoingPaymentId: args.input.outgoingPaymentId,
-          err
-        },
-        'error depositing liquidity'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to deposit liquidity',
-        success: false
-      }
+    }
+    return {
+      id: outgoingPaymentId,
+      liquidity: BigInt(event.data.debitAmount.value)
     }
   }
 
@@ -530,6 +577,7 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
+<<<<<<< HEAD
     const { incomingPaymentId, timeoutSeconds } = args.input
     try {
       const incomingPaymentService = await ctx.container.use(
@@ -537,19 +585,32 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
       )
       const incomingPayment = await incomingPaymentService.get({
         id: incomingPaymentId
+=======
+    const { incomingPaymentId } = args.input
+    const incomingPaymentService = await ctx.container.use(
+      'incomingPaymentService'
+    )
+    const incomingPayment = await incomingPaymentService.get({
+      id: incomingPaymentId
+    })
+    const webhookService = await ctx.container.use('webhookService')
+    const event = await webhookService.getLatestByResourceId({
+      incomingPaymentId,
+      types: [
+        IncomingPaymentEventType.IncomingPaymentCompleted,
+        IncomingPaymentEventType.IncomingPaymentExpired
+      ]
+    })
+    if (!incomingPayment || !incomingPayment.receivedAmount || !event?.id) {
+      throw new GraphQLError(errorToMessage[LiquidityError.InvalidId], {
+        extensions: {
+          code: errorToCode[LiquidityError.InvalidId]
+        }
+>>>>>>> c702654c (feat(wip): backend graphql logs)
       })
-      const webhookService = await ctx.container.use('webhookService')
-      const event = await webhookService.getLatestByResourceId({
-        incomingPaymentId,
-        types: [
-          IncomingPaymentEventType.IncomingPaymentCompleted,
-          IncomingPaymentEventType.IncomingPaymentExpired
-        ]
-      })
-      if (!incomingPayment || !incomingPayment.receivedAmount || !event?.id) {
-        return responses[LiquidityError.InvalidId]
-      }
+    }
 
+<<<<<<< HEAD
       const accountingService = await ctx.container.use('accountingService')
       const error = await accountingService.createWithdrawal({
         id: event.id,
@@ -560,28 +621,28 @@ export const createIncomingPaymentWithdrawal: MutationResolvers<ApolloContext>['
         amount: incomingPayment.receivedAmount.value,
         timeout: Number(timeoutSeconds)
       })
+=======
+    const accountingService = await ctx.container.use('accountingService')
+    const error = await accountingService.createWithdrawal({
+      id: event.id,
+      account: {
+        id: incomingPaymentId,
+        asset: incomingPayment.asset
+      },
+      amount: incomingPayment.receivedAmount.value
+    })
+>>>>>>> c702654c (feat(wip): backend graphql logs)
 
-      if (error) {
-        return errorToResponse(error)
-      }
-      return {
-        code: '200',
-        success: true,
-        message: 'Withdrew liquidity'
-      }
-    } catch (error) {
-      ctx.logger.error(
-        {
-          incomingPaymentId,
-          error
-        },
-        'error withdrawing liquidity'
-      )
-      return {
-        code: '400',
-        message: 'Error trying to withdraw liquidity',
-        success: false
-      }
+    if (error) {
+      throw new GraphQLError(fundingErrorToMessage[error], {
+        extensions: {
+          code: fundingErrorToCode[error]
+        }
+      })
+    }
+    return {
+      id: event.id,
+      liquidity: incomingPayment.receivedAmount.value
     }
   }
 
@@ -591,6 +652,7 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
     args,
     ctx
   ): Promise<ResolversTypes['LiquidityMutationResponse']> => {
+<<<<<<< HEAD
     const { outgoingPaymentId, timeoutSeconds } = args.input
     try {
       const outgoingPaymentService = await ctx.container.use(
@@ -598,19 +660,32 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
       )
       const outgoingPayment = await outgoingPaymentService.get({
         id: outgoingPaymentId
+=======
+    const { outgoingPaymentId } = args.input
+    const outgoingPaymentService = await ctx.container.use(
+      'outgoingPaymentService'
+    )
+    const outgoingPayment = await outgoingPaymentService.get({
+      id: outgoingPaymentId
+    })
+    const webhookService = await ctx.container.use('webhookService')
+    const event = await webhookService.getLatestByResourceId({
+      outgoingPaymentId,
+      types: [
+        OutgoingPaymentEventType.PaymentCompleted,
+        OutgoingPaymentEventType.PaymentFailed
+      ]
+    })
+    if (!outgoingPayment || !event?.id) {
+      throw new GraphQLError(errorToMessage[LiquidityError.InvalidId], {
+        extensions: {
+          code: errorToCode[LiquidityError.InvalidId]
+        }
+>>>>>>> c702654c (feat(wip): backend graphql logs)
       })
-      const webhookService = await ctx.container.use('webhookService')
-      const event = await webhookService.getLatestByResourceId({
-        outgoingPaymentId,
-        types: [
-          OutgoingPaymentEventType.PaymentCompleted,
-          OutgoingPaymentEventType.PaymentFailed
-        ]
-      })
-      if (!outgoingPayment || !event?.id) {
-        return responses[LiquidityError.InvalidId]
-      }
+    }
 
+<<<<<<< HEAD
       const accountingService = await ctx.container.use('accountingService')
       const balance = await accountingService.getBalance(outgoingPayment.id)
       if (!balance) {
@@ -637,17 +712,40 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
       }
     } catch (error) {
       ctx.logger.error(
+=======
+    const accountingService = await ctx.container.use('accountingService')
+    const balance = await accountingService.getBalance(outgoingPayment.id)
+    if (!balance) {
+      throw new GraphQLError(
+        errorToMessage[LiquidityError.InsufficientBalance],
+>>>>>>> c702654c (feat(wip): backend graphql logs)
         {
-          outgoingPaymentId,
-          error
-        },
-        'error withdrawing liquidity'
+          extensions: {
+            code: errorToCode[LiquidityError.InsufficientBalance]
+          }
+        }
       )
-      return {
-        code: '400',
-        message: 'Error trying to withdraw liquidity',
-        success: false
-      }
+    }
+
+    const error = await accountingService.createWithdrawal({
+      id: event.id,
+      account: {
+        id: outgoingPaymentId,
+        asset: outgoingPayment.asset
+      },
+      amount: balance
+    })
+
+    if (error) {
+      throw new GraphQLError(transferErrorToMessage[error], {
+        extensions: {
+          code: transferErrorToCode[error]
+        }
+      })
+    }
+    return {
+      id: event.id,
+      liquidity: balance
     }
   }
 
@@ -655,86 +753,36 @@ export const createOutgoingPaymentWithdrawal: MutationResolvers<ApolloContext>['
 const isLiquidityError = (o: any): o is LiquidityError =>
   Object.values(LiquidityError).includes(o)
 
-const errorToResponse = (error: FundingError): LiquidityMutationResponse => {
-  if (!isLiquidityError(error)) {
-    throw new Error(error)
-  }
-  return responses[error]
+const errorToCode: {
+  [key in LiquidityError]: string
+} = {
+  [LiquidityError.AlreadyPosted]: GraphQLErrorCode.Conflict,
+  [LiquidityError.AlreadyVoided]: GraphQLErrorCode.Conflict,
+  [LiquidityError.AmountZero]: GraphQLErrorCode.Forbidden,
+  [LiquidityError.InsufficientBalance]: GraphQLErrorCode.Forbidden,
+  [LiquidityError.InvalidId]: GraphQLErrorCode.BadUserInput,
+  [LiquidityError.TransferExists]: GraphQLErrorCode.Duplicate,
+  [LiquidityError.UnknownAsset]: GraphQLErrorCode.NotFound,
+  [LiquidityError.UnknownIncomingPayment]: GraphQLErrorCode.NotFound,
+  [LiquidityError.UnknownPayment]: GraphQLErrorCode.NotFound,
+  [LiquidityError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
+  [LiquidityError.UnknownPeer]: GraphQLErrorCode.NotFound,
+  [LiquidityError.UnknownTransfer]: GraphQLErrorCode.NotFound
 }
 
-const responses: {
-  [key in LiquidityError]: LiquidityMutationResponse
+const errorToMessage: {
+  [key in LiquidityError]: string
 } = {
-  [LiquidityError.AlreadyPosted]: {
-    code: '409',
-    message: 'Withdrawal already posted',
-    success: false,
-    error: LiquidityError.AlreadyPosted
-  },
-  [LiquidityError.AlreadyVoided]: {
-    code: '409',
-    message: 'Withdrawal already voided',
-    success: false,
-    error: LiquidityError.AlreadyVoided
-  },
-  [LiquidityError.AmountZero]: {
-    code: '400',
-    message: 'Amount is zero',
-    success: false,
-    error: LiquidityError.AmountZero
-  },
-  [LiquidityError.InsufficientBalance]: {
-    code: '403',
-    message: 'Insufficient balance',
-    success: false,
-    error: LiquidityError.InsufficientBalance
-  },
-  [LiquidityError.InvalidId]: {
-    code: '400',
-    message: 'Invalid id',
-    success: false,
-    error: LiquidityError.InvalidId
-  },
-  [LiquidityError.TransferExists]: {
-    code: '409',
-    message: 'Transfer exists',
-    success: false,
-    error: LiquidityError.TransferExists
-  },
-  [LiquidityError.UnknownWalletAddress]: {
-    code: '404',
-    message: 'Unknown wallet address',
-    success: false,
-    error: LiquidityError.UnknownWalletAddress
-  },
-  [LiquidityError.UnknownAsset]: {
-    code: '404',
-    message: 'Unknown asset',
-    success: false,
-    error: LiquidityError.UnknownAsset
-  },
-  [LiquidityError.UnknownIncomingPayment]: {
-    code: '404',
-    message: 'Unknown incoming payment',
-    success: false,
-    error: LiquidityError.UnknownIncomingPayment
-  },
-  [LiquidityError.UnknownPayment]: {
-    code: '404',
-    message: 'Unknown outgoing payment',
-    success: false,
-    error: LiquidityError.UnknownPayment
-  },
-  [LiquidityError.UnknownPeer]: {
-    code: '404',
-    message: 'Unknown peer',
-    success: false,
-    error: LiquidityError.UnknownPeer
-  },
-  [LiquidityError.UnknownTransfer]: {
-    code: '404',
-    message: 'Unknown withdrawal',
-    success: false,
-    error: LiquidityError.UnknownTransfer
-  }
+  [LiquidityError.AlreadyPosted]: 'Transfer already posted',
+  [LiquidityError.AlreadyVoided]: 'Transfer already voided',
+  [LiquidityError.AmountZero]: 'Transfer amount is zero',
+  [LiquidityError.InsufficientBalance]: 'Insufficient transfer balance',
+  [LiquidityError.InvalidId]: 'Invalid transfer id',
+  [LiquidityError.TransferExists]: 'Transfer already exists',
+  [LiquidityError.UnknownAsset]: 'Unknown asset',
+  [LiquidityError.UnknownIncomingPayment]: 'Unknown incoming payment',
+  [LiquidityError.UnknownPayment]: 'Unknown transfer payment',
+  [LiquidityError.UnknownWalletAddress]: 'Unknown wallet address',
+  [LiquidityError.UnknownPeer]: 'Unknown peer',
+  [LiquidityError.UnknownTransfer]: 'Unknown transfer'
 }

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -1,4 +1,4 @@
-import { ApolloError, gql } from '@apollo/client'
+import { gql } from '@apollo/client'
 import { PaymentError } from '@interledger/pay'
 import { v4 as uuid } from 'uuid'
 import * as Pay from '@interledger/pay'
@@ -32,6 +32,7 @@ import {
 } from '../generated/graphql'
 import { faker } from '@faker-js/faker'
 import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 describe('OutgoingPayment Resolvers', (): void => {
   let deps: IocContract<AppServices>
@@ -339,8 +340,16 @@ describe('OutgoingPayment Resolvers', (): void => {
         .then(
           (query): OutgoingPaymentResponse => query.data?.createOutgoingPayment
         )
-      await expect(query).rejects.toThrow(ApolloError)
-      await expect(query).rejects.toThrow('unknown wallet address')
+      await expect(query).rejects.toThrow(
+        new GraphQLError(
+          errorToMessage[OutgoingPaymentError.UnknownWalletAddress],
+          {
+            extensions: {
+              code: errorToCode[OutgoingPaymentError.UnknownWalletAddress]
+            }
+          }
+        )
+      )
       await expect(createSpy).toHaveBeenCalledWith(input)
     })
 
@@ -374,7 +383,13 @@ describe('OutgoingPayment Resolvers', (): void => {
           (query): OutgoingPaymentResponse => query.data?.createOutgoingPayment
         )
 
-      await expect(query).rejects.toThrow(ApolloError)
+      await expect(query).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
       expect(createSpy).toHaveBeenCalledWith(input)
     })
   })
@@ -511,7 +526,13 @@ describe('OutgoingPayment Resolvers', (): void => {
           (query): OutgoingPaymentResponse =>
             query.data?.createOutgoingPaymentFromIncomingPayment
         )
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
       expect(createSpy).toHaveBeenCalledWith(input)
     })
   })

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -9,13 +9,15 @@ import {
 import {
   OutgoingPaymentError,
   isOutgoingPaymentError,
-  errorToCode,
-  errorToMessage
+  errorToMessage,
+  errorToCode
 } from '../../open_payments/payment/outgoing/errors'
 import { OutgoingPayment } from '../../open_payments/payment/outgoing/model'
 import { ApolloContext } from '../../app'
 import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
+import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 export const getOutgoingPayment: QueryResolvers<ApolloContext>['outgoingPayment'] =
   async (parent, args, ctx): Promise<ResolversTypes['OutgoingPayment']> => {
@@ -25,7 +27,13 @@ export const getOutgoingPayment: QueryResolvers<ApolloContext>['outgoingPayment'
     const payment = await outgoingPaymentService.get({
       id: args.id
     })
-    if (!payment) throw new Error('payment does not exist')
+    if (!payment) {
+      throw new GraphQLError('payment does not exist', {
+        extensions: {
+          code: GraphQLErrorCode.NotFound
+        }
+      })
+    }
     return paymentToGraphql(payment)
   }
 
@@ -70,26 +78,19 @@ export const createOutgoingPayment: MutationResolvers<ApolloContext>['createOutg
     const outgoingPaymentService = await ctx.container.use(
       'outgoingPaymentService'
     )
-    return outgoingPaymentService
-      .create(args.input)
-      .then((paymentOrErr: OutgoingPayment | OutgoingPaymentError) =>
-        isOutgoingPaymentError(paymentOrErr)
-          ? {
-              code: errorToCode[paymentOrErr].toString(),
-              success: false,
-              message: errorToMessage[paymentOrErr]
-            }
-          : {
-              code: '201',
-              success: true,
-              payment: paymentToGraphql(paymentOrErr)
-            }
-      )
-      .catch(() => ({
-        code: '500',
-        success: false,
-        message: 'Error trying to create outgoing payment'
-      }))
+    const outgoingPaymentOrError = await outgoingPaymentService.create(
+      args.input
+    )
+    if (isOutgoingPaymentError(outgoingPaymentOrError)) {
+      throw new GraphQLError(errorToMessage[outgoingPaymentOrError], {
+        extensions: {
+          code: errorToCode[outgoingPaymentOrError]
+        }
+      })
+    } else
+      return {
+        payment: paymentToGraphql(outgoingPaymentOrError)
+      }
   }
 
 export const createOutgoingPaymentFromIncomingPayment: MutationResolvers<ApolloContext>['createOutgoingPaymentFromIncomingPayment'] =
@@ -111,8 +112,6 @@ export const createOutgoingPaymentFromIncomingPayment: MutationResolvers<ApolloC
               message: errorToMessage[paymentOrErr]
             }
           : {
-              code: '201',
-              success: true,
               payment: paymentToGraphql(paymentOrErr)
             }
       )
@@ -129,7 +128,13 @@ export const getWalletAddressOutgoingPayments: WalletAddressResolvers<ApolloCont
     args,
     ctx
   ): Promise<ResolversTypes['OutgoingPaymentConnection']> => {
-    if (!parent.id) throw new Error('missing wallet address id')
+    if (!parent.id) {
+      throw new GraphQLError('missing wallet address id', {
+        extensions: {
+          code: GraphQLErrorCode.BadUserInput
+        }
+      })
+    }
     const outgoingPaymentService = await ctx.container.use(
       'outgoingPaymentService'
     )

--- a/packages/backend/src/graphql/resolvers/peer.test.ts
+++ b/packages/backend/src/graphql/resolvers/peer.test.ts
@@ -22,7 +22,8 @@ import {
   CreatePeerInput,
   CreatePeerMutationResponse,
   PeersConnection,
-  UpdatePeerMutationResponse
+  UpdatePeerMutationResponse,
+  DeletePeerMutationResponse
 } from '../generated/graphql'
 import { AccountingService } from '../../accounting/service'
 
@@ -604,7 +605,7 @@ describe('Peer Resolvers', (): void => {
             }
           }
         })
-        .then((query): UpdatePeerMutationResponse => {
+        .then((query): DeletePeerMutationResponse => {
           if (query.data) {
             return query.data.deletePeer
           } else {
@@ -632,7 +633,7 @@ describe('Peer Resolvers', (): void => {
             }
           }
         })
-        .then((query): UpdatePeerMutationResponse => {
+        .then((query): DeletePeerMutationResponse => {
           if (query.data) {
             return query.data.deletePeer
           } else {
@@ -664,7 +665,7 @@ describe('Peer Resolvers', (): void => {
             }
           }
         })
-        .then((query): UpdatePeerMutationResponse => {
+        .then((query): DeletePeerMutationResponse => {
           if (query.data) {
             return query.data.deletePeer
           } else {

--- a/packages/backend/src/graphql/resolvers/peer.ts
+++ b/packages/backend/src/graphql/resolvers/peer.ts
@@ -16,7 +16,6 @@ import { ApolloContext } from '../../app'
 import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 import { GraphQLError } from 'graphql'
-import { GraphQLErrorCode } from '../errors'
 
 export const getPeers: QueryResolvers<ApolloContext>['peers'] = async (
   parent,
@@ -50,9 +49,9 @@ export const getPeer: QueryResolvers<ApolloContext>['peer'] = async (
   const peerService = await ctx.container.use('peerService')
   const peer = await peerService.get(args.id)
   if (!peer) {
-    throw new GraphQLError('Peer not found', {
+    throw new GraphQLError(errorToMessage[PeerError.UnknownPeer], {
       extensions: {
-        code: GraphQLErrorCode.NotFound
+        code: errorToCode[PeerError.UnknownPeer]
       }
     })
   }

--- a/packages/backend/src/graphql/resolvers/quote.test.ts
+++ b/packages/backend/src/graphql/resolvers/quote.test.ts
@@ -1,4 +1,4 @@
-import { ApolloError, gql } from '@apollo/client'
+import { gql } from '@apollo/client'
 import { v4 as uuid } from 'uuid'
 import { GraphQLError } from 'graphql'
 
@@ -22,6 +22,7 @@ import { QuoteService } from '../../open_payments/quote/service'
 import { Quote as QuoteModel } from '../../open_payments/quote/model'
 import { Amount } from '../../open_payments/amount'
 import { CreateQuoteInput, Quote, QuoteResponse } from '../generated/graphql'
+import { GraphQLErrorCode } from '../errors'
 
 describe('Quote Resolvers', (): void => {
   let deps: IocContract<AppServices>
@@ -269,7 +270,13 @@ describe('Quote Resolvers', (): void => {
           variables: { input }
         })
         .then((query): QuoteResponse => query.data?.createQuote)
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
       expect(createSpy).toHaveBeenCalledWith({ ...input, method: 'ilp' })
     })
   })

--- a/packages/backend/src/graphql/resolvers/receiver.test.ts
+++ b/packages/backend/src/graphql/resolvers/receiver.test.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { ApolloError, gql } from '@apollo/client'
 import { v4 as uuid } from 'uuid'
 import { createTestApp, TestContainer } from '../../tests/app'
 import { IocContract } from '@adonisjs/fold'
@@ -74,9 +74,6 @@ describe('Receiver Resolver', (): void => {
             query: gql`
               mutation CreateReceiver($input: CreateReceiverInput!) {
                 createReceiver(input: $input) {
-                  code
-                  success
-                  message
                   receiver {
                     id
                     walletAddressUrl
@@ -106,9 +103,6 @@ describe('Receiver Resolver', (): void => {
         expect(createSpy).toHaveBeenCalledWith(input)
         expect(query).toEqual({
           __typename: 'CreateReceiverResponse',
-          code: '200',
-          success: true,
-          message: null,
           receiver: {
             __typename: 'Receiver',
             id: receiver.incomingPayment?.id,
@@ -144,14 +138,11 @@ describe('Receiver Resolver', (): void => {
         walletAddressUrl: walletAddress.id
       }
 
-      const query = await appContainer.apolloClient
+      const query = appContainer.apolloClient
         .query({
           query: gql`
             mutation CreateReceiver($input: CreateReceiverInput!) {
               createReceiver(input: $input) {
-                code
-                success
-                message
                 receiver {
                   id
                   walletAddressUrl
@@ -178,14 +169,9 @@ describe('Receiver Resolver', (): void => {
         })
         .then((query): CreateReceiverResponse => query.data?.createReceiver)
 
+      await expect(query).rejects.toThrow(ApolloError)
+      await expect(query).rejects.toThrow('unknown wallet address')
       expect(createSpy).toHaveBeenCalledWith(input)
-      expect(query).toEqual({
-        __typename: 'CreateReceiverResponse',
-        code: '404',
-        success: false,
-        message: 'unknown wallet address',
-        receiver: null
-      })
     })
 
     test('returns error if error thrown when creating receiver', async (): Promise<void> => {
@@ -199,14 +185,11 @@ describe('Receiver Resolver', (): void => {
         walletAddressUrl: walletAddress.id
       }
 
-      const query = await appContainer.apolloClient
+      const query = appContainer.apolloClient
         .query({
           query: gql`
             mutation CreateReceiver($input: CreateReceiverInput!) {
               createReceiver(input: $input) {
-                code
-                success
-                message
                 receiver {
                   id
                   walletAddressUrl
@@ -233,14 +216,9 @@ describe('Receiver Resolver', (): void => {
         })
         .then((query): CreateReceiverResponse => query.data?.createReceiver)
 
+      await expect(query).rejects.toThrow(ApolloError)
+      await expect(query).rejects.toThrow('Cannot create receiver')
       expect(createSpy).toHaveBeenCalledWith(input)
-      expect(query).toEqual({
-        __typename: 'CreateReceiverResponse',
-        code: '500',
-        success: false,
-        message: 'Error trying to create receiver',
-        receiver: null
-      })
     })
   })
 

--- a/packages/backend/src/graphql/resolvers/receiver.ts
+++ b/packages/backend/src/graphql/resolvers/receiver.ts
@@ -12,6 +12,7 @@ import {
   errorToMessage as receiverErrorToMessage
 } from '../../open_payments/receiver/errors'
 import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 export const getReceiver: QueryResolvers<ApolloContext>['receiver'] = async (
   _,
@@ -22,7 +23,11 @@ export const getReceiver: QueryResolvers<ApolloContext>['receiver'] = async (
   const receiver = await receiverService.get(args.id)
   if (!receiver) {
     ctx.logger.error(`Receiver "${args.id}" was not found.`)
-    throw new Error('receiver does not exist')
+    throw new GraphQLError('receiver does not exist', {
+      extensions: {
+        code: GraphQLErrorCode.NotFound
+      }
+    })
   }
   return receiverToGraphql(receiver)
 }

--- a/packages/backend/src/graphql/resolvers/receiver.ts
+++ b/packages/backend/src/graphql/resolvers/receiver.ts
@@ -11,6 +11,7 @@ import {
   errorToCode as receiverErrorToCode,
   errorToMessage as receiverErrorToMessage
 } from '../../open_payments/receiver/errors'
+import { GraphQLError } from 'graphql'
 
 export const getReceiver: QueryResolvers<ApolloContext>['receiver'] = async (
   _,
@@ -30,38 +31,25 @@ export const createReceiver: MutationResolvers<ApolloContext>['createReceiver'] 
   async (_, args, ctx): Promise<ResolversTypes['CreateReceiverResponse']> => {
     const receiverService = await ctx.container.use('receiverService')
 
-    try {
-      const receiverOrError = await receiverService.create({
-        walletAddressUrl: args.input.walletAddressUrl,
-        expiresAt: args.input.expiresAt
-          ? new Date(args.input.expiresAt)
-          : undefined,
-        incomingAmount: args.input.incomingAmount,
-        metadata: args.input.metadata
-      })
+    const receiverOrError = await receiverService.create({
+      walletAddressUrl: args.input.walletAddressUrl,
+      expiresAt: args.input.expiresAt
+        ? new Date(args.input.expiresAt)
+        : undefined,
+      incomingAmount: args.input.incomingAmount,
+      metadata: args.input.metadata
+    })
 
-      if (isReceiverError(receiverOrError)) {
-        return {
-          code: receiverErrorToCode(receiverOrError).toString(),
-          success: false,
-          message: receiverErrorToMessage(receiverOrError)
+    if (isReceiverError(receiverOrError)) {
+      throw new GraphQLError(receiverErrorToMessage(receiverOrError), {
+        extensions: {
+          code: receiverErrorToCode(receiverOrError)
         }
-      }
+      })
+    }
 
-      return {
-        code: '200',
-        success: true,
-        receiver: receiverToGraphql(receiverOrError)
-      }
-    } catch (err) {
-      const errorMessage = 'Error trying to create receiver'
-      ctx.logger.error({ err, args }, errorMessage)
-
-      return {
-        code: '500',
-        success: false,
-        message: errorMessage
-      }
+    return {
+      receiver: receiverToGraphql(receiverOrError)
     }
   }
 

--- a/packages/backend/src/graphql/resolvers/walletAddressKey.test.ts
+++ b/packages/backend/src/graphql/resolvers/walletAddressKey.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { ApolloError, gql } from '@apollo/client'
+import { gql } from '@apollo/client'
 import { generateJwk } from '@interledger/http-signature-utils'
 import { v4 as uuid } from 'uuid'
 
@@ -19,6 +19,8 @@ import { WalletAddressKeyService } from '../../open_payments/wallet_address/key/
 import { createWalletAddress } from '../../tests/walletAddress'
 import { getPageTests } from './page.test'
 import { createWalletAddressKey } from '../../tests/walletAddressKey'
+import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 const TEST_KEY = generateJwk({ keyId: uuid() })
 
@@ -145,8 +147,13 @@ describe('Wallet Address Key Resolvers', (): void => {
             throw new Error('Data was empty')
           }
         })
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
-      await expect(gqlQuery).rejects.toThrow('unexpected')
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
     })
   })
 
@@ -237,8 +244,13 @@ describe('Wallet Address Key Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
-      await expect(gqlQuery).rejects.toThrow('Wallet address key not found')
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('Wallet address key not found', {
+          extensions: {
+            code: GraphQLErrorCode.NotFound
+          }
+        })
+      )
     })
   })
 

--- a/packages/backend/src/graphql/resolvers/walletAddressKey.ts
+++ b/packages/backend/src/graphql/resolvers/walletAddressKey.ts
@@ -10,6 +10,8 @@ import {
 } from '../generated/graphql'
 import { ApolloContext } from '../../app'
 import { WalletAddressKey } from '../../open_payments/wallet_address/key/model'
+import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 import { Pagination } from '../../shared/baseModel'
 import { getPageInfo } from '../../shared/pagination'
 
@@ -56,39 +58,20 @@ export const revokeWalletAddressKey: MutationResolvers<ApolloContext>['revokeWal
     args,
     ctx
   ): Promise<ResolversTypes['RevokeWalletAddressKeyMutationResponse']> => {
-    try {
-      const walletAddressKeyService = await ctx.container.use(
-        'walletAddressKeyService'
-      )
-      const key = await walletAddressKeyService.revoke(args.input.id)
-      if (!key) {
-        return {
-          code: '404',
-          success: false,
-          message: 'Wallet address key not found'
+    const walletAddressKeyService = await ctx.container.use(
+      'walletAddressKeyService'
+    )
+    const key = await walletAddressKeyService.revoke(args.input.id)
+    if (!key) {
+      throw new GraphQLError('Wallet address key not found', {
+        extensions: {
+          code: GraphQLErrorCode.NotFound
         }
-      }
+      })
+    }
 
-      return {
-        code: '200',
-        success: true,
-        message: 'Wallet address key revoked',
-        walletAddressKey: walletAddressKeyToGraphql(key)
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          options: args.input.id,
-          err
-        },
-        'error revoking wallet address key'
-      )
-
-      return {
-        code: '500',
-        message: 'Error trying to revoke wallet address key',
-        success: false
-      }
+    return {
+      walletAddressKey: walletAddressKeyToGraphql(key)
     }
   }
 
@@ -98,33 +81,14 @@ export const createWalletAddressKey: MutationResolvers<ApolloContext>['createWal
     args,
     ctx
   ): Promise<ResolversTypes['CreateWalletAddressKeyMutationResponse']> => {
-    try {
-      const walletAddressKeyService = await ctx.container.use(
-        'walletAddressKeyService'
-      )
+    const walletAddressKeyService = await ctx.container.use(
+      'walletAddressKeyService'
+    )
 
-      const key = await walletAddressKeyService.create(args.input)
+    const key = await walletAddressKeyService.create(args.input)
 
-      return {
-        code: '200',
-        success: true,
-        message: 'Added Key To Wallet Address',
-        walletAddressKey: walletAddressKeyToGraphql(key)
-      }
-    } catch (err) {
-      ctx.logger.error(
-        {
-          options: args.input,
-          err
-        },
-        'error creating wallet address key'
-      )
-
-      return {
-        code: '500',
-        message: 'Error trying to create wallet address key',
-        success: false
-      }
+    return {
+      walletAddressKey: walletAddressKeyToGraphql(key)
     }
   }
 

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -2,7 +2,6 @@ import assert from 'assert'
 import { gql } from '@apollo/client'
 import { Knex } from 'knex'
 import { v4 as uuid } from 'uuid'
-import { ApolloError } from '@apollo/client'
 
 import { createTestApp, TestContainer } from '../../tests/app'
 import { IocContract } from '@adonisjs/fold'
@@ -13,7 +12,8 @@ import { Config } from '../../config/app'
 import { truncateTables } from '../../tests/tableManager'
 import {
   WalletAddressError,
-  errorToMessage
+  errorToMessage,
+  errorToCode
 } from '../../open_payments/wallet_address/errors'
 import {
   WalletAddress as WalletAddressModel,
@@ -34,6 +34,8 @@ import {
 } from '../generated/graphql'
 import { getPageTests } from './page.test'
 import { WalletAddressAdditionalProperty } from '../../open_payments/wallet_address/additional_property/model'
+import { GraphQLError } from 'graphql'
+import { GraphQLErrorCode } from '../errors'
 
 describe('Wallet Address Resolvers', (): void => {
   let deps: IocContract<AppServices>
@@ -239,13 +241,16 @@ describe('Wallet Address Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
       await expect(gqlQuery).rejects.toThrow(
-        errorToMessage[error as WalletAddressError]
+        new GraphQLError(errorToMessage[error as WalletAddressError], {
+          extensions: {
+            code: errorToCode[error as WalletAddressError]
+          }
+        })
       )
     })
 
-    test('500', async (): Promise<void> => {
+    test('internal server error', async (): Promise<void> => {
       jest
         .spyOn(walletAddressService, 'create')
         .mockImplementationOnce(async (_args) => {
@@ -277,8 +282,13 @@ describe('Wallet Address Resolvers', (): void => {
             throw new Error('Data was empty')
           }
         })
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
-      await expect(gqlQuery).rejects.toThrow('unexpected')
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
     })
   })
 
@@ -545,9 +555,12 @@ describe('Wallet Address Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
       await expect(gqlQuery).rejects.toThrow(
-        errorToMessage[error as WalletAddressError]
+        new GraphQLError(errorToMessage[error as WalletAddressError], {
+          extensions: {
+            code: errorToCode[error as WalletAddressError]
+          }
+        })
       )
     })
 
@@ -583,8 +596,13 @@ describe('Wallet Address Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
-      await expect(gqlQuery).rejects.toThrow('unexpected')
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
     })
   })
 
@@ -695,7 +713,16 @@ describe('Wallet Address Resolvers', (): void => {
           }
         })
 
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError(
+          errorToMessage[WalletAddressError.UnknownWalletAddress],
+          {
+            extensions: {
+              code: errorToCode[WalletAddressError.UnknownWalletAddress]
+            }
+          }
+        )
+      )
     })
 
     getPageTests({
@@ -858,8 +885,13 @@ describe('Wallet Address Resolvers', (): void => {
             throw new Error('Data was empty')
           }
         })
-      await expect(gqlQuery).rejects.toThrow(ApolloError)
-      await expect(gqlQuery).rejects.toThrow('unexpected')
+      await expect(gqlQuery).rejects.toThrow(
+        new GraphQLError('unexpected', {
+          extensions: {
+            code: GraphQLErrorCode.InternalServerError
+          }
+        })
+      )
     })
   })
 })

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -148,9 +148,6 @@ describe('Wallet Address Resolvers', (): void => {
           mutation: gql`
             mutation CreateWalletAddress($input: CreateWalletAddressInput!) {
               createWalletAddress(input: $input) {
-                code
-                success
-                message
                 walletAddress {
                   id
                   asset {
@@ -180,26 +177,25 @@ describe('Wallet Address Resolvers', (): void => {
           }
         })
 
-      expect(response.success).toBe(true)
-      expect(response.code).toEqual('200')
-      assert.ok(response.walletAddress)
-      expect(response.walletAddress).toEqual({
-        __typename: 'WalletAddress',
-        id: response.walletAddress.id,
-        url: input.url,
-        asset: {
-          __typename: 'Asset',
-          code: asset.code,
-          scale: asset.scale
-        },
-        publicName: input.publicName,
-        additionalProperties: validAdditionalProperties.map((property) => {
-          return {
-            __typename: 'AdditionalProperty',
-            key: property.key,
-            value: property.value,
-            visibleInOpenPayments: property.visibleInOpenPayments
-          }
+
+        assert.ok(response.walletAddress)
+        expect(response.walletAddress).toEqual({
+          __typename: 'WalletAddress',
+          id: response.walletAddress.id,
+          url: input.url,
+          asset: {
+            __typename: 'Asset',
+            code: asset.code,
+            scale: asset.scale
+          },
+          publicName: input.publicName,
+          additionalProperties: validAdditionalProperties.map((property) => {
+            return {
+              __typename: 'AdditionalProperty',
+              key: property.key,
+              value: property.value,
+              visibleInOpenPayments: property.visibleInOpenPayments
+            }
         })
       })
       await expect(
@@ -370,9 +366,6 @@ describe('Wallet Address Resolvers', (): void => {
             mutation: gql`
               mutation UpdateWalletAddress($input: UpdateWalletAddressInput!) {
                 updateWalletAddress(input: $input) {
-                  code
-                  success
-                  message
                   walletAddress {
                     id
                     additionalProperties {
@@ -396,8 +389,6 @@ describe('Wallet Address Resolvers', (): void => {
             }
           })
 
-        expect(response.success).toBe(true)
-        expect(response.code).toEqual('200')
         expect(response.walletAddress?.additionalProperties).toEqual(
           updateOptions.additionalProperties.map((property) => {
             return {
@@ -440,9 +431,6 @@ describe('Wallet Address Resolvers', (): void => {
             mutation: gql`
               mutation UpdateWalletAddress($input: UpdateWalletAddressInput!) {
                 updateWalletAddress(input: $input) {
-                  code
-                  success
-                  message
                   walletAddress {
                     id
                     additionalProperties {
@@ -466,8 +454,6 @@ describe('Wallet Address Resolvers', (): void => {
             }
           })
 
-        expect(response.success).toBe(true)
-        expect(response.code).toEqual('200')
         // Does not include additional properties from create that were not also in the update
         expect(response.walletAddress?.additionalProperties).toEqual(
           updateOptions.additionalProperties.map((property) => {
@@ -499,9 +485,6 @@ describe('Wallet Address Resolvers', (): void => {
             mutation: gql`
               mutation UpdateWalletAddress($input: UpdateWalletAddressInput!) {
                 updateWalletAddress(input: $input) {
-                  code
-                  success
-                  message
                   walletAddress {
                     id
                     additionalProperties {
@@ -525,8 +508,6 @@ describe('Wallet Address Resolvers', (): void => {
             }
           })
 
-        expect(response.success).toBe(true)
-        expect(response.code).toEqual('200')
         expect(response.walletAddress?.additionalProperties).toEqual([])
       })
     })

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -179,25 +179,24 @@ describe('Wallet Address Resolvers', (): void => {
           }
         })
 
-
-        assert.ok(response.walletAddress)
-        expect(response.walletAddress).toEqual({
-          __typename: 'WalletAddress',
-          id: response.walletAddress.id,
-          url: input.url,
-          asset: {
-            __typename: 'Asset',
-            code: asset.code,
-            scale: asset.scale
-          },
-          publicName: input.publicName,
-          additionalProperties: validAdditionalProperties.map((property) => {
-            return {
-              __typename: 'AdditionalProperty',
-              key: property.key,
-              value: property.value,
-              visibleInOpenPayments: property.visibleInOpenPayments
-            }
+      assert.ok(response.walletAddress)
+      expect(response.walletAddress).toEqual({
+        __typename: 'WalletAddress',
+        id: response.walletAddress.id,
+        url: input.url,
+        asset: {
+          __typename: 'Asset',
+          code: asset.code,
+          scale: asset.scale
+        },
+        publicName: input.publicName,
+        additionalProperties: validAdditionalProperties.map((property) => {
+          return {
+            __typename: 'AdditionalProperty',
+            key: property.key,
+            value: property.value,
+            visibleInOpenPayments: property.visibleInOpenPayments
+          }
         })
       })
       await expect(

--- a/packages/backend/src/graphql/resolvers/wallet_address.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.ts
@@ -10,6 +10,7 @@ import {
 } from '../generated/graphql'
 import { ApolloContext } from '../../app'
 import {
+  WalletAddressError,
   isWalletAddressError,
   errorToCode,
   errorToMessage
@@ -57,11 +58,14 @@ export const getWalletAddress: QueryResolvers<ApolloContext>['walletAddress'] =
     const walletAddressService = await ctx.container.use('walletAddressService')
     const walletAddress = await walletAddressService.get(args.id)
     if (!walletAddress) {
-      throw new GraphQLError('Wallet address not found', {
-        extensions: {
-          code: GraphQLErrorCode.NotFound
+      throw new GraphQLError(
+        errorToMessage[WalletAddressError.UnknownWalletAddress],
+        {
+          extensions: {
+            code: errorToCode[WalletAddressError.UnknownWalletAddress]
+          }
         }
-      })
+      )
     }
     return walletAddressToGraphql(walletAddress)
   }

--- a/packages/backend/src/graphql/resolvers/wallet_address.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.ts
@@ -23,7 +23,6 @@ import {
   CreateOptions,
   UpdateOptions
 } from '../../open_payments/wallet_address/service'
-import { GraphQLErrorCode } from '../errors'
 
 export const getWalletAddresses: QueryResolvers<ApolloContext>['walletAddresses'] =
   async (
@@ -129,7 +128,8 @@ export const updateWalletAddress: MutationResolvers<ApolloContext>['updateWallet
         }
       )
     }
-    const walletAddressOrError = await walletAddressService.update(updateOptions)
+    const walletAddressOrError =
+      await walletAddressService.update(updateOptions)
     if (isWalletAddressError(walletAddressOrError)) {
       throw new GraphQLError(errorToMessage[walletAddressOrError], {
         extensions: {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1206,114 +1206,62 @@ interface Model {
   createdAt: String!
 }
 
-type CreateWalletAddressMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type CreateWalletAddressMutationResponse {
   walletAddress: WalletAddress
 }
 
-type UpdateWalletAddressMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type UpdateWalletAddressMutationResponse {
   walletAddress: WalletAddress
 }
 
-type TriggerWalletAddressEventsMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type TriggerWalletAddressEventsMutationResponse {
   "Number of events triggered"
   count: Int
 }
 
-type AssetMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type AssetMutationResponse {
   asset: Asset
 }
 
-type DeleteAssetMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type DeleteAssetMutationResponse {
+  asset: Asset
 }
 
-type CreatePeerMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type CreatePeerMutationResponse {
   peer: Peer
 }
 
-type CreateOrUpdatePeerByUrlMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type CreateOrUpdatePeerByUrlMutationResponse {
   peer: Peer
 }
 
-type UpdatePeerMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type UpdatePeerMutationResponse {
   peer: Peer
 }
 
-type DeletePeerMutationResponse implements MutationResponse {
-  code: String!
+type DeletePeerMutationResponse {
   success: Boolean!
-  message: String!
 }
 
-type TransferMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type LiquidityMutationResponse {
+  id: ID!
+  liquidity: UInt64
 }
 
-type LiquidityMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
-  error: LiquidityError
-}
-
-type WalletAddressWithdrawalMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
-  error: LiquidityError
+type WalletAddressWithdrawalMutationResponse {
   withdrawal: WalletAddressWithdrawal
 }
 
-type CreateWalletAddressKeyMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type CreateWalletAddressKeyMutationResponse {
   walletAddressKey: WalletAddressKey
 }
 
-type RevokeWalletAddressKeyMutationResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type RevokeWalletAddressKeyMutationResponse {
   walletAddressKey: WalletAddressKey
 }
 
-type SetFeeResponse implements MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
+type SetFeeResponse {
   fee: Fee
-}
-
-interface MutationResponse {
-  code: String!
-  success: Boolean!
-  message: String!
 }
 
 scalar UInt8

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -952,9 +952,6 @@ input CreateQuoteInput {
 }
 
 type QuoteResponse {
-  code: String!
-  success: Boolean!
-  message: String
   quote: Quote
 }
 
@@ -1016,23 +1013,14 @@ input CreateReceiverInput {
 }
 
 type OutgoingPaymentResponse {
-  code: String!
-  success: Boolean!
-  message: String
   payment: OutgoingPayment
 }
 
 type IncomingPaymentResponse {
-  code: String!
-  success: Boolean!
-  message: String
   payment: IncomingPayment
 }
 
 type CreateReceiverResponse {
-  code: String!
-  success: Boolean!
-  message: String
   receiver: Receiver
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1232,8 +1232,7 @@ type DeletePeerMutationResponse {
 }
 
 type LiquidityMutationResponse {
-  id: ID!
-  liquidity: UInt64
+  success: Boolean!
 }
 
 type WalletAddressWithdrawalMutationResponse {

--- a/packages/backend/src/open_payments/payment/incoming/errors.ts
+++ b/packages/backend/src/open_payments/payment/incoming/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../../../graphql/errors'
+
 export enum IncomingPaymentError {
   UnknownWalletAddress = 'UnknownWalletAddress',
   InvalidAmount = 'InvalidAmount',
@@ -12,7 +14,7 @@ export enum IncomingPaymentError {
 export const isIncomingPaymentError = (o: any): o is IncomingPaymentError =>
   Object.values(IncomingPaymentError).includes(o)
 
-export const errorToCode: {
+export const errorToHTTPCode: {
   [key in IncomingPaymentError]: number
 } = {
   [IncomingPaymentError.UnknownWalletAddress]: 404,
@@ -22,6 +24,18 @@ export const errorToCode: {
   [IncomingPaymentError.InvalidExpiry]: 400,
   [IncomingPaymentError.WrongState]: 409,
   [IncomingPaymentError.InactiveWalletAddress]: 400
+}
+
+export const errorToCode: {
+  [key in IncomingPaymentError]: string
+} = {
+  [IncomingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
+  [IncomingPaymentError.InvalidAmount]: GraphQLErrorCode.BadUserInput,
+  [IncomingPaymentError.UnknownPayment]: GraphQLErrorCode.NotFound,
+  [IncomingPaymentError.InvalidState]: GraphQLErrorCode.BadUserInput,
+  [IncomingPaymentError.InvalidExpiry]: GraphQLErrorCode.BadUserInput,
+  [IncomingPaymentError.WrongState]: GraphQLErrorCode.BadUserInput,
+  [IncomingPaymentError.InactiveWalletAddress]: GraphQLErrorCode.Inactive
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/open_payments/payment/incoming/errors.ts
+++ b/packages/backend/src/open_payments/payment/incoming/errors.ts
@@ -27,7 +27,7 @@ export const errorToHTTPCode: {
 }
 
 export const errorToCode: {
-  [key in IncomingPaymentError]: string
+  [key in IncomingPaymentError]: GraphQLErrorCode
 } = {
   [IncomingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
   [IncomingPaymentError.InvalidAmount]: GraphQLErrorCode.BadUserInput,

--- a/packages/backend/src/open_payments/payment/incoming/errors.ts
+++ b/packages/backend/src/open_payments/payment/incoming/errors.ts
@@ -34,7 +34,7 @@ export const errorToCode: {
   [IncomingPaymentError.UnknownPayment]: GraphQLErrorCode.NotFound,
   [IncomingPaymentError.InvalidState]: GraphQLErrorCode.BadUserInput,
   [IncomingPaymentError.InvalidExpiry]: GraphQLErrorCode.BadUserInput,
-  [IncomingPaymentError.WrongState]: GraphQLErrorCode.BadUserInput,
+  [IncomingPaymentError.WrongState]: GraphQLErrorCode.Conflict,
   [IncomingPaymentError.InactiveWalletAddress]: GraphQLErrorCode.Inactive
 }
 

--- a/packages/backend/src/open_payments/payment/incoming/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.test.ts
@@ -20,7 +20,7 @@ import { createAsset } from '../../../tests/asset'
 import { createIncomingPayment } from '../../../tests/incomingPayment'
 import { createWalletAddress } from '../../../tests/walletAddress'
 import { Asset } from '../../../asset/model'
-import { IncomingPaymentError, errorToCode, errorToMessage } from './errors'
+import { IncomingPaymentError, errorToHTTPCode, errorToMessage } from './errors'
 import { IncomingPaymentService } from './service'
 import { IncomingPaymentWithPaymentMethods as OpenPaymentsIncomingPaymentWithPaymentMethods } from '@interledger/open-payments'
 
@@ -176,7 +176,7 @@ describe('Incoming Payment Routes', (): void => {
           .mockResolvedValueOnce(error)
         await expect(incomingPaymentRoutes.create(ctx)).rejects.toMatchObject({
           message: errorToMessage[error],
-          status: errorToCode[error]
+          status: errorToHTTPCode[error]
         })
         expect(createSpy).toHaveBeenCalledWith({
           walletAddressId: walletAddress.id

--- a/packages/backend/src/open_payments/payment/incoming/routes.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.ts
@@ -8,7 +8,11 @@ import {
 } from '../../../app'
 import { IAppConfig } from '../../../config/app'
 import { IncomingPaymentService } from './service'
-import { errorToCode, errorToMessage, isIncomingPaymentError } from './errors'
+import {
+  errorToHTTPCode,
+  errorToMessage,
+  isIncomingPaymentError
+} from './errors'
 import { AmountJSON, parseAmount } from '../../amount'
 import { listSubresource } from '../../wallet_address/routes'
 import { StreamCredentialsService } from '../../../payment-method/ilp/stream-credentials/service'
@@ -139,7 +143,7 @@ async function createIncomingPayment(
 
   if (isIncomingPaymentError(incomingPaymentOrError)) {
     throw new OpenPaymentsServerRouteError(
-      errorToCode[incomingPaymentOrError],
+      errorToHTTPCode[incomingPaymentOrError],
       errorToMessage[incomingPaymentOrError]
     )
   }
@@ -164,7 +168,7 @@ async function completeIncomingPayment(
 
   if (isIncomingPaymentError(incomingPaymentOrError)) {
     throw new OpenPaymentsServerRouteError(
-      errorToCode[incomingPaymentOrError],
+      errorToHTTPCode[incomingPaymentOrError],
       errorToMessage[incomingPaymentOrError]
     )
   }

--- a/packages/backend/src/open_payments/payment/incoming_remote/errors.ts
+++ b/packages/backend/src/open_payments/payment/incoming_remote/errors.ts
@@ -21,7 +21,7 @@ export const errorToHTTPCode: {
 }
 
 export const errorToCode: {
-  [key in RemoteIncomingPaymentError]: string
+  [key in RemoteIncomingPaymentError]: GraphQLErrorCode
 } = {
   [RemoteIncomingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
   [RemoteIncomingPaymentError.InvalidRequest]: GraphQLErrorCode.BadUserInput,

--- a/packages/backend/src/open_payments/payment/incoming_remote/errors.ts
+++ b/packages/backend/src/open_payments/payment/incoming_remote/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../../../graphql/errors'
+
 export enum RemoteIncomingPaymentError {
   UnknownWalletAddress = 'UnknownWalletAddress',
   InvalidRequest = 'InvalidRequest',
@@ -10,7 +12,7 @@ export const isRemoteIncomingPaymentError = (
 ): o is RemoteIncomingPaymentError =>
   Object.values(RemoteIncomingPaymentError).includes(o)
 
-export const errorToCode: {
+export const errorToHTTPCode: {
   [key in RemoteIncomingPaymentError]: number
 } = {
   [RemoteIncomingPaymentError.UnknownWalletAddress]: 404,
@@ -18,6 +20,13 @@ export const errorToCode: {
   [RemoteIncomingPaymentError.InvalidGrant]: 500
 }
 
+export const errorToCode: {
+  [key in RemoteIncomingPaymentError]: string
+} = {
+  [RemoteIncomingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
+  [RemoteIncomingPaymentError.InvalidRequest]: GraphQLErrorCode.BadUserInput,
+  [RemoteIncomingPaymentError.InvalidGrant]: GraphQLErrorCode.Forbidden
+}
 export const errorToMessage: {
   [key in RemoteIncomingPaymentError]: string
 } = {

--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -57,7 +57,7 @@ export const errorToCode: {
   [OutgoingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
   [OutgoingPaymentError.UnknownPayment]: GraphQLErrorCode.NotFound,
   [OutgoingPaymentError.UnknownQuote]: GraphQLErrorCode.NotFound,
-  [OutgoingPaymentError.WrongState]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.WrongState]: GraphQLErrorCode.Conflict,
   [OutgoingPaymentError.InvalidQuote]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.InsufficientGrant]: GraphQLErrorCode.Forbidden,
   [OutgoingPaymentError.InactiveWalletAddress]: GraphQLErrorCode.Inactive,

--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -1,4 +1,5 @@
 import { TransferError } from '../../../accounting/errors'
+import { GraphQLErrorCode } from '../../../graphql/errors'
 import { PaymentMethodHandlerError } from '../../../payment-method/handler/errors'
 import { QuoteError } from '../../quote/errors'
 
@@ -31,7 +32,7 @@ export const quoteErrorToOutgoingPaymentError: Record<
 export const isOutgoingPaymentError = (o: any): o is OutgoingPaymentError =>
   Object.values(OutgoingPaymentError).includes(o)
 
-export const errorToCode: {
+export const errorToHTTPCode: {
   [key in OutgoingPaymentError]: number
 } = {
   [OutgoingPaymentError.UnknownWalletAddress]: 404,
@@ -44,6 +45,18 @@ export const errorToCode: {
   [OutgoingPaymentError.InvalidAmount]: 400,
   [OutgoingPaymentError.NegativeReceiveAmount]: 400,
   [OutgoingPaymentError.InvalidReceiver]: 400
+}
+
+export const errorToCode: {
+  [key in OutgoingPaymentError]: string
+} = {
+  [OutgoingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
+  [OutgoingPaymentError.UnknownPayment]: GraphQLErrorCode.NotFound,
+  [OutgoingPaymentError.UnknownQuote]: GraphQLErrorCode.NotFound,
+  [OutgoingPaymentError.WrongState]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.InvalidQuote]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.InsufficientGrant]: GraphQLErrorCode.Forbidden,
+  [OutgoingPaymentError.InactiveWalletAddress]: GraphQLErrorCode.Inactive
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -52,7 +52,7 @@ export const errorToHTTPCode: {
 }
 
 export const errorToCode: {
-  [key in OutgoingPaymentError]: string
+  [key in OutgoingPaymentError]: GraphQLErrorCode
 } = {
   [OutgoingPaymentError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
   [OutgoingPaymentError.UnknownPayment]: GraphQLErrorCode.NotFound,

--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -1,4 +1,8 @@
-import { TransferError } from '../../../accounting/errors'
+import {
+  TransferError,
+  errorToMessage as transferErrorToMessage,
+  errorToCode as transferErrorToCode
+} from '../../../accounting/errors'
 import { GraphQLErrorCode } from '../../../graphql/errors'
 import { PaymentMethodHandlerError } from '../../../payment-method/handler/errors'
 import { QuoteError } from '../../quote/errors'
@@ -56,7 +60,10 @@ export const errorToCode: {
   [OutgoingPaymentError.WrongState]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.InvalidQuote]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.InsufficientGrant]: GraphQLErrorCode.Forbidden,
-  [OutgoingPaymentError.InactiveWalletAddress]: GraphQLErrorCode.Inactive
+  [OutgoingPaymentError.InactiveWalletAddress]: GraphQLErrorCode.Inactive,
+  [OutgoingPaymentError.InvalidAmount]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.NegativeReceiveAmount]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.InvalidReceiver]: GraphQLErrorCode.BadUserInput
 }
 
 export const errorToMessage: {
@@ -76,6 +83,11 @@ export const errorToMessage: {
 
 export const FundingError = { ...OutgoingPaymentError, ...TransferError }
 export type FundingError = OutgoingPaymentError | TransferError
+export const fundingErrorToMessage = {
+  ...errorToMessage,
+  ...transferErrorToMessage
+}
+export const fundingErrorToCode = { ...errorToCode, ...transferErrorToCode }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const isFundingError = (o: any): o is FundingError =>

--- a/packages/backend/src/open_payments/payment/outgoing/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/routes.test.ts
@@ -10,7 +10,6 @@ import { initIocContainer } from '../../..'
 import { AppServices, CreateContext } from '../../../app'
 import { truncateTables } from '../../../tests/tableManager'
 import { createAsset } from '../../../tests/asset'
-import { errorToCode, errorToMessage, OutgoingPaymentError } from './errors'
 import {
   CreateFromIncomingPayment,
   CreateFromQuote,
@@ -18,6 +17,7 @@ import {
   OutgoingPaymentService,
   BaseOptions as CreateOutgoingPaymentBaseOptions
 } from './service'
+import { errorToHTTPCode, errorToMessage, OutgoingPaymentError } from './errors'
 import { OutgoingPayment, OutgoingPaymentState } from './model'
 import { OutgoingPaymentRoutes, CreateBody } from './routes'
 import { serializeAmount } from '../../amount'
@@ -295,7 +295,7 @@ describe('Outgoing Payment Routes', (): void => {
         } catch (err) {
           assert(err instanceof OpenPaymentsServerRouteError)
           expect(err.message).toBe(errorToMessage[error])
-          expect(err.status).toBe(errorToCode[error])
+          expect(err.status).toBe(errorToHTTPCode[error])
         }
 
         expect(createSpy).toHaveBeenCalledWith({

--- a/packages/backend/src/open_payments/payment/outgoing/routes.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/routes.ts
@@ -6,7 +6,11 @@ import {
   OutgoingPaymentService,
   BaseOptions as OutgoingPaymentCreateBaseOptions
 } from './service'
-import { isOutgoingPaymentError, errorToCode, errorToMessage } from './errors'
+import {
+  isOutgoingPaymentError,
+  errorToHTTPCode,
+  errorToMessage
+} from './errors'
 import { OutgoingPayment } from './model'
 import { listSubresource } from '../../wallet_address/routes'
 import {
@@ -127,7 +131,7 @@ async function createOutgoingPayment(
 
   if (isOutgoingPaymentError(outgoingPaymentOrError)) {
     throw new OpenPaymentsServerRouteError(
-      errorToCode[outgoingPaymentOrError],
+      errorToHTTPCode[outgoingPaymentOrError],
       errorToMessage[outgoingPaymentOrError]
     )
   }

--- a/packages/backend/src/open_payments/quote/errors.ts
+++ b/packages/backend/src/open_payments/quote/errors.ts
@@ -23,7 +23,7 @@ export const errorToHTTPCode: {
 }
 
 export const errorToCode: {
-  [key in QuoteError]: string
+  [key in QuoteError]: GraphQLErrorCode
 } = {
   [QuoteError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
   [QuoteError.InvalidAmount]: GraphQLErrorCode.BadUserInput,

--- a/packages/backend/src/open_payments/quote/errors.ts
+++ b/packages/backend/src/open_payments/quote/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../../graphql/errors'
+
 export enum QuoteError {
   UnknownWalletAddress = 'UnknownWalletAddress',
   InvalidAmount = 'InvalidAmount',
@@ -10,7 +12,7 @@ export enum QuoteError {
 export const isQuoteError = (o: any): o is QuoteError =>
   Object.values(QuoteError).includes(o)
 
-export const errorToCode: {
+export const errorToHTTPCode: {
   [key in QuoteError]: number
 } = {
   [QuoteError.UnknownWalletAddress]: 404,
@@ -18,6 +20,16 @@ export const errorToCode: {
   [QuoteError.InvalidReceiver]: 400,
   [QuoteError.InactiveWalletAddress]: 400,
   [QuoteError.NegativeReceiveAmount]: 400
+}
+
+export const errorToCode: {
+  [key in QuoteError]: string
+} = {
+  [QuoteError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
+  [QuoteError.InvalidAmount]: GraphQLErrorCode.BadUserInput,
+  [QuoteError.InvalidReceiver]: GraphQLErrorCode.BadUserInput,
+  [QuoteError.InactiveWalletAddress]: GraphQLErrorCode.Inactive,
+  [QuoteError.NegativeReceiveAmount]: GraphQLErrorCode.BadUserInput
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/open_payments/quote/routes.ts
+++ b/packages/backend/src/open_payments/quote/routes.ts
@@ -3,7 +3,7 @@ import { Logger } from 'pino'
 import { ReadContext, CreateContext } from '../../app'
 import { IAppConfig } from '../../config/app'
 import { CreateQuoteOptions, QuoteService } from './service'
-import { isQuoteError, errorToCode, errorToMessage } from './errors'
+import { isQuoteError, errorToHTTPCode, errorToMessage } from './errors'
 import { Quote } from './model'
 import { AmountJSON, parseAmount } from '../amount'
 import { Quote as OpenPaymentsQuote } from '@interledger/open-payments'
@@ -96,7 +96,7 @@ async function createQuote(
 
   if (isQuoteError(quoteOrErr)) {
     throw new OpenPaymentsServerRouteError(
-      errorToCode[quoteOrErr],
+      errorToHTTPCode[quoteOrErr],
       errorToMessage[quoteOrErr]
     )
   }

--- a/packages/backend/src/open_payments/receiver/errors.ts
+++ b/packages/backend/src/open_payments/receiver/errors.ts
@@ -1,6 +1,6 @@
 import {
   errorToMessage as incomingPaymentErrorToMessage,
-  errorToCode as incomingPaymentErrorToCode,
+  errorToHTTPCode as incomingPaymentErrorToCode,
   isIncomingPaymentError,
   IncomingPaymentError
 } from '../payment/incoming/errors'

--- a/packages/backend/src/open_payments/receiver/errors.ts
+++ b/packages/backend/src/open_payments/receiver/errors.ts
@@ -1,6 +1,6 @@
 import {
   errorToMessage as incomingPaymentErrorToMessage,
-  errorToHTTPCode as incomingPaymentErrorToCode,
+  errorToCode as incomingPaymentErrorToCode,
   isIncomingPaymentError,
   IncomingPaymentError
 } from '../payment/incoming/errors'
@@ -20,7 +20,7 @@ export const ReceiverError = {
 export const isReceiverError = (o: any): o is ReceiverError =>
   Object.values(ReceiverError).includes(o)
 
-export const errorToCode = (error: ReceiverError): number =>
+export const errorToCode = (error: ReceiverError): string =>
   isIncomingPaymentError(error)
     ? incomingPaymentErrorToCode[error]
     : remoteIncomingPaymentErrorToCode[error]

--- a/packages/backend/src/open_payments/receiver/errors.ts
+++ b/packages/backend/src/open_payments/receiver/errors.ts
@@ -1,3 +1,4 @@
+import { GraphQLErrorCode } from '../../graphql/errors'
 import {
   errorToMessage as incomingPaymentErrorToMessage,
   errorToCode as incomingPaymentErrorToCode,
@@ -20,7 +21,7 @@ export const ReceiverError = {
 export const isReceiverError = (o: any): o is ReceiverError =>
   Object.values(ReceiverError).includes(o)
 
-export const errorToCode = (error: ReceiverError): string =>
+export const errorToCode = (error: ReceiverError): GraphQLErrorCode =>
   isIncomingPaymentError(error)
     ? incomingPaymentErrorToCode[error]
     : remoteIncomingPaymentErrorToCode[error]

--- a/packages/backend/src/open_payments/wallet_address/errors.ts
+++ b/packages/backend/src/open_payments/wallet_address/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../../graphql/errors'
+
 export enum WalletAddressError {
   InvalidUrl = 'InvalidUrl',
   UnknownAsset = 'UnknownAsset',
@@ -9,11 +11,11 @@ export const isWalletAddressError = (o: any): o is WalletAddressError =>
   Object.values(WalletAddressError).includes(o)
 
 export const errorToCode: {
-  [key in WalletAddressError]: number
+  [key in WalletAddressError]: string
 } = {
-  [WalletAddressError.InvalidUrl]: 400,
-  [WalletAddressError.UnknownAsset]: 400,
-  [WalletAddressError.UnknownWalletAddress]: 404
+  [WalletAddressError.InvalidUrl]: GraphQLErrorCode.BadUserInput,
+  [WalletAddressError.UnknownAsset]: GraphQLErrorCode.BadUserInput,
+  [WalletAddressError.UnknownWalletAddress]: GraphQLErrorCode.NotFound
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/open_payments/wallet_address/errors.ts
+++ b/packages/backend/src/open_payments/wallet_address/errors.ts
@@ -11,7 +11,7 @@ export const isWalletAddressError = (o: any): o is WalletAddressError =>
   Object.values(WalletAddressError).includes(o)
 
 export const errorToCode: {
-  [key in WalletAddressError]: string
+  [key in WalletAddressError]: GraphQLErrorCode
 } = {
   [WalletAddressError.InvalidUrl]: GraphQLErrorCode.BadUserInput,
   [WalletAddressError.UnknownAsset]: GraphQLErrorCode.BadUserInput,

--- a/packages/backend/src/payment-method/ilp/auto-peering/errors.ts
+++ b/packages/backend/src/payment-method/ilp/auto-peering/errors.ts
@@ -40,3 +40,15 @@ export const errorToMessage: {
   [AutoPeeringError.InvalidPeeringRequest]: 'Invalid peering request',
   [AutoPeeringError.LiquidityError]: 'Could not deposit liquidity to peer'
 }
+
+export const errorToHttpCode: {
+  [key in AutoPeeringError]: number
+} = {
+  [AutoPeeringError.InvalidIlpConfiguration]: 400,
+  [AutoPeeringError.InvalidPeerIlpConfiguration]: 400,
+  [AutoPeeringError.UnknownAsset]: 404,
+  [AutoPeeringError.PeerUnsupportedAsset]: 400,
+  [AutoPeeringError.InvalidPeerUrl]: 400,
+  [AutoPeeringError.InvalidPeeringRequest]: 400,
+  [AutoPeeringError.LiquidityError]: 400
+}

--- a/packages/backend/src/payment-method/ilp/auto-peering/errors.ts
+++ b/packages/backend/src/payment-method/ilp/auto-peering/errors.ts
@@ -15,7 +15,7 @@ export const isAutoPeeringError = (o: any): o is AutoPeeringError =>
   Object.values(AutoPeeringError).includes(o)
 
 export const errorToCode: {
-  [key in AutoPeeringError]: string
+  [key in AutoPeeringError]: GraphQLErrorCode
 } = {
   [AutoPeeringError.InvalidIlpConfiguration]: GraphQLErrorCode.BadUserInput,
   [AutoPeeringError.InvalidPeerIlpConfiguration]:

--- a/packages/backend/src/payment-method/ilp/auto-peering/errors.ts
+++ b/packages/backend/src/payment-method/ilp/auto-peering/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../../../graphql/errors'
+
 export enum AutoPeeringError {
   InvalidIlpConfiguration = 'InvalidIlpConfiguration',
   InvalidPeerIlpConfiguration = 'InvalidPeerIlpConfiguration',
@@ -13,15 +15,16 @@ export const isAutoPeeringError = (o: any): o is AutoPeeringError =>
   Object.values(AutoPeeringError).includes(o)
 
 export const errorToCode: {
-  [key in AutoPeeringError]: number
+  [key in AutoPeeringError]: string
 } = {
-  [AutoPeeringError.InvalidIlpConfiguration]: 400,
-  [AutoPeeringError.InvalidPeerIlpConfiguration]: 400,
-  [AutoPeeringError.UnknownAsset]: 404,
-  [AutoPeeringError.PeerUnsupportedAsset]: 400,
-  [AutoPeeringError.InvalidPeerUrl]: 400,
-  [AutoPeeringError.InvalidPeeringRequest]: 400,
-  [AutoPeeringError.LiquidityError]: 400
+  [AutoPeeringError.InvalidIlpConfiguration]: GraphQLErrorCode.BadUserInput,
+  [AutoPeeringError.InvalidPeerIlpConfiguration]:
+    GraphQLErrorCode.InternalServerError,
+  [AutoPeeringError.UnknownAsset]: GraphQLErrorCode.NotFound,
+  [AutoPeeringError.PeerUnsupportedAsset]: GraphQLErrorCode.BadUserInput,
+  [AutoPeeringError.InvalidPeerUrl]: GraphQLErrorCode.NotFound,
+  [AutoPeeringError.InvalidPeeringRequest]: GraphQLErrorCode.BadUserInput,
+  [AutoPeeringError.LiquidityError]: GraphQLErrorCode.InternalServerError
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/payment-method/ilp/auto-peering/routes.test.ts
+++ b/packages/backend/src/payment-method/ilp/auto-peering/routes.test.ts
@@ -6,7 +6,7 @@ import { createTestApp, TestContainer } from '../../../tests/app'
 import { createAsset } from '../../../tests/asset'
 import { createContext } from '../../../tests/context'
 import { truncateTables } from '../../../tests/tableManager'
-import { AutoPeeringError, errorToCode, errorToMessage } from './errors'
+import { AutoPeeringError, errorToHttpCode, errorToMessage } from './errors'
 import { AutoPeeringRoutes, PeerRequestContext } from './routes'
 
 describe('Auto Peering Routes', (): void => {
@@ -74,10 +74,10 @@ describe('Auto Peering Routes', (): void => {
       await expect(
         autoPeeringRoutes.acceptPeerRequest(ctx)
       ).resolves.toBeUndefined()
-      expect(ctx.status).toBe(errorToCode[AutoPeeringError.UnknownAsset])
+      expect(ctx.status).toBe(errorToHttpCode[AutoPeeringError.UnknownAsset])
       expect(ctx.body).toEqual({
         error: {
-          code: errorToCode[AutoPeeringError.UnknownAsset],
+          code: errorToHttpCode[AutoPeeringError.UnknownAsset],
           message: errorToMessage[AutoPeeringError.UnknownAsset],
           type: AutoPeeringError.UnknownAsset
         }

--- a/packages/backend/src/payment-method/ilp/auto-peering/routes.ts
+++ b/packages/backend/src/payment-method/ilp/auto-peering/routes.ts
@@ -1,6 +1,6 @@
 import { AppContext } from '../../../app'
 import { BaseService } from '../../../shared/baseService'
-import { errorToCode, errorToMessage, isAutoPeeringError } from './errors'
+import { errorToHttpCode, errorToMessage, isAutoPeeringError } from './errors'
 import { AutoPeeringService } from './service'
 
 interface PeeringRequestArgs {
@@ -49,7 +49,7 @@ async function acceptPeerRequest(
     await deps.autoPeeringService.acceptPeeringRequest(ctx.request.body)
 
   if (isAutoPeeringError(peeringDetailsOrError)) {
-    const errorCode = errorToCode[peeringDetailsOrError]
+    const errorCode = errorToHttpCode[peeringDetailsOrError]
     ctx.status = errorCode
     ctx.body = {
       error: {

--- a/packages/backend/src/payment-method/ilp/peer/errors.ts
+++ b/packages/backend/src/payment-method/ilp/peer/errors.ts
@@ -1,3 +1,5 @@
+import { GraphQLErrorCode } from '../../../graphql/errors'
+
 export enum PeerError {
   DuplicateIncomingToken = 'DuplicateIncomingToken',
   DuplicatePeer = 'DuplicatePeer',
@@ -13,15 +15,15 @@ export const isPeerError = (o: any): o is PeerError =>
   Object.values(PeerError).includes(o)
 
 export const errorToCode: {
-  [key in PeerError]: number
+  [key in PeerError]: string
 } = {
-  [PeerError.DuplicateIncomingToken]: 409,
-  [PeerError.DuplicatePeer]: 409,
-  [PeerError.InvalidStaticIlpAddress]: 400,
-  [PeerError.InvalidHTTPEndpoint]: 400,
-  [PeerError.UnknownAsset]: 400,
-  [PeerError.UnknownPeer]: 404,
-  [PeerError.InvalidInitialLiquidity]: 400
+  [PeerError.DuplicateIncomingToken]: GraphQLErrorCode.Duplicate,
+  [PeerError.DuplicatePeer]: GraphQLErrorCode.Duplicate,
+  [PeerError.InvalidStaticIlpAddress]: GraphQLErrorCode.BadUserInput,
+  [PeerError.InvalidHTTPEndpoint]: GraphQLErrorCode.BadUserInput,
+  [PeerError.UnknownAsset]: GraphQLErrorCode.NotFound,
+  [PeerError.UnknownPeer]: GraphQLErrorCode.NotFound,
+  [PeerError.InvalidInitialLiquidity]: GraphQLErrorCode.BadUserInput
 }
 
 export const errorToMessage: {

--- a/packages/backend/src/payment-method/ilp/peer/errors.ts
+++ b/packages/backend/src/payment-method/ilp/peer/errors.ts
@@ -15,7 +15,7 @@ export const isPeerError = (o: any): o is PeerError =>
   Object.values(PeerError).includes(o)
 
 export const errorToCode: {
-  [key in PeerError]: string
+  [key in PeerError]: GraphQLErrorCode
 } = {
   [PeerError.DuplicateIncomingToken]: GraphQLErrorCode.Duplicate,
   [PeerError.DuplicatePeer]: GraphQLErrorCode.Duplicate,

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -573,8 +573,7 @@ export enum LiquidityError {
 
 export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  id: Scalars['ID']['output'];
-  liquidity?: Maybe<Scalars['UInt64']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type Model = {
@@ -1881,8 +1880,7 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2313,14 +2311,14 @@ export type DepositAssetLiquidityMutationVariables = Exact<{
 }>;
 
 
-export type DepositAssetLiquidityMutation = { __typename?: 'Mutation', depositAssetLiquidity?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type DepositAssetLiquidityMutation = { __typename?: 'Mutation', depositAssetLiquidity?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type WithdrawAssetLiquidityVariables = Exact<{
   input: CreateAssetLiquidityWithdrawalInput;
 }>;
 
 
-export type WithdrawAssetLiquidity = { __typename?: 'Mutation', createAssetLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type WithdrawAssetLiquidity = { __typename?: 'Mutation', createAssetLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type DeleteAssetMutationVariables = Exact<{
   input: DeleteAssetInput;
@@ -2359,21 +2357,21 @@ export type DepositOutgoingPaymentLiquidityVariables = Exact<{
 }>;
 
 
-export type DepositOutgoingPaymentLiquidity = { __typename?: 'Mutation', depositOutgoingPaymentLiquidity?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type DepositOutgoingPaymentLiquidity = { __typename?: 'Mutation', depositOutgoingPaymentLiquidity?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type CreateOutgoingPaymentWithdrawalVariables = Exact<{
   input: CreateOutgoingPaymentWithdrawalInput;
 }>;
 
 
-export type CreateOutgoingPaymentWithdrawal = { __typename?: 'Mutation', createOutgoingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type CreateOutgoingPaymentWithdrawal = { __typename?: 'Mutation', createOutgoingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type CreateIncomingPaymentWithdrawalVariables = Exact<{
   input: CreateIncomingPaymentWithdrawalInput;
 }>;
 
 
-export type CreateIncomingPaymentWithdrawal = { __typename?: 'Mutation', createIncomingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type CreateIncomingPaymentWithdrawal = { __typename?: 'Mutation', createIncomingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type GetPeerQueryVariables = Exact<{
   id: Scalars['String']['input'];
@@ -2418,14 +2416,14 @@ export type DepositPeerLiquidityMutationVariables = Exact<{
 }>;
 
 
-export type DepositPeerLiquidityMutation = { __typename?: 'Mutation', depositPeerLiquidity?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type DepositPeerLiquidityMutation = { __typename?: 'Mutation', depositPeerLiquidity?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type WithdrawPeerLiquidityVariables = Exact<{
   input: CreatePeerLiquidityWithdrawalInput;
 }>;
 
 
-export type WithdrawPeerLiquidity = { __typename?: 'Mutation', createPeerLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
+export type WithdrawPeerLiquidity = { __typename?: 'Mutation', createPeerLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
 
 export type GetWalletAddressQueryVariables = Exact<{
   id: Scalars['String']['input'];

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -286,10 +286,7 @@ export type CreateReceiverInput = {
 
 export type CreateReceiverResponse = {
   __typename?: 'CreateReceiverResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   receiver?: Maybe<Receiver>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateWalletAddressInput = {
@@ -514,10 +511,7 @@ export type IncomingPaymentEdge = {
 
 export type IncomingPaymentResponse = {
   __typename?: 'IncomingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<IncomingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum IncomingPaymentState {
@@ -859,10 +853,7 @@ export type OutgoingPaymentEdge = {
 
 export type OutgoingPaymentResponse = {
   __typename?: 'OutgoingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<OutgoingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum OutgoingPaymentState {
@@ -1123,10 +1114,7 @@ export type QuoteEdge = {
 
 export type QuoteResponse = {
   __typename?: 'QuoteResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   quote?: Maybe<Quote>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type Receiver = {
@@ -1791,10 +1779,7 @@ export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType ex
 };
 
 export type CreateReceiverResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateReceiverResponse'] = ResolversParentTypes['CreateReceiverResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receiver?: Resolver<Maybe<ResolversTypes['Receiver']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1878,10 +1863,7 @@ export type IncomingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type IncomingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['IncomingPaymentResponse'] = ResolversParentTypes['IncomingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1975,10 +1957,7 @@ export type OutgoingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type OutgoingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentResponse'] = ResolversParentTypes['OutgoingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['OutgoingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2082,10 +2061,7 @@ export type QuoteEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 };
 
 export type QuoteResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['QuoteResponse'] = ResolversParentTypes['QuoteResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -92,12 +92,9 @@ export type AssetEdge = {
   node: Asset;
 };
 
-export type AssetMutationResponse = MutationResponse & {
+export type AssetMutationResponse = {
   __typename?: 'AssetMutationResponse';
   asset?: Maybe<Asset>;
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type AssetsConnection = {
@@ -186,12 +183,9 @@ export type CreateOrUpdatePeerByUrlInput = {
   peerUrl: Scalars['String']['input'];
 };
 
-export type CreateOrUpdatePeerByUrlMutationResponse = MutationResponse & {
+export type CreateOrUpdatePeerByUrlMutationResponse = {
   __typename?: 'CreateOrUpdatePeerByUrlMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateOutgoingPaymentFromIncomingPaymentInput = {
@@ -259,12 +253,9 @@ export type CreatePeerLiquidityWithdrawalInput = {
   timeoutSeconds: Scalars['UInt64']['input'];
 };
 
-export type CreatePeerMutationResponse = MutationResponse & {
+export type CreatePeerMutationResponse = {
   __typename?: 'CreatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateQuoteInput = {
@@ -322,19 +313,13 @@ export type CreateWalletAddressKeyInput = {
   walletAddressId: Scalars['String']['input'];
 };
 
-export type CreateWalletAddressKeyMutationResponse = MutationResponse & {
+export type CreateWalletAddressKeyMutationResponse = {
   __typename?: 'CreateWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
-export type CreateWalletAddressMutationResponse = MutationResponse & {
+export type CreateWalletAddressMutationResponse = {
   __typename?: 'CreateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -360,11 +345,9 @@ export type DeleteAssetInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeleteAssetMutationResponse = MutationResponse & {
+export type DeleteAssetMutationResponse = {
   __typename?: 'DeleteAssetMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  asset?: Maybe<Asset>;
 };
 
 export type DeletePeerInput = {
@@ -373,10 +356,8 @@ export type DeletePeerInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeletePeerMutationResponse = MutationResponse & {
+export type DeletePeerMutationResponse = {
   __typename?: 'DeletePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   success: Scalars['Boolean']['output'];
 };
 
@@ -596,12 +577,10 @@ export enum LiquidityError {
   UnknownWalletAddress = 'UnknownWalletAddress'
 }
 
-export type LiquidityMutationResponse = MutationResponse & {
+export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
 };
 
 export type Model = {
@@ -834,12 +813,6 @@ export type MutationVoidLiquidityWithdrawalArgs = {
 
 export type MutationWithdrawEventLiquidityArgs = {
   input: WithdrawEventLiquidityInput;
-};
-
-export type MutationResponse = {
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type OutgoingPayment = BasePayment & Model & {
@@ -1185,11 +1158,8 @@ export type RevokeWalletAddressKeyInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type RevokeWalletAddressKeyMutationResponse = MutationResponse & {
+export type RevokeWalletAddressKeyMutationResponse = {
   __typename?: 'RevokeWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
@@ -1204,12 +1174,9 @@ export type SetFeeInput = {
   type: FeeType;
 };
 
-export type SetFeeResponse = MutationResponse & {
+export type SetFeeResponse = {
   __typename?: 'SetFeeResponse';
-  code: Scalars['String']['output'];
   fee?: Maybe<Fee>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export enum SortOrder {
@@ -1219,13 +1186,6 @@ export enum SortOrder {
   Desc = 'DESC'
 }
 
-export type TransferMutationResponse = MutationResponse & {
-  __typename?: 'TransferMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 export type TriggerWalletAddressEventsInput = {
   /** Unique key to ensure duplicate or retried requests are processed only once. See [idempotence](https://en.wikipedia.org/wiki/Idempotence) */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1233,13 +1193,10 @@ export type TriggerWalletAddressEventsInput = {
   limit: Scalars['Int']['input'];
 };
 
-export type TriggerWalletAddressEventsMutationResponse = MutationResponse & {
+export type TriggerWalletAddressEventsMutationResponse = {
   __typename?: 'TriggerWalletAddressEventsMutationResponse';
-  code: Scalars['String']['output'];
   /** Number of events triggered */
   count?: Maybe<Scalars['Int']['output']>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateAssetInput = {
@@ -1270,12 +1227,9 @@ export type UpdatePeerInput = {
   staticIlpAddress?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdatePeerMutationResponse = MutationResponse & {
+export type UpdatePeerMutationResponse = {
   __typename?: 'UpdatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateWalletAddressInput = {
@@ -1291,11 +1245,8 @@ export type UpdateWalletAddressInput = {
   status?: InputMaybe<WalletAddressStatus>;
 };
 
-export type UpdateWalletAddressMutationResponse = MutationResponse & {
+export type UpdateWalletAddressMutationResponse = {
   __typename?: 'UpdateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -1419,12 +1370,8 @@ export type WalletAddressWithdrawal = {
   walletAddress: WalletAddress;
 };
 
-export type WalletAddressWithdrawalMutationResponse = MutationResponse & {
+export type WalletAddressWithdrawalMutationResponse = {
   __typename?: 'WalletAddressWithdrawalMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   withdrawal?: Maybe<WalletAddressWithdrawal>;
 };
 
@@ -1541,7 +1488,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
-  MutationResponse: ( Partial<AssetMutationResponse> ) | ( Partial<CreateOrUpdatePeerByUrlMutationResponse> ) | ( Partial<CreatePeerMutationResponse> ) | ( Partial<CreateWalletAddressKeyMutationResponse> ) | ( Partial<CreateWalletAddressMutationResponse> ) | ( Partial<DeleteAssetMutationResponse> ) | ( Partial<DeletePeerMutationResponse> ) | ( Partial<LiquidityMutationResponse> ) | ( Partial<RevokeWalletAddressKeyMutationResponse> ) | ( Partial<SetFeeResponse> ) | ( Partial<TransferMutationResponse> ) | ( Partial<TriggerWalletAddressEventsMutationResponse> ) | ( Partial<UpdatePeerMutationResponse> ) | ( Partial<UpdateWalletAddressMutationResponse> ) | ( Partial<WalletAddressWithdrawalMutationResponse> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1614,7 +1560,6 @@ export type ResolversTypes = {
   LiquidityMutationResponse: ResolverTypeWrapper<Partial<LiquidityMutationResponse>>;
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
-  MutationResponse: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['MutationResponse']>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
@@ -1642,7 +1587,6 @@ export type ResolversTypes = {
   SetFeeResponse: ResolverTypeWrapper<Partial<SetFeeResponse>>;
   SortOrder: ResolverTypeWrapper<Partial<SortOrder>>;
   String: ResolverTypeWrapper<Partial<Scalars['String']['output']>>;
-  TransferMutationResponse: ResolverTypeWrapper<Partial<TransferMutationResponse>>;
   TriggerWalletAddressEventsInput: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsInput>>;
   TriggerWalletAddressEventsMutationResponse: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsMutationResponse>>;
   UInt8: ResolverTypeWrapper<Partial<Scalars['UInt8']['output']>>;
@@ -1733,7 +1677,6 @@ export type ResolversParentTypes = {
   LiquidityMutationResponse: Partial<LiquidityMutationResponse>;
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
-  MutationResponse: ResolversInterfaceTypes<ResolversParentTypes>['MutationResponse'];
   OutgoingPayment: Partial<OutgoingPayment>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
@@ -1758,7 +1701,6 @@ export type ResolversParentTypes = {
   SetFeeInput: Partial<SetFeeInput>;
   SetFeeResponse: Partial<SetFeeResponse>;
   String: Partial<Scalars['String']['output']>;
-  TransferMutationResponse: Partial<TransferMutationResponse>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
   UInt8: Partial<Scalars['UInt8']['output']>;
@@ -1820,9 +1762,6 @@ export type AssetEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type AssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AssetMutationResponse'] = ResolversParentTypes['AssetMutationResponse']> = {
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1842,18 +1781,12 @@ export type BasePaymentResolvers<ContextType = any, ParentType extends Resolvers
 };
 
 export type CreateOrUpdatePeerByUrlMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse'] = ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreatePeerMutationResponse'] = ResolversParentTypes['CreatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1866,31 +1799,21 @@ export type CreateReceiverResponseResolvers<ContextType = any, ParentType extend
 };
 
 export type CreateWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressKeyMutationResponse'] = ResolversParentTypes['CreateWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressMutationResponse'] = ResolversParentTypes['CreateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeleteAssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteAssetMutationResponse'] = ResolversParentTypes['DeleteAssetMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeletePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeletePeerMutationResponse'] = ResolversParentTypes['DeletePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1976,10 +1899,8 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2021,13 +1942,6 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateWalletAddress?: Resolver<ResolversTypes['UpdateWalletAddressMutationResponse'], ParentType, ContextType, RequireFields<MutationUpdateWalletAddressArgs, 'input'>>;
   voidLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationVoidLiquidityWithdrawalArgs, 'input'>>;
   withdrawEventLiquidity?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationWithdrawEventLiquidityArgs, 'input'>>;
-};
-
-export type MutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutationResponse'] = ResolversParentTypes['MutationResponse']> = {
-  __resolveType: TypeResolveFn<'AssetMutationResponse' | 'CreateOrUpdatePeerByUrlMutationResponse' | 'CreatePeerMutationResponse' | 'CreateWalletAddressKeyMutationResponse' | 'CreateWalletAddressMutationResponse' | 'DeleteAssetMutationResponse' | 'DeletePeerMutationResponse' | 'LiquidityMutationResponse' | 'RevokeWalletAddressKeyMutationResponse' | 'SetFeeResponse' | 'TransferMutationResponse' | 'TriggerWalletAddressEventsMutationResponse' | 'UpdatePeerMutationResponse' | 'UpdateWalletAddressMutationResponse' | 'WalletAddressWithdrawalMutationResponse', ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
@@ -2189,33 +2103,17 @@ export type ReceiverResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type RevokeWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['RevokeWalletAddressKeyMutationResponse'] = ResolversParentTypes['RevokeWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SetFeeResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetFeeResponse'] = ResolversParentTypes['SetFeeResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   fee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TransferMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransferMutationResponse'] = ResolversParentTypes['TransferMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type TriggerWalletAddressEventsMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TriggerWalletAddressEventsMutationResponse'] = ResolversParentTypes['TriggerWalletAddressEventsMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2228,17 +2126,11 @@ export interface UInt64ScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 }
 
 export type UpdatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdatePeerMutationResponse'] = ResolversParentTypes['UpdatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateWalletAddressMutationResponse'] = ResolversParentTypes['UpdateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2294,10 +2186,6 @@ export type WalletAddressWithdrawalResolvers<ContextType = any, ParentType exten
 };
 
 export type WalletAddressWithdrawalMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddressWithdrawalMutationResponse'] = ResolversParentTypes['WalletAddressWithdrawalMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   withdrawal?: Resolver<Maybe<ResolversTypes['WalletAddressWithdrawal']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2357,7 +2245,6 @@ export type Resolvers<ContextType = any> = {
   LiquidityMutationResponse?: LiquidityMutationResponseResolvers<ContextType>;
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
-  MutationResponse?: MutationResponseResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
@@ -2377,7 +2264,6 @@ export type Resolvers<ContextType = any> = {
   Receiver?: ReceiverResolvers<ContextType>;
   RevokeWalletAddressKeyMutationResponse?: RevokeWalletAddressKeyMutationResponseResolvers<ContextType>;
   SetFeeResponse?: SetFeeResponseResolvers<ContextType>;
-  TransferMutationResponse?: TransferMutationResponseResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;
   UInt64?: GraphQLScalarType;
@@ -2430,42 +2316,42 @@ export type CreateAssetMutationVariables = Exact<{
 }>;
 
 
-export type CreateAssetMutation = { __typename?: 'Mutation', createAsset: { __typename?: 'AssetMutationResponse', code: string, success: boolean, message: string, asset?: { __typename?: 'Asset', id: string } | null } };
+export type CreateAssetMutation = { __typename?: 'Mutation', createAsset: { __typename?: 'AssetMutationResponse', asset?: { __typename?: 'Asset', id: string, code: string, scale: number, withdrawalThreshold?: bigint | null, liquidity?: bigint | null, createdAt: string, sendingFee?: { __typename?: 'Fee', basisPoints: number, fixed: bigint, createdAt: string } | null } | null } };
 
 export type UpdateAssetMutationVariables = Exact<{
   input: UpdateAssetInput;
 }>;
 
 
-export type UpdateAssetMutation = { __typename?: 'Mutation', updateAsset: { __typename?: 'AssetMutationResponse', code: string, success: boolean, message: string } };
+export type UpdateAssetMutation = { __typename?: 'Mutation', updateAsset: { __typename?: 'AssetMutationResponse', asset?: { __typename?: 'Asset', id: string, code: string, scale: number, withdrawalThreshold?: bigint | null, liquidity?: bigint | null, createdAt: string, sendingFee?: { __typename?: 'Fee', basisPoints: number, fixed: bigint, createdAt: string } | null } | null } };
 
 export type SetFeeMutationVariables = Exact<{
   input: SetFeeInput;
 }>;
 
 
-export type SetFeeMutation = { __typename?: 'Mutation', setFee: { __typename?: 'SetFeeResponse', code: string, message: string, success: boolean, fee?: { __typename?: 'Fee', assetId: string, basisPoints: number, createdAt: string, fixed: bigint, id: string, type: FeeType } | null } };
+export type SetFeeMutation = { __typename?: 'Mutation', setFee: { __typename?: 'SetFeeResponse', fee?: { __typename?: 'Fee', assetId: string, basisPoints: number, createdAt: string, fixed: bigint, id: string, type: FeeType } | null } };
 
 export type DepositAssetLiquidityMutationVariables = Exact<{
   input: DepositAssetLiquidityInput;
 }>;
 
 
-export type DepositAssetLiquidityMutation = { __typename?: 'Mutation', depositAssetLiquidity?: { __typename?: 'LiquidityMutationResponse', code: string, success: boolean, message: string, error?: LiquidityError | null } | null };
+export type DepositAssetLiquidityMutation = { __typename?: 'Mutation', depositAssetLiquidity?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type WithdrawAssetLiquidityVariables = Exact<{
   input: CreateAssetLiquidityWithdrawalInput;
 }>;
 
 
-export type WithdrawAssetLiquidity = { __typename?: 'Mutation', createAssetLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', code: string, success: boolean, message: string, error?: LiquidityError | null } | null };
+export type WithdrawAssetLiquidity = { __typename?: 'Mutation', createAssetLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type DeleteAssetMutationVariables = Exact<{
   input: DeleteAssetInput;
 }>;
 
 
-export type DeleteAssetMutation = { __typename?: 'Mutation', deleteAsset: { __typename?: 'DeleteAssetMutationResponse', code: string, success: boolean, message: string } };
+export type DeleteAssetMutation = { __typename?: 'Mutation', deleteAsset: { __typename?: 'DeleteAssetMutationResponse', asset?: { __typename?: 'Asset', id: string, code: string, scale: number, withdrawalThreshold?: bigint | null, liquidity?: bigint | null, createdAt: string, sendingFee?: { __typename?: 'Fee', basisPoints: number, fixed: bigint, createdAt: string } | null } | null } };
 
 export type GetIncomingPaymentVariables = Exact<{
   id: Scalars['String']['input'];
@@ -2497,21 +2383,21 @@ export type DepositOutgoingPaymentLiquidityVariables = Exact<{
 }>;
 
 
-export type DepositOutgoingPaymentLiquidity = { __typename?: 'Mutation', depositOutgoingPaymentLiquidity?: { __typename?: 'LiquidityMutationResponse', success: boolean, message: string } | null };
+export type DepositOutgoingPaymentLiquidity = { __typename?: 'Mutation', depositOutgoingPaymentLiquidity?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type CreateOutgoingPaymentWithdrawalVariables = Exact<{
   input: CreateOutgoingPaymentWithdrawalInput;
 }>;
 
 
-export type CreateOutgoingPaymentWithdrawal = { __typename?: 'Mutation', createOutgoingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean, message: string } | null };
+export type CreateOutgoingPaymentWithdrawal = { __typename?: 'Mutation', createOutgoingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type CreateIncomingPaymentWithdrawalVariables = Exact<{
   input: CreateIncomingPaymentWithdrawalInput;
 }>;
 
 
-export type CreateIncomingPaymentWithdrawal = { __typename?: 'Mutation', createIncomingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean, message: string } | null };
+export type CreateIncomingPaymentWithdrawal = { __typename?: 'Mutation', createIncomingPaymentWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type GetPeerQueryVariables = Exact<{
   id: Scalars['String']['input'];
@@ -2535,35 +2421,35 @@ export type CreatePeerMutationVariables = Exact<{
 }>;
 
 
-export type CreatePeerMutation = { __typename?: 'Mutation', createPeer: { __typename?: 'CreatePeerMutationResponse', code: string, success: boolean, message: string, peer?: { __typename?: 'Peer', id: string } | null } };
+export type CreatePeerMutation = { __typename?: 'Mutation', createPeer: { __typename?: 'CreatePeerMutationResponse', peer?: { __typename?: 'Peer', id: string } | null } };
 
 export type UpdatePeerMutationVariables = Exact<{
   input: UpdatePeerInput;
 }>;
 
 
-export type UpdatePeerMutation = { __typename?: 'Mutation', updatePeer: { __typename?: 'UpdatePeerMutationResponse', code: string, success: boolean, message: string } };
+export type UpdatePeerMutation = { __typename?: 'Mutation', updatePeer: { __typename?: 'UpdatePeerMutationResponse', peer?: { __typename?: 'Peer', id: string } | null } };
 
 export type DeletePeerMutationVariables = Exact<{
   input: DeletePeerInput;
 }>;
 
 
-export type DeletePeerMutation = { __typename?: 'Mutation', deletePeer: { __typename?: 'DeletePeerMutationResponse', code: string, success: boolean, message: string } };
+export type DeletePeerMutation = { __typename?: 'Mutation', deletePeer: { __typename?: 'DeletePeerMutationResponse', success: boolean } };
 
 export type DepositPeerLiquidityMutationVariables = Exact<{
   input: DepositPeerLiquidityInput;
 }>;
 
 
-export type DepositPeerLiquidityMutation = { __typename?: 'Mutation', depositPeerLiquidity?: { __typename?: 'LiquidityMutationResponse', code: string, success: boolean, message: string, error?: LiquidityError | null } | null };
+export type DepositPeerLiquidityMutation = { __typename?: 'Mutation', depositPeerLiquidity?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type WithdrawPeerLiquidityVariables = Exact<{
   input: CreatePeerLiquidityWithdrawalInput;
 }>;
 
 
-export type WithdrawPeerLiquidity = { __typename?: 'Mutation', createPeerLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', code: string, success: boolean, message: string, error?: LiquidityError | null } | null };
+export type WithdrawPeerLiquidity = { __typename?: 'Mutation', createPeerLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', id: string, liquidity?: bigint | null } | null };
 
 export type GetWalletAddressQueryVariables = Exact<{
   id: Scalars['String']['input'];
@@ -2587,21 +2473,21 @@ export type UpdateWalletAddressMutationVariables = Exact<{
 }>;
 
 
-export type UpdateWalletAddressMutation = { __typename?: 'Mutation', updateWalletAddress: { __typename?: 'UpdateWalletAddressMutationResponse', code: string, message: string, success: boolean } };
+export type UpdateWalletAddressMutation = { __typename?: 'Mutation', updateWalletAddress: { __typename?: 'UpdateWalletAddressMutationResponse', walletAddress?: { __typename?: 'WalletAddress', id: string } | null } };
 
 export type CreateWalletAddressMutationVariables = Exact<{
   input: CreateWalletAddressInput;
 }>;
 
 
-export type CreateWalletAddressMutation = { __typename?: 'Mutation', createWalletAddress: { __typename?: 'CreateWalletAddressMutationResponse', code: string, success: boolean, message: string, walletAddress?: { __typename?: 'WalletAddress', id: string } | null } };
+export type CreateWalletAddressMutation = { __typename?: 'Mutation', createWalletAddress: { __typename?: 'CreateWalletAddressMutationResponse', walletAddress?: { __typename?: 'WalletAddress', id: string } | null } };
 
 export type CreateWalletAddressWithdrawalVariables = Exact<{
   input: CreateWalletAddressWithdrawalInput;
 }>;
 
 
-export type CreateWalletAddressWithdrawal = { __typename?: 'Mutation', createWalletAddressWithdrawal?: { __typename?: 'WalletAddressWithdrawalMutationResponse', success: boolean, message: string } | null };
+export type CreateWalletAddressWithdrawal = { __typename?: 'Mutation', createWalletAddressWithdrawal?: { __typename?: 'WalletAddressWithdrawalMutationResponse', withdrawal?: { __typename?: 'WalletAddressWithdrawal', id: string } | null } | null };
 
 export type ListWebhookEventsVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;

--- a/packages/frontend/app/lib/api/asset.server.ts
+++ b/packages/frontend/app/lib/api/asset.server.ts
@@ -142,11 +142,18 @@ export const createAsset = async (args: CreateAssetInput) => {
     mutation: gql`
       mutation CreateAssetMutation($input: CreateAssetInput!) {
         createAsset(input: $input) {
-          code
-          success
-          message
           asset {
             id
+            code
+            scale
+            withdrawalThreshold
+            liquidity
+            sendingFee {
+              basisPoints
+              fixed
+              createdAt
+            }
+            createdAt
           }
         }
       }
@@ -167,9 +174,19 @@ export const updateAsset = async (args: UpdateAssetInput) => {
     mutation: gql`
       mutation UpdateAssetMutation($input: UpdateAssetInput!) {
         updateAsset(input: $input) {
-          code
-          success
-          message
+          asset {
+            id
+            code
+            scale
+            withdrawalThreshold
+            liquidity
+            sendingFee {
+              basisPoints
+              fixed
+              createdAt
+            }
+            createdAt
+          }
         }
       }
     `,
@@ -189,7 +206,6 @@ export const setFee = async (args: SetFeeInput) => {
     mutation: gql`
       mutation SetFeeMutation($input: SetFeeInput!) {
         setFee(input: $input) {
-          code
           fee {
             assetId
             basisPoints
@@ -198,8 +214,6 @@ export const setFee = async (args: SetFeeInput) => {
             id
             type
           }
-          message
-          success
         }
       }
     `,
@@ -223,10 +237,8 @@ export const depositAssetLiquidity = async (
         $input: DepositAssetLiquidityInput!
       ) {
         depositAssetLiquidity(input: $input) {
-          code
-          success
-          message
-          error
+          id
+          liquidity
         }
       }
     `,
@@ -250,10 +262,8 @@ export const withdrawAssetLiquidity = async (
         $input: CreateAssetLiquidityWithdrawalInput!
       ) {
         createAssetLiquidityWithdrawal(input: $input) {
-          code
-          success
-          message
-          error
+          id
+          liquidity
         }
       }
     `,
@@ -292,9 +302,19 @@ export const deleteAsset = async (args: DeleteAssetInput) => {
     mutation: gql`
       mutation DeleteAssetMutation($input: DeleteAssetInput!) {
         deleteAsset(input: $input) {
-          code
-          success
-          message
+          asset {
+            id
+            code
+            scale
+            withdrawalThreshold
+            liquidity
+            sendingFee {
+              basisPoints
+              fixed
+              createdAt
+            }
+            createdAt
+          }
         }
       }
     `,

--- a/packages/frontend/app/lib/api/asset.server.ts
+++ b/packages/frontend/app/lib/api/asset.server.ts
@@ -237,8 +237,7 @@ export const depositAssetLiquidity = async (
         $input: DepositAssetLiquidityInput!
       ) {
         depositAssetLiquidity(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,
@@ -262,8 +261,7 @@ export const withdrawAssetLiquidity = async (
         $input: CreateAssetLiquidityWithdrawalInput!
       ) {
         createAssetLiquidityWithdrawal(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,

--- a/packages/frontend/app/lib/api/payments.server.ts
+++ b/packages/frontend/app/lib/api/payments.server.ts
@@ -151,8 +151,8 @@ export const depositOutgoingPaymentLiquidity = async (
         $input: DepositOutgoingPaymentLiquidityInput!
       ) {
         depositOutgoingPaymentLiquidity(input: $input) {
-          success
-          message
+          id
+          liquidity
         }
       }
     `,
@@ -176,8 +176,8 @@ export const createOutgoingPaymentWithdrawal = async (
         $input: CreateOutgoingPaymentWithdrawalInput!
       ) {
         createOutgoingPaymentWithdrawal(input: $input) {
-          success
-          message
+          id
+          liquidity
         }
       }
     `,
@@ -201,8 +201,8 @@ export const createIncomingPaymentWithdrawal = async (
         $input: CreateIncomingPaymentWithdrawalInput!
       ) {
         createIncomingPaymentWithdrawal(input: $input) {
-          success
-          message
+          id
+          liquidity
         }
       }
     `,

--- a/packages/frontend/app/lib/api/payments.server.ts
+++ b/packages/frontend/app/lib/api/payments.server.ts
@@ -151,8 +151,7 @@ export const depositOutgoingPaymentLiquidity = async (
         $input: DepositOutgoingPaymentLiquidityInput!
       ) {
         depositOutgoingPaymentLiquidity(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,
@@ -176,8 +175,7 @@ export const createOutgoingPaymentWithdrawal = async (
         $input: CreateOutgoingPaymentWithdrawalInput!
       ) {
         createOutgoingPaymentWithdrawal(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,
@@ -201,8 +199,7 @@ export const createIncomingPaymentWithdrawal = async (
         $input: CreateIncomingPaymentWithdrawalInput!
       ) {
         createIncomingPaymentWithdrawal(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,

--- a/packages/frontend/app/lib/api/peer.server.ts
+++ b/packages/frontend/app/lib/api/peer.server.ts
@@ -111,9 +111,6 @@ export const createPeer = async (args: CreatePeerInput) => {
     mutation: gql`
       mutation CreatePeerMutation($input: CreatePeerInput!) {
         createPeer(input: $input) {
-          code
-          success
-          message
           peer {
             id
           }
@@ -136,9 +133,9 @@ export const updatePeer = async (args: UpdatePeerInput) => {
     mutation: gql`
       mutation UpdatePeerMutation($input: UpdatePeerInput!) {
         updatePeer(input: $input) {
-          code
-          success
-          message
+          peer {
+            id
+          }
         }
       }
     `,
@@ -158,9 +155,7 @@ export const deletePeer = async (args: MutationDeletePeerArgs) => {
     mutation: gql`
       mutation DeletePeerMutation($input: DeletePeerInput!) {
         deletePeer(input: $input) {
-          code
           success
-          message
         }
       }
     `,
@@ -180,10 +175,8 @@ export const depositPeerLiquidity = async (args: DepositPeerLiquidityInput) => {
         $input: DepositPeerLiquidityInput!
       ) {
         depositPeerLiquidity(input: $input) {
-          code
-          success
-          message
-          error
+          id
+          liquidity
         }
       }
     `,
@@ -207,10 +200,8 @@ export const withdrawPeerLiquidity = async (
         $input: CreatePeerLiquidityWithdrawalInput!
       ) {
         createPeerLiquidityWithdrawal(input: $input) {
-          code
-          success
-          message
-          error
+          id
+          liquidity
         }
       }
     `,

--- a/packages/frontend/app/lib/api/peer.server.ts
+++ b/packages/frontend/app/lib/api/peer.server.ts
@@ -175,8 +175,7 @@ export const depositPeerLiquidity = async (args: DepositPeerLiquidityInput) => {
         $input: DepositPeerLiquidityInput!
       ) {
         depositPeerLiquidity(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,
@@ -200,8 +199,7 @@ export const withdrawPeerLiquidity = async (
         $input: CreatePeerLiquidityWithdrawalInput!
       ) {
         createPeerLiquidityWithdrawal(input: $input) {
-          id
-          liquidity
+          success
         }
       }
     `,

--- a/packages/frontend/app/lib/api/wallet-address.server.ts
+++ b/packages/frontend/app/lib/api/wallet-address.server.ts
@@ -92,9 +92,9 @@ export const updateWalletAddress = async (args: UpdateWalletAddressInput) => {
     mutation: gql`
       mutation UpdateWalletAddressMutation($input: UpdateWalletAddressInput!) {
         updateWalletAddress(input: $input) {
-          code
-          message
-          success
+          walletAddress {
+            id
+          }
         }
       }
     `,
@@ -114,9 +114,6 @@ export const createWalletAddress = async (args: CreateWalletAddressInput) => {
     mutation: gql`
       mutation CreateWalletAddressMutation($input: CreateWalletAddressInput!) {
         createWalletAddress(input: $input) {
-          code
-          success
-          message
           walletAddress {
             id
           }
@@ -143,8 +140,9 @@ export const createWalletAddressWithdrawal = async (
         $input: CreateWalletAddressWithdrawalInput!
       ) {
         createWalletAddressWithdrawal(input: $input) {
-          success
-          message
+          withdrawal {
+            id
+          }
         }
       }
     `,

--- a/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
@@ -67,8 +67,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return setMessageAndRedirect({
       session,
       message: {
-        content:
-          'Could not deposit asset liquidity. Please try again!',
+        content: 'Could not deposit asset liquidity. Please try again!',
         type: 'error'
       },
       location: '.'

--- a/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
@@ -63,7 +63,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     idempotencyKey: v4()
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
@@ -63,12 +63,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     idempotencyKey: v4()
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not deposit asset liquidity. Please try again!',
         type: 'error'
       },
@@ -79,7 +78,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Deposited asset liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/assets.$assetId.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.tsx
@@ -301,9 +301,9 @@ export async function action({ request }: ActionFunctionArgs) {
           : { withdrawalThreshold: undefined })
       })
 
-      if (!response?.success) {
+      if (!response?.asset) {
         actionResponse.errors.general.message = [
-          response?.message ?? 'Could not update asset. Please try again!'
+          'Could not update asset. Please try again!'
         ]
         return json({ ...actionResponse }, { status: 400 })
       }
@@ -327,9 +327,8 @@ export async function action({ request }: ActionFunctionArgs) {
         }
       })
 
-      if (!response?.success) {
+      if (!response?.fee) {
         actionResponse.errors.sendingFee.message = [
-          response?.message ??
             'Could not update asset sending fee. Please try again!'
         ]
         return json({ ...actionResponse }, { status: 400 })
@@ -351,11 +350,11 @@ export async function action({ request }: ActionFunctionArgs) {
       }
 
       const response = await deleteAsset({ id: result.data.id })
-      if (!response?.success) {
+      if (!response?.asset) {
         return setMessageAndRedirect({
           session,
           message: {
-            content: response?.message || 'Could not delete Asset.',
+            content: 'Could not delete Asset.',
             type: 'error'
           },
           location: '.'

--- a/packages/frontend/app/routes/assets.$assetId.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.tsx
@@ -329,7 +329,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
       if (!response?.fee) {
         actionResponse.errors.sendingFee.message = [
-            'Could not update asset sending fee. Please try again!'
+          'Could not update asset sending fee. Please try again!'
         ]
         return json({ ...actionResponse }, { status: 400 })
       }

--- a/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
@@ -64,7 +64,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
@@ -64,12 +64,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not withdraw asset liquidity. Please try again!',
         type: 'error'
       },
@@ -80,7 +79,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Successfully withdrew asset liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
@@ -68,8 +68,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return setMessageAndRedirect({
       session,
       message: {
-        content:
-          'Could not withdraw asset liquidity. Please try again!',
+        content: 'Could not withdraw asset liquidity. Please try again!',
         type: 'error'
       },
       location: '.'

--- a/packages/frontend/app/routes/assets.create.tsx
+++ b/packages/frontend/app/routes/assets.create.tsx
@@ -104,9 +104,9 @@ export async function action({ request }: ActionFunctionArgs) {
       : { withdrawalThreshold: undefined })
   })
 
-  if (!response?.success) {
+  if (!response?.asset) {
     errors.message = [
-      response?.message ?? 'Could not create asset. Please try again!'
+      'Could not create asset. Please try again!'
     ]
     return json({ errors }, { status: 400 })
   }

--- a/packages/frontend/app/routes/assets.create.tsx
+++ b/packages/frontend/app/routes/assets.create.tsx
@@ -105,9 +105,7 @@ export async function action({ request }: ActionFunctionArgs) {
   })
 
   if (!response?.asset) {
-    errors.message = [
-      'Could not create asset. Please try again!'
-    ]
+    errors.message = ['Could not create asset. Please try again!']
     return json({ errors }, { status: 400 })
   }
 

--- a/packages/frontend/app/routes/payments.incoming.$incomingPaymentId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/payments.incoming.$incomingPaymentId.withdraw-liquidity.tsx
@@ -49,7 +49,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/payments.incoming.$incomingPaymentId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/payments.incoming.$incomingPaymentId.withdraw-liquidity.tsx
@@ -49,12 +49,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not withdraw incoming payment liquidity. Please try again!',
         type: 'error'
       },
@@ -65,7 +64,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Withdrew incoming payment liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.deposit-liquidity.tsx
@@ -50,12 +50,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     idempotencyKey: v4()
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not deposit outgoing payment liquidity. Please try again!',
         type: 'error'
       },
@@ -66,7 +65,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Deposited outgoing payment liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.deposit-liquidity.tsx
@@ -50,7 +50,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     idempotencyKey: v4()
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.withdraw-liquidity.tsx
@@ -51,12 +51,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not withdraw outgoing payment liquidity. Please try again!',
         type: 'error'
       },
@@ -67,7 +66,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Withdrew outgoing payment liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/payments.outgoing.$outgoingPaymentId.withdraw-liquidity.tsx
@@ -51,7 +51,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
@@ -67,8 +67,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return setMessageAndRedirect({
       session,
       message: {
-        content:
-          'Could not deposit peer liquidity. Please try again!',
+        content: 'Could not deposit peer liquidity. Please try again!',
         type: 'error'
       },
       location: '.'

--- a/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
@@ -63,7 +63,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     idempotencyKey: v4()
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
@@ -63,12 +63,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     idempotencyKey: v4()
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not deposit peer liquidity. Please try again!',
         type: 'error'
       },
@@ -79,7 +78,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Deposited peer liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/peers.$peerId.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.tsx
@@ -418,9 +418,9 @@ export async function action({ request }: ActionFunctionArgs) {
           : { maxPacketAmount: undefined })
       })
 
-      if (!response?.success) {
+      if (!response?.peer) {
         actionResponse.errors.general.message = [
-          response?.message ?? 'Could not update peer. Please try again!'
+          'Could not update peer. Please try again!'
         ]
         return json({ ...actionResponse }, { status: 400 })
       }
@@ -455,9 +455,9 @@ export async function action({ request }: ActionFunctionArgs) {
         }
       })
 
-      if (!response?.success) {
+      if (!response?.peer) {
         actionResponse.errors.general.message = [
-          response?.message ?? 'Could not update peer. Please try again!'
+          'Could not update peer. Please try again!'
         ]
         return json({ ...actionResponse }, { status: 400 })
       }

--- a/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
@@ -68,8 +68,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return setMessageAndRedirect({
       session,
       message: {
-        content:
-          'Could not withdraw peer liquidity. Please try again!',
+        content: 'Could not withdraw peer liquidity. Please try again!',
         type: 'error'
       },
       location: '.'

--- a/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
@@ -64,7 +64,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.id) {
+  if (!response?.success) {
     return setMessageAndRedirect({
       session,
       message: {

--- a/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
@@ -64,12 +64,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.success) {
+  if (!response?.id) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not withdraw peer liquidity. Please try again!',
         type: 'error'
       },
@@ -80,7 +79,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Withdrew peer liquidity',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -264,9 +264,9 @@ export async function action({ request }: ActionFunctionArgs) {
       : { maxPacketAmount: undefined })
   })
 
-  if (!response?.success) {
+  if (!response?.peer) {
     errors.message = [
-      response?.message ?? 'Could not create peer. Please try again!'
+      'Could not create peer. Please try again!'
     ]
     return json({ errors }, { status: 400 })
   }

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -265,9 +265,7 @@ export async function action({ request }: ActionFunctionArgs) {
   })
 
   if (!response?.peer) {
-    errors.message = [
-      'Could not create peer. Please try again!'
-    ]
+    errors.message = ['Could not create peer. Please try again!']
     return json({ errors }, { status: 400 })
   }
 

--- a/packages/frontend/app/routes/wallet-addresses.$walletAddressId.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.$walletAddressId.tsx
@@ -239,8 +239,6 @@ export async function action({ request }: ActionFunctionArgs) {
     ...result.data
   })
 
-  console.log('response=', response)
-
   if (!response?.walletAddress) {
     actionResponse.errors.message = [
       'Could not update the wallet address. Please try again!'

--- a/packages/frontend/app/routes/wallet-addresses.$walletAddressId.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.$walletAddressId.tsx
@@ -239,10 +239,11 @@ export async function action({ request }: ActionFunctionArgs) {
     ...result.data
   })
 
-  if (!response?.success) {
+  console.log('response=', response)
+
+  if (!response?.walletAddress) {
     actionResponse.errors.message = [
-      response?.message ??
-        'Could not update the wallet address. Please try again!'
+      'Could not update the wallet address. Please try again!'
     ]
     return json({ ...actionResponse }, { status: 400 })
   }

--- a/packages/frontend/app/routes/wallet-addresses.$walletAddressId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.$walletAddressId.withdraw-liquidity.tsx
@@ -50,12 +50,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
     timeoutSeconds: BigInt(0)
   })
 
-  if (!response?.success) {
+  if (!response?.withdrawal) {
     return setMessageAndRedirect({
       session,
       message: {
         content:
-          response?.message ??
           'Could not withdraw wallet address liquidity. Please try again!',
         type: 'error'
       },
@@ -66,7 +65,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   return setMessageAndRedirect({
     session,
     message: {
-      content: response.message,
+      content: 'Withdrew wallet address liquidity.',
       type: 'success'
     },
     location: '..'

--- a/packages/frontend/app/routes/wallet-addresses.create.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.create.tsx
@@ -117,9 +117,7 @@ export async function action({ request }: ActionFunctionArgs) {
   })
 
   if (!response?.walletAddress) {
-    errors.message = [
-      'Could not create wallet address. Please try again!'
-    ]
+    errors.message = ['Could not create wallet address. Please try again!']
     return json({ errors }, { status: 400 })
   }
 

--- a/packages/frontend/app/routes/wallet-addresses.create.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.create.tsx
@@ -116,9 +116,9 @@ export async function action({ request }: ActionFunctionArgs) {
     additionalProperties: []
   })
 
-  if (!response?.success) {
+  if (!response?.walletAddress) {
     errors.message = [
-      response?.message ?? 'Could not create wallet address. Please try again!'
+      'Could not create wallet address. Please try again!'
     ]
     return json({ errors }, { status: 400 })
   }

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -573,8 +573,7 @@ export enum LiquidityError {
 
 export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  id: Scalars['ID']['output'];
-  liquidity?: Maybe<Scalars['UInt64']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type Model = {
@@ -1881,8 +1880,7 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -92,12 +92,9 @@ export type AssetEdge = {
   node: Asset;
 };
 
-export type AssetMutationResponse = MutationResponse & {
+export type AssetMutationResponse = {
   __typename?: 'AssetMutationResponse';
   asset?: Maybe<Asset>;
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type AssetsConnection = {
@@ -186,12 +183,9 @@ export type CreateOrUpdatePeerByUrlInput = {
   peerUrl: Scalars['String']['input'];
 };
 
-export type CreateOrUpdatePeerByUrlMutationResponse = MutationResponse & {
+export type CreateOrUpdatePeerByUrlMutationResponse = {
   __typename?: 'CreateOrUpdatePeerByUrlMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateOutgoingPaymentFromIncomingPaymentInput = {
@@ -259,12 +253,9 @@ export type CreatePeerLiquidityWithdrawalInput = {
   timeoutSeconds: Scalars['UInt64']['input'];
 };
 
-export type CreatePeerMutationResponse = MutationResponse & {
+export type CreatePeerMutationResponse = {
   __typename?: 'CreatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateQuoteInput = {
@@ -322,19 +313,13 @@ export type CreateWalletAddressKeyInput = {
   walletAddressId: Scalars['String']['input'];
 };
 
-export type CreateWalletAddressKeyMutationResponse = MutationResponse & {
+export type CreateWalletAddressKeyMutationResponse = {
   __typename?: 'CreateWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
-export type CreateWalletAddressMutationResponse = MutationResponse & {
+export type CreateWalletAddressMutationResponse = {
   __typename?: 'CreateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -360,11 +345,9 @@ export type DeleteAssetInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeleteAssetMutationResponse = MutationResponse & {
+export type DeleteAssetMutationResponse = {
   __typename?: 'DeleteAssetMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  asset?: Maybe<Asset>;
 };
 
 export type DeletePeerInput = {
@@ -373,10 +356,8 @@ export type DeletePeerInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeletePeerMutationResponse = MutationResponse & {
+export type DeletePeerMutationResponse = {
   __typename?: 'DeletePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   success: Scalars['Boolean']['output'];
 };
 
@@ -596,12 +577,10 @@ export enum LiquidityError {
   UnknownWalletAddress = 'UnknownWalletAddress'
 }
 
-export type LiquidityMutationResponse = MutationResponse & {
+export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
 };
 
 export type Model = {
@@ -834,12 +813,6 @@ export type MutationVoidLiquidityWithdrawalArgs = {
 
 export type MutationWithdrawEventLiquidityArgs = {
   input: WithdrawEventLiquidityInput;
-};
-
-export type MutationResponse = {
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type OutgoingPayment = BasePayment & Model & {
@@ -1185,11 +1158,8 @@ export type RevokeWalletAddressKeyInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type RevokeWalletAddressKeyMutationResponse = MutationResponse & {
+export type RevokeWalletAddressKeyMutationResponse = {
   __typename?: 'RevokeWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
@@ -1204,12 +1174,9 @@ export type SetFeeInput = {
   type: FeeType;
 };
 
-export type SetFeeResponse = MutationResponse & {
+export type SetFeeResponse = {
   __typename?: 'SetFeeResponse';
-  code: Scalars['String']['output'];
   fee?: Maybe<Fee>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export enum SortOrder {
@@ -1219,13 +1186,6 @@ export enum SortOrder {
   Desc = 'DESC'
 }
 
-export type TransferMutationResponse = MutationResponse & {
-  __typename?: 'TransferMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 export type TriggerWalletAddressEventsInput = {
   /** Unique key to ensure duplicate or retried requests are processed only once. See [idempotence](https://en.wikipedia.org/wiki/Idempotence) */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1233,13 +1193,10 @@ export type TriggerWalletAddressEventsInput = {
   limit: Scalars['Int']['input'];
 };
 
-export type TriggerWalletAddressEventsMutationResponse = MutationResponse & {
+export type TriggerWalletAddressEventsMutationResponse = {
   __typename?: 'TriggerWalletAddressEventsMutationResponse';
-  code: Scalars['String']['output'];
   /** Number of events triggered */
   count?: Maybe<Scalars['Int']['output']>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateAssetInput = {
@@ -1270,12 +1227,9 @@ export type UpdatePeerInput = {
   staticIlpAddress?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdatePeerMutationResponse = MutationResponse & {
+export type UpdatePeerMutationResponse = {
   __typename?: 'UpdatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateWalletAddressInput = {
@@ -1291,11 +1245,8 @@ export type UpdateWalletAddressInput = {
   status?: InputMaybe<WalletAddressStatus>;
 };
 
-export type UpdateWalletAddressMutationResponse = MutationResponse & {
+export type UpdateWalletAddressMutationResponse = {
   __typename?: 'UpdateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -1419,12 +1370,8 @@ export type WalletAddressWithdrawal = {
   walletAddress: WalletAddress;
 };
 
-export type WalletAddressWithdrawalMutationResponse = MutationResponse & {
+export type WalletAddressWithdrawalMutationResponse = {
   __typename?: 'WalletAddressWithdrawalMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   withdrawal?: Maybe<WalletAddressWithdrawal>;
 };
 
@@ -1541,7 +1488,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
-  MutationResponse: ( Partial<AssetMutationResponse> ) | ( Partial<CreateOrUpdatePeerByUrlMutationResponse> ) | ( Partial<CreatePeerMutationResponse> ) | ( Partial<CreateWalletAddressKeyMutationResponse> ) | ( Partial<CreateWalletAddressMutationResponse> ) | ( Partial<DeleteAssetMutationResponse> ) | ( Partial<DeletePeerMutationResponse> ) | ( Partial<LiquidityMutationResponse> ) | ( Partial<RevokeWalletAddressKeyMutationResponse> ) | ( Partial<SetFeeResponse> ) | ( Partial<TransferMutationResponse> ) | ( Partial<TriggerWalletAddressEventsMutationResponse> ) | ( Partial<UpdatePeerMutationResponse> ) | ( Partial<UpdateWalletAddressMutationResponse> ) | ( Partial<WalletAddressWithdrawalMutationResponse> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1614,7 +1560,6 @@ export type ResolversTypes = {
   LiquidityMutationResponse: ResolverTypeWrapper<Partial<LiquidityMutationResponse>>;
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
-  MutationResponse: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['MutationResponse']>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
@@ -1642,7 +1587,6 @@ export type ResolversTypes = {
   SetFeeResponse: ResolverTypeWrapper<Partial<SetFeeResponse>>;
   SortOrder: ResolverTypeWrapper<Partial<SortOrder>>;
   String: ResolverTypeWrapper<Partial<Scalars['String']['output']>>;
-  TransferMutationResponse: ResolverTypeWrapper<Partial<TransferMutationResponse>>;
   TriggerWalletAddressEventsInput: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsInput>>;
   TriggerWalletAddressEventsMutationResponse: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsMutationResponse>>;
   UInt8: ResolverTypeWrapper<Partial<Scalars['UInt8']['output']>>;
@@ -1733,7 +1677,6 @@ export type ResolversParentTypes = {
   LiquidityMutationResponse: Partial<LiquidityMutationResponse>;
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
-  MutationResponse: ResolversInterfaceTypes<ResolversParentTypes>['MutationResponse'];
   OutgoingPayment: Partial<OutgoingPayment>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
@@ -1758,7 +1701,6 @@ export type ResolversParentTypes = {
   SetFeeInput: Partial<SetFeeInput>;
   SetFeeResponse: Partial<SetFeeResponse>;
   String: Partial<Scalars['String']['output']>;
-  TransferMutationResponse: Partial<TransferMutationResponse>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
   UInt8: Partial<Scalars['UInt8']['output']>;
@@ -1820,9 +1762,6 @@ export type AssetEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type AssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AssetMutationResponse'] = ResolversParentTypes['AssetMutationResponse']> = {
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1842,18 +1781,12 @@ export type BasePaymentResolvers<ContextType = any, ParentType extends Resolvers
 };
 
 export type CreateOrUpdatePeerByUrlMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse'] = ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreatePeerMutationResponse'] = ResolversParentTypes['CreatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1866,31 +1799,21 @@ export type CreateReceiverResponseResolvers<ContextType = any, ParentType extend
 };
 
 export type CreateWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressKeyMutationResponse'] = ResolversParentTypes['CreateWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressMutationResponse'] = ResolversParentTypes['CreateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeleteAssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteAssetMutationResponse'] = ResolversParentTypes['DeleteAssetMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeletePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeletePeerMutationResponse'] = ResolversParentTypes['DeletePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1976,10 +1899,8 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2021,13 +1942,6 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateWalletAddress?: Resolver<ResolversTypes['UpdateWalletAddressMutationResponse'], ParentType, ContextType, RequireFields<MutationUpdateWalletAddressArgs, 'input'>>;
   voidLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationVoidLiquidityWithdrawalArgs, 'input'>>;
   withdrawEventLiquidity?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationWithdrawEventLiquidityArgs, 'input'>>;
-};
-
-export type MutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutationResponse'] = ResolversParentTypes['MutationResponse']> = {
-  __resolveType: TypeResolveFn<'AssetMutationResponse' | 'CreateOrUpdatePeerByUrlMutationResponse' | 'CreatePeerMutationResponse' | 'CreateWalletAddressKeyMutationResponse' | 'CreateWalletAddressMutationResponse' | 'DeleteAssetMutationResponse' | 'DeletePeerMutationResponse' | 'LiquidityMutationResponse' | 'RevokeWalletAddressKeyMutationResponse' | 'SetFeeResponse' | 'TransferMutationResponse' | 'TriggerWalletAddressEventsMutationResponse' | 'UpdatePeerMutationResponse' | 'UpdateWalletAddressMutationResponse' | 'WalletAddressWithdrawalMutationResponse', ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
@@ -2189,33 +2103,17 @@ export type ReceiverResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type RevokeWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['RevokeWalletAddressKeyMutationResponse'] = ResolversParentTypes['RevokeWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SetFeeResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetFeeResponse'] = ResolversParentTypes['SetFeeResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   fee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TransferMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransferMutationResponse'] = ResolversParentTypes['TransferMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type TriggerWalletAddressEventsMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TriggerWalletAddressEventsMutationResponse'] = ResolversParentTypes['TriggerWalletAddressEventsMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2228,17 +2126,11 @@ export interface UInt64ScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 }
 
 export type UpdatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdatePeerMutationResponse'] = ResolversParentTypes['UpdatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateWalletAddressMutationResponse'] = ResolversParentTypes['UpdateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2294,10 +2186,6 @@ export type WalletAddressWithdrawalResolvers<ContextType = any, ParentType exten
 };
 
 export type WalletAddressWithdrawalMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddressWithdrawalMutationResponse'] = ResolversParentTypes['WalletAddressWithdrawalMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   withdrawal?: Resolver<Maybe<ResolversTypes['WalletAddressWithdrawal']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2357,7 +2245,6 @@ export type Resolvers<ContextType = any> = {
   LiquidityMutationResponse?: LiquidityMutationResponseResolvers<ContextType>;
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
-  MutationResponse?: MutationResponseResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
@@ -2377,7 +2264,6 @@ export type Resolvers<ContextType = any> = {
   Receiver?: ReceiverResolvers<ContextType>;
   RevokeWalletAddressKeyMutationResponse?: RevokeWalletAddressKeyMutationResponseResolvers<ContextType>;
   SetFeeResponse?: SetFeeResponseResolvers<ContextType>;
-  TransferMutationResponse?: TransferMutationResponseResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;
   UInt64?: GraphQLScalarType;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -286,10 +286,7 @@ export type CreateReceiverInput = {
 
 export type CreateReceiverResponse = {
   __typename?: 'CreateReceiverResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   receiver?: Maybe<Receiver>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateWalletAddressInput = {
@@ -514,10 +511,7 @@ export type IncomingPaymentEdge = {
 
 export type IncomingPaymentResponse = {
   __typename?: 'IncomingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<IncomingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum IncomingPaymentState {
@@ -859,10 +853,7 @@ export type OutgoingPaymentEdge = {
 
 export type OutgoingPaymentResponse = {
   __typename?: 'OutgoingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<OutgoingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum OutgoingPaymentState {
@@ -1123,10 +1114,7 @@ export type QuoteEdge = {
 
 export type QuoteResponse = {
   __typename?: 'QuoteResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   quote?: Maybe<Quote>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type Receiver = {
@@ -1791,10 +1779,7 @@ export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType ex
 };
 
 export type CreateReceiverResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateReceiverResponse'] = ResolversParentTypes['CreateReceiverResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receiver?: Resolver<Maybe<ResolversTypes['Receiver']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1878,10 +1863,7 @@ export type IncomingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type IncomingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['IncomingPaymentResponse'] = ResolversParentTypes['IncomingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1975,10 +1957,7 @@ export type OutgoingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type OutgoingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentResponse'] = ResolversParentTypes['OutgoingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['OutgoingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2082,10 +2061,7 @@ export type QuoteEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 };
 
 export type QuoteResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['QuoteResponse'] = ResolversParentTypes['QuoteResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/mock-account-service-lib/src/requesters.ts
+++ b/packages/mock-account-service-lib/src/requesters.ts
@@ -117,9 +117,6 @@ export async function createAsset(
   const createAssetMutation = gql`
     mutation CreateAsset($input: CreateAssetInput!) {
       createAsset(input: $input) {
-        code
-        success
-        message
         asset {
           id
           code
@@ -142,7 +139,7 @@ export async function createAsset(
       variables: createAssetInput
     })
     .then(({ data }): AssetMutationResponse => {
-      if (!data.createAsset.success) {
+      if (!data.createAsset.asset) {
         throw new Error('Data was empty')
       }
       return data.createAsset
@@ -162,9 +159,6 @@ export async function createPeer(
   const createPeerMutation = gql`
     mutation CreatePeer($input: CreatePeerInput!) {
       createPeer(input: $input) {
-        code
-        success
-        message
         peer {
           id
         }
@@ -190,7 +184,7 @@ export async function createPeer(
     })
     .then(({ data }): CreatePeerMutationResponse => {
       logger.debug(data)
-      if (!data.createPeer.success) {
+      if (!data.createPeer.peer) {
         throw new Error('Data was empty')
       }
       return data.createPeer
@@ -206,9 +200,6 @@ export async function createAutoPeer(
   const createAutoPeerMutation = gql`
     mutation CreateOrUpdatePeerByUrl($input: CreateOrUpdatePeerByUrlInput!) {
       createOrUpdatePeerByUrl(input: $input) {
-        code
-        success
-        message
         peer {
           id
           name
@@ -237,7 +228,7 @@ export async function createAutoPeer(
       variables: createPeerInput
     })
     .then(({ data }): CreateOrUpdatePeerByUrlMutationResponse => {
-      if (!data.createOrUpdatePeerByUrl.success) {
+      if (!data.createOrUpdatePeerByUrl.peer) {
         logger.debug(data.createOrUpdatePeerByUrl)
         throw new Error(`Data was empty for assetId: ${assetId}`)
       }
@@ -255,10 +246,8 @@ export async function depositPeerLiquidity(
   const depositPeerLiquidityMutation = gql`
     mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
       depositPeerLiquidity(input: $input) {
-        code
-        success
-        message
-        error
+        id
+        liquidity
       }
     }
   `
@@ -277,7 +266,7 @@ export async function depositPeerLiquidity(
     })
     .then(({ data }): LiquidityMutationResponse => {
       logger.debug(data)
-      if (!data.depositPeerLiquidity.success) {
+      if (!data.depositPeerLiquidity) {
         throw new Error('Data was empty')
       }
       return data.depositPeerLiquidity
@@ -294,10 +283,8 @@ export async function depositAssetLiquidity(
   const depositAssetLiquidityMutation = gql`
     mutation DepositAssetLiquidity($input: DepositAssetLiquidityInput!) {
       depositAssetLiquidity(input: $input) {
-        code
-        success
-        message
-        error
+        id
+        liquidity
       }
     }
   `
@@ -316,7 +303,7 @@ export async function depositAssetLiquidity(
     })
     .then(({ data }): LiquidityMutationResponse => {
       logger.debug(data)
-      if (!data.depositAssetLiquidity.success) {
+      if (!data.depositAssetLiquidity) {
         throw new Error('Data was empty')
       }
       return data.depositAssetLiquidity
@@ -333,9 +320,6 @@ export async function createWalletAddress(
   const createWalletAddressMutation = gql`
     mutation CreateWalletAddress($input: CreateWalletAddressInput!) {
       createWalletAddress(input: $input) {
-        code
-        success
-        message
         walletAddress {
           id
           url
@@ -361,10 +345,7 @@ export async function createWalletAddress(
     .then(({ data }) => {
       logger.debug(data)
 
-      if (
-        !data.createWalletAddress.success ||
-        !data.createWalletAddress.walletAddress
-      ) {
+      if (!data.createWalletAddress.walletAddress) {
         throw new Error('Data was empty')
       }
 
@@ -386,9 +367,9 @@ export async function createWalletAddressKey(
   const createWalletAddressKeyMutation = gql`
     mutation CreateWalletAddressKey($input: CreateWalletAddressKeyInput!) {
       createWalletAddressKey(input: $input) {
-        code
-        success
-        message
+        walletAddressKey {
+          id
+        }
       }
     }
   `
@@ -406,7 +387,7 @@ export async function createWalletAddressKey(
     })
     .then(({ data }): CreateWalletAddressKeyMutationResponse => {
       logger.debug(data)
-      if (!data.createWalletAddressKey.success) {
+      if (!data.createWalletAddressKey.walletAddressKey) {
         throw new Error('Data was empty')
       }
       return data.createWalletAddressKey
@@ -424,9 +405,6 @@ export async function setFee(
   const setFeeMutation = gql`
     mutation SetFee($input: SetFeeInput!) {
       setFee(input: $input) {
-        code
-        success
-        message
         fee {
           id
           assetId

--- a/packages/mock-account-service-lib/src/requesters.ts
+++ b/packages/mock-account-service-lib/src/requesters.ts
@@ -246,8 +246,7 @@ export async function depositPeerLiquidity(
   const depositPeerLiquidityMutation = gql`
     mutation DepositPeerLiquidity($input: DepositPeerLiquidityInput!) {
       depositPeerLiquidity(input: $input) {
-        id
-        liquidity
+        success
       }
     }
   `
@@ -283,8 +282,7 @@ export async function depositAssetLiquidity(
   const depositAssetLiquidityMutation = gql`
     mutation DepositAssetLiquidity($input: DepositAssetLiquidityInput!) {
       depositAssetLiquidity(input: $input) {
-        id
-        liquidity
+        success
       }
     }
   `

--- a/packages/mock-account-service-lib/src/seed.ts
+++ b/packages/mock-account-service-lib/src/seed.ts
@@ -48,14 +48,10 @@ export async function setupFromSeed(
       throw new Error('asset not defined')
     }
 
-    const initialLiquidity = await depositAssetLiquidity(
-      asset.id,
-      liquidity,
-      v4()
-    )
+    await depositAssetLiquidity(asset.id, liquidity, v4())
 
     assets[code] = asset
-    logger.debug({ asset, initialLiquidity })
+    logger.debug({ asset, liquidity })
 
     const { fees } = config.seed
     const fee = fees.find((fee) => fee.asset === code && fee.scale == scale)
@@ -80,12 +76,12 @@ export async function setupFromSeed(
         throw new Error('peer response not defined')
       }
       const transferUid = v4()
-      const liquidity = await depositPeerLiquidity(
+      await depositPeerLiquidity(
         peerResponse.id,
         peer.initialLiquidity,
         transferUid
       )
-      return [peerResponse, liquidity]
+      return [peerResponse, peer.initialLiquidity]
     })
   )
 

--- a/test/integration/lib/admin-client.ts
+++ b/test/integration/lib/admin-client.ts
@@ -223,8 +223,7 @@ export class AdminClient {
             $input: DepositOutgoingPaymentLiquidityInput!
           ) {
             depositOutgoingPaymentLiquidity(input: $input) {
-              id
-              liquidity
+              success
             }
           }
         `,

--- a/test/integration/lib/admin-client.ts
+++ b/test/integration/lib/admin-client.ts
@@ -30,8 +30,6 @@ export class AdminClient {
         mutation: gql`
           mutation CreateReceiver($input: CreateReceiverInput!) {
             createReceiver(input: $input) {
-              code
-              message
               receiver {
                 completed
                 createdAt
@@ -51,7 +49,6 @@ export class AdminClient {
                 }
                 updatedAt
               }
-              success
             }
           }
         `,
@@ -68,8 +65,6 @@ export class AdminClient {
         mutation: gql`
           mutation CreateQuote($input: CreateQuoteInput!) {
             createQuote(input: $input) {
-              code
-              message
               quote {
                 createdAt
                 expiresAt
@@ -109,8 +104,6 @@ export class AdminClient {
         mutation: gql`
           mutation CreateOutgoingPayment($input: CreateOutgoingPaymentInput!) {
             createOutgoingPayment(input: $input) {
-              code
-              message
               payment {
                 createdAt
                 error
@@ -136,7 +129,6 @@ export class AdminClient {
                 state
                 stateAttempts
               }
-              success
             }
           }
         `,
@@ -231,10 +223,8 @@ export class AdminClient {
             $input: DepositOutgoingPaymentLiquidityInput!
           ) {
             depositOutgoingPaymentLiquidity(input: $input) {
-              code
-              success
-              message
-              error
+              id
+              liquidity
             }
           }
         `,
@@ -253,7 +243,6 @@ export class AdminClient {
         mutation: gql`
           mutation CreateWalletAddress($input: CreateWalletAddressInput!) {
             createWalletAddress(input: $input) {
-              success
               walletAddress {
                 id
                 url

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -573,8 +573,7 @@ export enum LiquidityError {
 
 export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  id: Scalars['ID']['output'];
-  liquidity?: Maybe<Scalars['UInt64']['output']>;
+  success: Scalars['Boolean']['output'];
 };
 
 export type Model = {
@@ -1881,8 +1880,7 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
+  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -92,12 +92,9 @@ export type AssetEdge = {
   node: Asset;
 };
 
-export type AssetMutationResponse = MutationResponse & {
+export type AssetMutationResponse = {
   __typename?: 'AssetMutationResponse';
   asset?: Maybe<Asset>;
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type AssetsConnection = {
@@ -186,12 +183,9 @@ export type CreateOrUpdatePeerByUrlInput = {
   peerUrl: Scalars['String']['input'];
 };
 
-export type CreateOrUpdatePeerByUrlMutationResponse = MutationResponse & {
+export type CreateOrUpdatePeerByUrlMutationResponse = {
   __typename?: 'CreateOrUpdatePeerByUrlMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateOutgoingPaymentFromIncomingPaymentInput = {
@@ -259,12 +253,9 @@ export type CreatePeerLiquidityWithdrawalInput = {
   timeoutSeconds: Scalars['UInt64']['input'];
 };
 
-export type CreatePeerMutationResponse = MutationResponse & {
+export type CreatePeerMutationResponse = {
   __typename?: 'CreatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateQuoteInput = {
@@ -322,19 +313,13 @@ export type CreateWalletAddressKeyInput = {
   walletAddressId: Scalars['String']['input'];
 };
 
-export type CreateWalletAddressKeyMutationResponse = MutationResponse & {
+export type CreateWalletAddressKeyMutationResponse = {
   __typename?: 'CreateWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
-export type CreateWalletAddressMutationResponse = MutationResponse & {
+export type CreateWalletAddressMutationResponse = {
   __typename?: 'CreateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -360,11 +345,9 @@ export type DeleteAssetInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeleteAssetMutationResponse = MutationResponse & {
+export type DeleteAssetMutationResponse = {
   __typename?: 'DeleteAssetMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  asset?: Maybe<Asset>;
 };
 
 export type DeletePeerInput = {
@@ -373,10 +356,8 @@ export type DeletePeerInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type DeletePeerMutationResponse = MutationResponse & {
+export type DeletePeerMutationResponse = {
   __typename?: 'DeletePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   success: Scalars['Boolean']['output'];
 };
 
@@ -596,12 +577,10 @@ export enum LiquidityError {
   UnknownWalletAddress = 'UnknownWalletAddress'
 }
 
-export type LiquidityMutationResponse = MutationResponse & {
+export type LiquidityMutationResponse = {
   __typename?: 'LiquidityMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  liquidity?: Maybe<Scalars['UInt64']['output']>;
 };
 
 export type Model = {
@@ -834,12 +813,6 @@ export type MutationVoidLiquidityWithdrawalArgs = {
 
 export type MutationWithdrawEventLiquidityArgs = {
   input: WithdrawEventLiquidityInput;
-};
-
-export type MutationResponse = {
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type OutgoingPayment = BasePayment & Model & {
@@ -1185,11 +1158,8 @@ export type RevokeWalletAddressKeyInput = {
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type RevokeWalletAddressKeyMutationResponse = MutationResponse & {
+export type RevokeWalletAddressKeyMutationResponse = {
   __typename?: 'RevokeWalletAddressKeyMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddressKey?: Maybe<WalletAddressKey>;
 };
 
@@ -1204,12 +1174,9 @@ export type SetFeeInput = {
   type: FeeType;
 };
 
-export type SetFeeResponse = MutationResponse & {
+export type SetFeeResponse = {
   __typename?: 'SetFeeResponse';
-  code: Scalars['String']['output'];
   fee?: Maybe<Fee>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export enum SortOrder {
@@ -1219,13 +1186,6 @@ export enum SortOrder {
   Desc = 'DESC'
 }
 
-export type TransferMutationResponse = MutationResponse & {
-  __typename?: 'TransferMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
-};
-
 export type TriggerWalletAddressEventsInput = {
   /** Unique key to ensure duplicate or retried requests are processed only once. See [idempotence](https://en.wikipedia.org/wiki/Idempotence) */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1233,13 +1193,10 @@ export type TriggerWalletAddressEventsInput = {
   limit: Scalars['Int']['input'];
 };
 
-export type TriggerWalletAddressEventsMutationResponse = MutationResponse & {
+export type TriggerWalletAddressEventsMutationResponse = {
   __typename?: 'TriggerWalletAddressEventsMutationResponse';
-  code: Scalars['String']['output'];
   /** Number of events triggered */
   count?: Maybe<Scalars['Int']['output']>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateAssetInput = {
@@ -1270,12 +1227,9 @@ export type UpdatePeerInput = {
   staticIlpAddress?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type UpdatePeerMutationResponse = MutationResponse & {
+export type UpdatePeerMutationResponse = {
   __typename?: 'UpdatePeerMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
   peer?: Maybe<Peer>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type UpdateWalletAddressInput = {
@@ -1291,11 +1245,8 @@ export type UpdateWalletAddressInput = {
   status?: InputMaybe<WalletAddressStatus>;
 };
 
-export type UpdateWalletAddressMutationResponse = MutationResponse & {
+export type UpdateWalletAddressMutationResponse = {
   __typename?: 'UpdateWalletAddressMutationResponse';
-  code: Scalars['String']['output'];
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   walletAddress?: Maybe<WalletAddress>;
 };
 
@@ -1419,12 +1370,8 @@ export type WalletAddressWithdrawal = {
   walletAddress: WalletAddress;
 };
 
-export type WalletAddressWithdrawalMutationResponse = MutationResponse & {
+export type WalletAddressWithdrawalMutationResponse = {
   __typename?: 'WalletAddressWithdrawalMutationResponse';
-  code: Scalars['String']['output'];
-  error?: Maybe<LiquidityError>;
-  message: Scalars['String']['output'];
-  success: Scalars['Boolean']['output'];
   withdrawal?: Maybe<WalletAddressWithdrawal>;
 };
 
@@ -1541,7 +1488,6 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
-  MutationResponse: ( Partial<AssetMutationResponse> ) | ( Partial<CreateOrUpdatePeerByUrlMutationResponse> ) | ( Partial<CreatePeerMutationResponse> ) | ( Partial<CreateWalletAddressKeyMutationResponse> ) | ( Partial<CreateWalletAddressMutationResponse> ) | ( Partial<DeleteAssetMutationResponse> ) | ( Partial<DeletePeerMutationResponse> ) | ( Partial<LiquidityMutationResponse> ) | ( Partial<RevokeWalletAddressKeyMutationResponse> ) | ( Partial<SetFeeResponse> ) | ( Partial<TransferMutationResponse> ) | ( Partial<TriggerWalletAddressEventsMutationResponse> ) | ( Partial<UpdatePeerMutationResponse> ) | ( Partial<UpdateWalletAddressMutationResponse> ) | ( Partial<WalletAddressWithdrawalMutationResponse> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1614,7 +1560,6 @@ export type ResolversTypes = {
   LiquidityMutationResponse: ResolverTypeWrapper<Partial<LiquidityMutationResponse>>;
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
-  MutationResponse: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['MutationResponse']>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
@@ -1642,7 +1587,6 @@ export type ResolversTypes = {
   SetFeeResponse: ResolverTypeWrapper<Partial<SetFeeResponse>>;
   SortOrder: ResolverTypeWrapper<Partial<SortOrder>>;
   String: ResolverTypeWrapper<Partial<Scalars['String']['output']>>;
-  TransferMutationResponse: ResolverTypeWrapper<Partial<TransferMutationResponse>>;
   TriggerWalletAddressEventsInput: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsInput>>;
   TriggerWalletAddressEventsMutationResponse: ResolverTypeWrapper<Partial<TriggerWalletAddressEventsMutationResponse>>;
   UInt8: ResolverTypeWrapper<Partial<Scalars['UInt8']['output']>>;
@@ -1733,7 +1677,6 @@ export type ResolversParentTypes = {
   LiquidityMutationResponse: Partial<LiquidityMutationResponse>;
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
-  MutationResponse: ResolversInterfaceTypes<ResolversParentTypes>['MutationResponse'];
   OutgoingPayment: Partial<OutgoingPayment>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
@@ -1758,7 +1701,6 @@ export type ResolversParentTypes = {
   SetFeeInput: Partial<SetFeeInput>;
   SetFeeResponse: Partial<SetFeeResponse>;
   String: Partial<Scalars['String']['output']>;
-  TransferMutationResponse: Partial<TransferMutationResponse>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
   UInt8: Partial<Scalars['UInt8']['output']>;
@@ -1820,9 +1762,6 @@ export type AssetEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type AssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['AssetMutationResponse'] = ResolversParentTypes['AssetMutationResponse']> = {
   asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1842,18 +1781,12 @@ export type BasePaymentResolvers<ContextType = any, ParentType extends Resolvers
 };
 
 export type CreateOrUpdatePeerByUrlMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse'] = ResolversParentTypes['CreateOrUpdatePeerByUrlMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreatePeerMutationResponse'] = ResolversParentTypes['CreatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1866,31 +1799,21 @@ export type CreateReceiverResponseResolvers<ContextType = any, ParentType extend
 };
 
 export type CreateWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressKeyMutationResponse'] = ResolversParentTypes['CreateWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type CreateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateWalletAddressMutationResponse'] = ResolversParentTypes['CreateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeleteAssetMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeleteAssetMutationResponse'] = ResolversParentTypes['DeleteAssetMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  asset?: Resolver<Maybe<ResolversTypes['Asset']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type DeletePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['DeletePeerMutationResponse'] = ResolversParentTypes['DeletePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1976,10 +1899,8 @@ export type JwkResolvers<ContextType = any, ParentType extends ResolversParentTy
 };
 
 export type LiquidityMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['LiquidityMutationResponse'] = ResolversParentTypes['LiquidityMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  liquidity?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2021,13 +1942,6 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateWalletAddress?: Resolver<ResolversTypes['UpdateWalletAddressMutationResponse'], ParentType, ContextType, RequireFields<MutationUpdateWalletAddressArgs, 'input'>>;
   voidLiquidityWithdrawal?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationVoidLiquidityWithdrawalArgs, 'input'>>;
   withdrawEventLiquidity?: Resolver<Maybe<ResolversTypes['LiquidityMutationResponse']>, ParentType, ContextType, RequireFields<MutationWithdrawEventLiquidityArgs, 'input'>>;
-};
-
-export type MutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutationResponse'] = ResolversParentTypes['MutationResponse']> = {
-  __resolveType: TypeResolveFn<'AssetMutationResponse' | 'CreateOrUpdatePeerByUrlMutationResponse' | 'CreatePeerMutationResponse' | 'CreateWalletAddressKeyMutationResponse' | 'CreateWalletAddressMutationResponse' | 'DeleteAssetMutationResponse' | 'DeletePeerMutationResponse' | 'LiquidityMutationResponse' | 'RevokeWalletAddressKeyMutationResponse' | 'SetFeeResponse' | 'TransferMutationResponse' | 'TriggerWalletAddressEventsMutationResponse' | 'UpdatePeerMutationResponse' | 'UpdateWalletAddressMutationResponse' | 'WalletAddressWithdrawalMutationResponse', ParentType, ContextType>;
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
@@ -2189,33 +2103,17 @@ export type ReceiverResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type RevokeWalletAddressKeyMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['RevokeWalletAddressKeyMutationResponse'] = ResolversParentTypes['RevokeWalletAddressKeyMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddressKey?: Resolver<Maybe<ResolversTypes['WalletAddressKey']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SetFeeResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetFeeResponse'] = ResolversParentTypes['SetFeeResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   fee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TransferMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransferMutationResponse'] = ResolversParentTypes['TransferMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type TriggerWalletAddressEventsMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['TriggerWalletAddressEventsMutationResponse'] = ResolversParentTypes['TriggerWalletAddressEventsMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2228,17 +2126,11 @@ export interface UInt64ScalarConfig extends GraphQLScalarTypeConfig<ResolversTyp
 }
 
 export type UpdatePeerMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdatePeerMutationResponse'] = ResolversParentTypes['UpdatePeerMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   peer?: Resolver<Maybe<ResolversTypes['Peer']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['UpdateWalletAddressMutationResponse'] = ResolversParentTypes['UpdateWalletAddressMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   walletAddress?: Resolver<Maybe<ResolversTypes['WalletAddress']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2294,10 +2186,6 @@ export type WalletAddressWithdrawalResolvers<ContextType = any, ParentType exten
 };
 
 export type WalletAddressWithdrawalMutationResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddressWithdrawalMutationResponse'] = ResolversParentTypes['WalletAddressWithdrawalMutationResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  error?: Resolver<Maybe<ResolversTypes['LiquidityError']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   withdrawal?: Resolver<Maybe<ResolversTypes['WalletAddressWithdrawal']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2357,7 +2245,6 @@ export type Resolvers<ContextType = any> = {
   LiquidityMutationResponse?: LiquidityMutationResponseResolvers<ContextType>;
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
-  MutationResponse?: MutationResponseResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
@@ -2377,7 +2264,6 @@ export type Resolvers<ContextType = any> = {
   Receiver?: ReceiverResolvers<ContextType>;
   RevokeWalletAddressKeyMutationResponse?: RevokeWalletAddressKeyMutationResponseResolvers<ContextType>;
   SetFeeResponse?: SetFeeResponseResolvers<ContextType>;
-  TransferMutationResponse?: TransferMutationResponseResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;
   UInt64?: GraphQLScalarType;

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -286,10 +286,7 @@ export type CreateReceiverInput = {
 
 export type CreateReceiverResponse = {
   __typename?: 'CreateReceiverResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   receiver?: Maybe<Receiver>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type CreateWalletAddressInput = {
@@ -514,10 +511,7 @@ export type IncomingPaymentEdge = {
 
 export type IncomingPaymentResponse = {
   __typename?: 'IncomingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<IncomingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum IncomingPaymentState {
@@ -859,10 +853,7 @@ export type OutgoingPaymentEdge = {
 
 export type OutgoingPaymentResponse = {
   __typename?: 'OutgoingPaymentResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   payment?: Maybe<OutgoingPayment>;
-  success: Scalars['Boolean']['output'];
 };
 
 export enum OutgoingPaymentState {
@@ -1123,10 +1114,7 @@ export type QuoteEdge = {
 
 export type QuoteResponse = {
   __typename?: 'QuoteResponse';
-  code: Scalars['String']['output'];
-  message?: Maybe<Scalars['String']['output']>;
   quote?: Maybe<Quote>;
-  success: Scalars['Boolean']['output'];
 };
 
 export type Receiver = {
@@ -1791,10 +1779,7 @@ export type CreatePeerMutationResponseResolvers<ContextType = any, ParentType ex
 };
 
 export type CreateReceiverResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CreateReceiverResponse'] = ResolversParentTypes['CreateReceiverResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receiver?: Resolver<Maybe<ResolversTypes['Receiver']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1878,10 +1863,7 @@ export type IncomingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type IncomingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['IncomingPaymentResponse'] = ResolversParentTypes['IncomingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['IncomingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1975,10 +1957,7 @@ export type OutgoingPaymentEdgeResolvers<ContextType = any, ParentType extends R
 };
 
 export type OutgoingPaymentResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentResponse'] = ResolversParentTypes['OutgoingPaymentResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   payment?: Resolver<Maybe<ResolversTypes['OutgoingPayment']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2082,10 +2061,7 @@ export type QuoteEdgeResolvers<ContextType = any, ParentType extends ResolversPa
 };
 
 export type QuoteResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['QuoteResponse'] = ResolversParentTypes['QuoteResponse']> = {
-  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   quote?: Resolver<Maybe<ResolversTypes['Quote']>, ParentType, ContextType>;
-  success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/test/integration/lib/integration-server.ts
+++ b/test/integration/lib/integration-server.ts
@@ -134,9 +134,6 @@ export class WebhookEventHandler {
     })
     const { walletAddress } = response
 
-    if (!response.walletAddress) {
-      throw new Error('Failed to create wallet address')
-    }
     if (!walletAddress) {
       throw new Error('Could not get wallet address')
     }

--- a/test/integration/lib/integration-server.ts
+++ b/test/integration/lib/integration-server.ts
@@ -134,7 +134,7 @@ export class WebhookEventHandler {
     })
     const { walletAddress } = response
 
-    if (!response.success) {
+    if (!response.walletAddress) {
       throw new Error('Failed to create wallet address')
     }
     if (!walletAddress) {
@@ -175,7 +175,7 @@ export class WebhookEventHandler {
       idempotencyKey: crypto.randomUUID()
     })
 
-    if (response.code !== '200') {
+    if (!response.id) {
       const msg = 'Deposit outgoing payment liquidity failed'
       throw new Error(msg)
     }

--- a/test/integration/lib/integration-server.ts
+++ b/test/integration/lib/integration-server.ts
@@ -175,7 +175,7 @@ export class WebhookEventHandler {
       idempotencyKey: crypto.randomUUID()
     })
 
-    if (!response.id) {
+    if (!response.success) {
       const msg = 'Deposit outgoing payment liquidity failed'
       throw new Error(msg)
     }

--- a/test/integration/lib/test-actions/admin.ts
+++ b/test/integration/lib/test-actions/admin.ts
@@ -57,7 +57,6 @@ async function createReceiver(
   const response =
     await sendingASE.adminClient.createReceiver(createReceiverInput)
 
-  expect(response.code).toBe('200')
   assert(response.receiver)
 
   await pollCondition(
@@ -90,7 +89,6 @@ async function createQuote(
     receiver: receiver.id
   })
 
-  expect(response.code).toBe('200')
   assert(response.quote)
 
   return response.quote
@@ -111,7 +109,6 @@ async function createOutgoingPayment(
     quoteId: quote.id
   })
 
-  expect(response.code).toBe('201')
   assert(response.payment)
 
   await pollCondition(


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Refactored `backend` GraphQL responses to no longer use `code`, `message`, or `success`. If a response is not successful, it will now throw a GraphQL error instead of returning a `success: false` and `code: 4XX/5XX` response.
- Adds a logging plugin to the Apollo Server that will log if a resolver throws a GraphQL Error.
- Updated `frontend` package and local MASE to use the new backend GraphQL response models.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #2575.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [x] Bruno collection updated
