### PR TITLE
feat(localenv): span metrics generation

### DIFF
--- a/localenv/telemetry/docker-compose.yml
+++ b/localenv/telemetry/docker-compose.yml
@@ -25,7 +25,10 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
-    command: "--config.file=/etc/prometheus/prometheus.yaml --log.level=debug"
+    command: 
+      - --config.file=/etc/prometheus/prometheus.yaml
+      - --log.level=debug
+      - --web.enable-remote-write-receiver
     networks:
       - rafiki
     volumes:

--- a/localenv/telemetry/grafana/provisioning/dashboards/example.json
+++ b/localenv/telemetry/grafana/provisioning/dashboards/example.json
@@ -18,7 +18,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
   "links": [],
   "panels": [
     {
@@ -325,6 +324,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -387,7 +387,7 @@
           "refId": "A"
         }
       ],
-      "title": "Panel Title",
+      "title": "Graphql Resolver Duration (95th Percentile)",
       "type": "bargauge"
     },
     {
@@ -607,6 +607,6 @@
   "timezone": "browser",
   "title": "Example Dashboard",
   "uid": "fdr58stwkr6yof",
-  "version": 3,
+  "version": 1,
   "weekStart": ""
 }

--- a/localenv/telemetry/grafana/provisioning/dashboards/example.json
+++ b/localenv/telemetry/grafana/provisioning/dashboards/example.json
@@ -18,6 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 1,
   "links": [],
   "panels": [
     {
@@ -175,7 +176,7 @@
           }
         ]
       },
-      "pluginVersion": "11.1.0",
+      "pluginVersion": "11.1.3",
       "targets": [
         {
           "datasource": {
@@ -324,6 +325,76 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(traces_spanmetrics_latency_bucket{span_name=~\"^(mutation|query).*\"}[$__rate_interval])) by (le, span_name))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Panel Title",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Maximum time it takes to complete the fastest 25%/50%/75% of ILP payments.",
       "fieldConfig": {
         "defaults": {
@@ -370,7 +441,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0",
+      "pluginVersion": "11.1.3",
       "targets": [
         {
           "datasource": {
@@ -465,7 +536,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.1.0",
+      "pluginVersion": "11.1.3",
       "targets": [
         {
           "datasource": {
@@ -536,6 +607,6 @@
   "timezone": "browser",
   "title": "Example Dashboard",
   "uid": "fdr58stwkr6yof",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }

--- a/localenv/telemetry/tempo.yaml
+++ b/localenv/telemetry/tempo.yaml
@@ -15,3 +15,13 @@ storage:
       path: /var/tempo/blocks
     wal:
       path: /var/tempo/wal
+
+metrics_generator:
+  storage:
+    path: /tmp/tempo/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+overrides:
+  metrics_generator_processors: [span-metrics]


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Configures tempo to generate metrics based off spans
- Adds visualization for 95th percentile graphql resolver durations to localenv dashboard (live dashboard not applicable because tracing is local only atm)


Visualization preview:

![image](https://github.com/user-attachments/assets/e999e786-422b-49ea-922b-f86c3abef1dd)


## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

fixes: https://github.com/interledger/rafiki/issues/2848

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Documentation added
- [x] Make sure that all checks pass
- [ ] Bruno collection updated
