### PR TITLE
feat(docker): switch to alpine3.19

### DIFF
--- a/localenv/mock-account-servicing-entity/Dockerfile
+++ b/localenv/mock-account-servicing-entity/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18 AS base
+FROM node:20-alpine3.19 AS base
 
 WORKDIR /home/rafiki
 
@@ -42,7 +42,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --frozen-lockfile
 RUN pnpm --filter mock-account-servicing-entity build
 
-FROM node:20-alpine3.18 AS runner
+FROM node:20-alpine3.19 AS runner
 
 WORKDIR /home/rafiki
 

--- a/packages/auth/Dockerfile.dev
+++ b/packages/auth/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18
+FROM node:20-alpine3.19
 
 WORKDIR /home/rafiki
 

--- a/packages/auth/Dockerfile.prod
+++ b/packages/auth/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18 AS base
+FROM node:20-alpine3.19 AS base
 
 WORKDIR /home/rafiki
 
@@ -43,7 +43,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --frozen-lockfile
 RUN pnpm --filter auth build
 
-FROM node:20-alpine3.18 AS runner
+FROM node:20-alpine3.19 AS runner
 
 WORKDIR /home/rafiki
 

--- a/packages/backend/Dockerfile.dev
+++ b/packages/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18
+FROM node:20-alpine3.19
 
 WORKDIR /home/rafiki
 

--- a/packages/backend/Dockerfile.prod
+++ b/packages/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18 AS base
+FROM node:20-alpine3.19 AS base
 
 WORKDIR /home/rafiki
 
@@ -43,7 +43,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --frozen-lockfile
 RUN pnpm --filter backend build
 
-FROM node:20-alpine3.18 AS runner
+FROM node:20-alpine3.19 AS runner
 
 WORKDIR /home/rafiki
 

--- a/packages/frontend/Dockerfile.dev
+++ b/packages/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18 AS base
+FROM node:20-alpine3.19 AS base
 
 WORKDIR /home/rafiki
 

--- a/packages/frontend/Dockerfile.prod
+++ b/packages/frontend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.18 AS base
+FROM node:20-alpine3.19 AS base
 
 WORKDIR /home/rafiki
 
@@ -40,7 +40,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --frozen-lockfile
 RUN pnpm --filter frontend build
 
-FROM node:20-alpine3.18 AS runner
+FROM node:20-alpine3.19 AS runner
 
 WORKDIR /home/rafiki
 


### PR DESCRIPTION
- feat(auth): build with alpine3.19
- feat(backend): build with alpine3.19
- feat(frontend): build with alpine3.19

Due to one CVE, our CI builds are failing due to some CVE that was not fixed in alpine3.18, so I decided that maybe we can bump that up a little bit. So I did an upgrade from alpine3.18 to alpine3.19
