### PR TITLE
fix: fix incorrect loading of admin ui settings page

### DIFF
--- a/packages/frontend/app/routes/auth.login.tsx
+++ b/packages/frontend/app/routes/auth.login.tsx
@@ -1,4 +1,8 @@
-import { json, type LoaderFunctionArgs, redirectDocument, } from '@remix-run/node'
+import {
+  json,
+  type LoaderFunctionArgs,
+  redirectDocument
+} from '@remix-run/node'
 import { uuidSchema } from '~/lib/validate.server'
 import { isUiNodeInputAttributes } from '@ory/integrations/ui'
 import type { UiContainer } from '@ory/client'

--- a/packages/frontend/app/routes/auth.login.tsx
+++ b/packages/frontend/app/routes/auth.login.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs } from '@remix-run/node'
+import { json, type LoaderFunctionArgs, redirectDocument, } from '@remix-run/node'
 import { uuidSchema } from '~/lib/validate.server'
 import { isUiNodeInputAttributes } from '@ory/integrations/ui'
 import type { UiContainer } from '@ory/client'
@@ -34,10 +34,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const recoveryUrl = `${variables.kratosBrowserPublicUrl}/self-service/recovery/browser`
     return { responseData, recoveryUrl }
   } else {
-    throw json(null, {
-      status: 400,
-      statusText: 'No Kratos login flow ID found.'
-    })
+    return redirectDocument(
+      `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
+    )
   }
 }
 

--- a/packages/frontend/app/routes/auth.recovery.tsx
+++ b/packages/frontend/app/routes/auth.recovery.tsx
@@ -1,4 +1,8 @@
-import { json, type LoaderFunctionArgs, redirectDocument } from '@remix-run/node'
+import {
+  json,
+  type LoaderFunctionArgs,
+  redirectDocument
+} from '@remix-run/node'
 import { uuidSchema } from '~/lib/validate.server'
 import { isUiNodeInputAttributes } from '@ory/integrations/ui'
 import type { UiContainer } from '@ory/client'

--- a/packages/frontend/app/routes/auth.recovery.tsx
+++ b/packages/frontend/app/routes/auth.recovery.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs } from '@remix-run/node'
+import { json, type LoaderFunctionArgs, redirectDocument } from '@remix-run/node'
 import { uuidSchema } from '~/lib/validate.server'
 import { isUiNodeInputAttributes } from '@ory/integrations/ui'
 import type { UiContainer } from '@ory/client'
@@ -35,10 +35,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     return { responseData }
   } else {
-    throw json(null, {
-      status: 400,
-      statusText: 'No Kratos account recovery flow ID found.'
-    })
+    return redirectDocument(
+      `${variables.kratosBrowserPublicUrl}/self-service/recovery/browser`
+    )
   }
 }
 

--- a/packages/frontend/app/routes/settings.tsx
+++ b/packages/frontend/app/routes/settings.tsx
@@ -1,4 +1,8 @@
-import { json, redirect, type LoaderFunctionArgs } from '@remix-run/node'
+import {
+  json,
+  redirectDocument,
+  type LoaderFunctionArgs
+} from '@remix-run/node'
 import { uuidSchema } from '~/lib/validate.server'
 import {
   isUiNodeInputAttributes,
@@ -39,7 +43,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     return { responseData }
   } else {
-    return redirect(
+    return redirectDocument(
       `${variables.kratosBrowserPublicUrl}/self-service/settings/browser`
     )
   }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- This PR addresses a bug in the Admin UI where the settings page fails to load correctly, resulting in a 404 error. The issue arises due to the browser getting stuck at the Kratos endpoint and not following the redirect back to the settings page in the Admin UI with the flow ID appended. This bug is resolved by replacing the redirect function with redirectDocument to ensure the correct handling of document-level redirects. In the settings.tsx page I'm simply swapping `redirect` with `redirectDocument`. 

We are using a nightly build to test if this resolves issues in possible production deployments. 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

- fixes #2793 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated
