### PR TITLE
fix(frontend): It is ambiguous on what scale is the withdrawal and deposit input

### DIFF
--- a/packages/frontend/app/components/LiquidityDialog.tsx
+++ b/packages/frontend/app/components/LiquidityDialog.tsx
@@ -30,7 +30,10 @@ export const LiquidityDialog = ({
     const userInput = e.target.value
     const scaledInput = parseFloat(userInput) * Math.pow(10, asset.scale)
     const integerScaledInput = Math.floor(scaledInput)
-    if (scaledInput !== integerScaledInput) {
+    if (scaledInput < 0) {
+      const error = 'The amount should be a positive value'
+      setErrorMessage(error)
+    } else if (scaledInput !== integerScaledInput) {
       const error = 'The asset scale cannot accomodate this value'
       setErrorMessage(error)
     } else {
@@ -63,18 +66,17 @@ export const LiquidityDialog = ({
                 {title}
               </Dialog.Title>
               <div className='mt-2'>
+                <Input
+                  required
+                  type='number'
+                  name='displayAmount'
+                  label='Amount'
+                  onChange={handleChange}
+                  addOn={asset.code}
+                  step='any'
+                  error={errorMessage}
+                />
                 <Form method='post' replace preventScrollReset>
-                  <Input
-                    required
-                    type='number'
-                    name='displayAmount'
-                    label='Amount'
-                    onChange={handleChange}
-                    addOn={asset.code}
-                    step='any'
-                    min={1 / Math.pow(10, asset.scale)}
-                    error={errorMessage}
-                  />
                   <Input
                     required
                     min={1}

--- a/packages/frontend/app/components/LiquidityDialog.tsx
+++ b/packages/frontend/app/components/LiquidityDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog } from '@headlessui/react'
 import { Form } from '@remix-run/react'
-import { ChangeEvent, useState } from 'react'
+import type { ChangeEvent } from 'react'
+import { useState } from 'react'
 import { XIcon } from '~/components/icons'
 import { Button, Input } from '~/components/ui'
 

--- a/packages/frontend/app/components/LiquidityDialog.tsx
+++ b/packages/frontend/app/components/LiquidityDialog.tsx
@@ -1,5 +1,6 @@
 import { Dialog } from '@headlessui/react'
 import { Form } from '@remix-run/react'
+import { useState } from 'react'
 import { XIcon } from '~/components/icons'
 import { Button, Input } from '~/components/ui'
 
@@ -14,6 +15,8 @@ export const LiquidityDialog = ({
   onClose,
   type
 }: LiquidityDialogProps) => {
+  const [amount, setAmount] = useState(0)
+
   return (
     <Dialog as='div' className='relative z-10' onClose={onClose} open={true}>
       <div className='fixed inset-0 bg-tealish/30 bg-opacity-75 transition-opacity' />
@@ -46,6 +49,10 @@ export const LiquidityDialog = ({
                     name='amount'
                     label='Amount'
                   />
+                  <div className='mt-2'>
+                    <p>Based on the asset:</p>
+                    <p>Amount {amount} = {amount / 100} USD </p>
+                  </div>
                   <div className='flex justify-end py-3'>
                     <Button aria-label={`${type} liquidity`} type='submit'>
                       {type} liquidity

--- a/packages/frontend/app/components/LiquidityDialog.tsx
+++ b/packages/frontend/app/components/LiquidityDialog.tsx
@@ -4,18 +4,25 @@ import { useState } from 'react'
 import { XIcon } from '~/components/icons'
 import { Button, Input } from '~/components/ui'
 
+type BasicAsset = {
+  code: string
+  scale: number
+}
+
 type LiquidityDialogProps = {
   title: string
   onClose: () => void
   type: 'Deposit' | 'Withdraw'
+  asset: BasicAsset
 }
 
 export const LiquidityDialog = ({
   title,
   onClose,
-  type
+  type,
+  asset
 }: LiquidityDialogProps) => {
-  const [amount, setAmount] = useState(0)
+  const [amount, setAmount] = useState<number>(0)
 
   return (
     <Dialog as='div' className='relative z-10' onClose={onClose} open={true}>
@@ -48,10 +55,11 @@ export const LiquidityDialog = ({
                     type='number'
                     name='amount'
                     label='Amount'
+                    onChange={e => setAmount(Number(e.target.value))}
                   />
                   <div className='mt-2'>
                     <p>Based on the asset:</p>
-                    <p>Amount {amount} = {amount / 100} USD </p>
+                    <p>Amount {amount} = {amount / Math.pow(10, asset.scale)} {asset.code} </p>
                   </div>
                   <div className='flex justify-end py-3'>
                     <Button aria-label={`${type} liquidity`} type='submit'>

--- a/packages/frontend/app/components/LiquidityDialog.tsx
+++ b/packages/frontend/app/components/LiquidityDialog.tsx
@@ -57,7 +57,7 @@ export const LiquidityDialog = ({
                     label='Amount'
                     onChange={e => setAmount(Number(e.target.value))}
                   />
-                  <div className='mt-2'>
+                  <div className='text-gray-500 text-sm mt-2'>
                     <p>Based on the asset:</p>
                     <p>Amount {amount} = {amount / Math.pow(10, asset.scale)} {asset.code} </p>
                   </div>

--- a/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
@@ -39,7 +39,7 @@ export default function AssetDepositLiquidity() {
       onClose={dismissDialog}
       title='Deposit asset liquidity'
       type='Deposit'
-      asset={asset}
+      asset={{ code: asset.code, scale: asset.scale }}
     />
   )
 }

--- a/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.deposit-liquidity.tsx
@@ -1,28 +1,45 @@
-import { type ActionFunctionArgs } from '@remix-run/node'
-import { useNavigate } from '@remix-run/react'
+import { json, type ActionFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useNavigate } from '@remix-run/react'
 import { v4 } from 'uuid'
 import { LiquidityDialog } from '~/components/LiquidityDialog'
-import { depositAssetLiquidity } from '~/lib/api/asset.server'
+import { depositAssetLiquidity, getAssetInfo } from '~/lib/api/asset.server'
 import { messageStorage, setMessageAndRedirect } from '~/lib/message.server'
 import { amountSchema } from '~/lib/validate.server'
 import { redirectIfUnauthorizedAccess } from '../lib/kratos_checks.server'
 import { type LoaderFunctionArgs } from '@remix-run/node'
+import { z } from 'zod'
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const cookies = request.headers.get('cookie')
   await redirectIfUnauthorizedAccess(request.url, cookies)
-  return null
+
+  const assetId = params.assetId
+
+  const result = z.string().uuid().safeParse(assetId)
+  if (!result.success) {
+    throw json(null, { status: 400, statusText: 'Invalid asset ID.' })
+  }
+
+  const asset = await getAssetInfo({ id: result.data })
+
+  if (!asset) {
+    throw json(null, { status: 404, statusText: 'Asset not found.' })
+  }
+
+  return json({ asset })
 }
 
 export default function AssetDepositLiquidity() {
   const navigate = useNavigate()
   const dismissDialog = () => navigate('..', { preventScrollReset: true })
+  const { asset } = useLoaderData<typeof loader>()
 
   return (
     <LiquidityDialog
       onClose={dismissDialog}
       title='Deposit asset liquidity'
       type='Deposit'
+      asset={asset}
     />
   )
 }

--- a/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
@@ -1,28 +1,45 @@
-import { type ActionFunctionArgs } from '@remix-run/node'
-import { useNavigate } from '@remix-run/react'
+import { json, type ActionFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useNavigate } from '@remix-run/react'
 import { v4 } from 'uuid'
 import { LiquidityDialog } from '~/components/LiquidityDialog'
-import { withdrawAssetLiquidity } from '~/lib/api/asset.server'
+import { getAssetInfo, withdrawAssetLiquidity } from '~/lib/api/asset.server'
 import { messageStorage, setMessageAndRedirect } from '~/lib/message.server'
 import { amountSchema } from '~/lib/validate.server'
 import { redirectIfUnauthorizedAccess } from '~/lib/kratos_checks.server'
 import { type LoaderFunctionArgs } from '@remix-run/node'
+import { z } from 'zod'
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const cookies = request.headers.get('cookie')
   await redirectIfUnauthorizedAccess(request.url, cookies)
-  return null
+
+  const assetId = params.assetId
+
+  const result = z.string().uuid().safeParse(assetId)
+  if (!result.success) {
+    throw json(null, { status: 400, statusText: 'Invalid asset ID.' })
+  }
+
+  const asset = await getAssetInfo({ id: result.data })
+
+  if (!asset) {
+    throw json(null, { status: 404, statusText: 'Asset not found.' })
+  }
+
+  return json({ asset })
 }
 
 export default function AssetWithdrawLiquidity() {
   const navigate = useNavigate()
   const dismissDialog = () => navigate('..', { preventScrollReset: true })
+  const { asset } = useLoaderData<typeof loader>()
 
   return (
     <LiquidityDialog
       onClose={dismissDialog}
       title='Withdraw asset liquidity'
       type='Withdraw'
+      asset={asset}
     />
   )
 }

--- a/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/assets.$assetId.withdraw-liquidity.tsx
@@ -39,7 +39,7 @@ export default function AssetWithdrawLiquidity() {
       onClose={dismissDialog}
       title='Withdraw asset liquidity'
       type='Withdraw'
-      asset={asset}
+      asset={{ code: asset.code, scale: asset.scale }}
     />
   )
 }

--- a/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
@@ -1,28 +1,45 @@
-import { type ActionFunctionArgs } from '@remix-run/node'
-import { useNavigate } from '@remix-run/react'
+import { json, type ActionFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useNavigate } from '@remix-run/react'
 import { v4 } from 'uuid'
 import { LiquidityDialog } from '~/components/LiquidityDialog'
-import { depositPeerLiquidity } from '~/lib/api/peer.server'
+import { depositPeerLiquidity, getPeer } from '~/lib/api/peer.server'
 import { messageStorage, setMessageAndRedirect } from '~/lib/message.server'
 import { amountSchema } from '~/lib/validate.server'
 import { redirectIfUnauthorizedAccess } from '../lib/kratos_checks.server'
 import { type LoaderFunctionArgs } from '@remix-run/node'
+import { z } from 'zod'
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const cookies = request.headers.get('cookie')
   await redirectIfUnauthorizedAccess(request.url, cookies)
-  return null
+
+  const peerId = params.peerId
+
+  const result = z.string().uuid().safeParse(peerId)
+  if (!result.success) {
+    throw json(null, { status: 400, statusText: 'Invalid peer ID.' })
+  }
+
+  const peer = await getPeer({ id: result.data })
+
+  if (!peer) {
+    throw json(null, { status: 400, statusText: 'Peer not found.' })
+  }
+
+  return json({ asset: peer.asset })
 }
 
 export default function PeerDepositLiquidity() {
   const navigate = useNavigate()
   const dismissDialog = () => navigate('..', { preventScrollReset: true })
+  const { asset } = useLoaderData<typeof loader>()
 
   return (
     <LiquidityDialog
       onClose={dismissDialog}
       title='Deposit peer liquidity'
       type='Deposit'
+      asset={asset}
     />
   )
 }

--- a/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.deposit-liquidity.tsx
@@ -39,7 +39,7 @@ export default function PeerDepositLiquidity() {
       onClose={dismissDialog}
       title='Deposit peer liquidity'
       type='Deposit'
-      asset={asset}
+      asset={{ code: asset.code, scale: asset.scale }}
     />
   )
 }

--- a/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
@@ -1,28 +1,45 @@
-import { type ActionFunctionArgs } from '@remix-run/node'
-import { useNavigate } from '@remix-run/react'
+import { json, type ActionFunctionArgs } from '@remix-run/node'
+import { useLoaderData, useNavigate } from '@remix-run/react'
 import { v4 } from 'uuid'
 import { LiquidityDialog } from '~/components/LiquidityDialog'
-import { withdrawPeerLiquidity } from '~/lib/api/peer.server'
+import { getPeer, withdrawPeerLiquidity } from '~/lib/api/peer.server'
 import { messageStorage, setMessageAndRedirect } from '~/lib/message.server'
 import { amountSchema } from '~/lib/validate.server'
 import { redirectIfUnauthorizedAccess } from '../lib/kratos_checks.server'
 import { type LoaderFunctionArgs } from '@remix-run/node'
+import { z } from 'zod'
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const cookies = request.headers.get('cookie')
   await redirectIfUnauthorizedAccess(request.url, cookies)
-  return null
+
+  const peerId = params.peerId
+
+  const result = z.string().uuid().safeParse(peerId)
+  if (!result.success) {
+    throw json(null, { status: 400, statusText: 'Invalid peer ID.' })
+  }
+
+  const peer = await getPeer({ id: result.data })
+
+  if (!peer) {
+    throw json(null, { status: 400, statusText: 'Peer not found.' })
+  }
+
+  return json({ asset: peer.asset })
 }
 
 export default function PeerWithdrawLiquidity() {
   const navigate = useNavigate()
   const dismissDialog = () => navigate('..', { preventScrollReset: true })
+  const { asset } = useLoaderData<typeof loader>()
 
   return (
     <LiquidityDialog
       onClose={dismissDialog}
       title='Withdraw peer liquidity'
       type='Withdraw'
+      asset={asset}
     />
   )
 }

--- a/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.withdraw-liquidity.tsx
@@ -39,7 +39,7 @@ export default function PeerWithdrawLiquidity() {
       onClose={dismissDialog}
       title='Withdraw peer liquidity'
       type='Withdraw'
-      asset={asset}
+      asset={{ code: asset.code, scale: asset.scale }}
     />
   )
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Add an asset prop in liquidity dialog component to receive the asset info.
- Get the asset info on the loader of withdraw and deposit components using the `getPeer` api method.
- Get the asset info on the loader of withdraw and deposit components using the `getAssetInfo` api method.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
In the rafiki Admin UI, the liquidity information of peer and asset details are displayed using the current asset scale. When the user wants to deposit or withdraw liquidity, the amount introduced is handle using a scale of 0. So it is ambiguous on what scale the user is withdrawing or depositing.

Fixes: #2798 