### PR TITLE
Add migration files for updating Rafiki resources with multiple tenant support

### DIFF
--- a/packages/auth/migrations/20240827131401_create_tenants_tables.js.js
+++ b/packages/auth/migrations/20240827131401_create_tenants_tables.js.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable('tenants', function (table) {
+    table.uuid('id').primary()
+    table.string('kratosUrl').notNullable()
+    table.timestamp('createdAt').defaultTo(knex.fn.now())
+    table.timestamp('updatedAt').defaultTo(knex.fn.now())
+    table.timestamp('deletedAt').nullable().defaultTo(null)
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable('tenants')
+}

--- a/packages/auth/migrations/20240827131417_update_grants_with_tenantId.js.js
+++ b/packages/auth/migrations/20240827131417_update_grants_with_tenantId.js.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table('grants', function (table) {
+    table.uuid('tenantId').notNullable()
+    table
+      .foreign('tenantId')
+      .references('id')
+      .inTable('tenants')
+      .onDelete('CASCADE')
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table('grants', function (table) {
+    table.dropForeign(['tenantId'])
+    table.dropColumn('tenantId')
+  })
+}

--- a/packages/backend/migrations/20240827115808_create_tenants_tables.js.js
+++ b/packages/backend/migrations/20240827115808_create_tenants_tables.js.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable('tenants', function (table) {
+    table.uuid('id').primary()
+    table.string('kratosUrl').notNullable()
+    table.timestamp('createdAt').defaultTo(knex.fn.now())
+    table.timestamp('updatedAt').defaultTo(knex.fn.now())
+    table.timestamp('deletedAt').nullable().defaultTo(null)
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTable('tenants')
+}

--- a/packages/backend/migrations/20240827115832_update_resources_with_tenantId.js.js
+++ b/packages/backend/migrations/20240827115832_update_resources_with_tenantId.js.js
@@ -1,0 +1,75 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .table('quotes', function (table) {
+      table.uuid('tenantId').notNullable()
+      table
+        .foreign('tenantId')
+        .references('id')
+        .inTable('tenants')
+        .onDelete('CASCADE')
+    })
+    .table('incomingPayments', function (table) {
+      table.uuid('tenantId').notNullable()
+      table
+        .foreign('tenantId')
+        .references('id')
+        .inTable('tenants')
+        .onDelete('CASCADE')
+    })
+    .table('outgoingPayments', function (table) {
+      table.uuid('tenantId').notNullable()
+      table
+        .foreign('tenantId')
+        .references('id')
+        .inTable('tenants')
+        .onDelete('CASCADE')
+    })
+    .table('walletAddresses', function (table) {
+      table.uuid('tenantId').notNullable()
+      table
+        .foreign('tenantId')
+        .references('id')
+        .inTable('tenants')
+        .onDelete('CASCADE')
+    })
+    .table('grants', function (table) {
+      table.uuid('tenantId').notNullable()
+      table
+        .foreign('tenantId')
+        .references('id')
+        .inTable('tenants')
+        .onDelete('CASCADE')
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .table('quotes', function (table) {
+      table.dropForeign(['tenantId'])
+      table.dropColumn('tenantId')
+    })
+    .table('incomingPayments', function (table) {
+      table.dropForeign(['tenantId'])
+      table.dropColumn('tenantId')
+    })
+    .table('outgoingPayments', function (table) {
+      table.dropForeign(['tenantId'])
+      table.dropColumn('tenantId')
+    })
+    .table('walletAddresses', function (table) {
+      table.dropForeign(['tenantId'])
+      table.dropColumn('tenantId')
+    })
+    .table('grants', function (table) {
+      table.dropForeign(['tenantId'])
+      table.dropColumn('tenantId')
+    })
+}


### PR DESCRIPTION
## Changes proposed in this pull request

Changes consist of creating `tenants` table for both Rafiki backend and auth services, as well as adding `tenantId` as a foreign key for Rafiki backend resources.

## Context

This PR introduces some of the changes needed for achieving multi-tenancy on Rafiki. 

Closes #2894

## Checklist

- [ ] Create `tenants` table in Rafiki auth db
- [ ] Update `grants` table with `tenantId` foreign key in Rafiki auth db
- [ ] Create `tenants` table in Rafiki backend db
- [ ] Update `walletAddresses`, `incomingPayments`, `outgoingPayments` and `quotes` tables with `tenantId` foreign key in Rafiki backend db