### PR TITLE
fix: always pass in `identifier` into token introspection

### DIFF
--- a/packages/auth/src/access/utils.ts
+++ b/packages/auth/src/access/utils.ts
@@ -42,13 +42,22 @@ export function compareRequestAndGrantAccessItems(
     return false
   }
 
-  // Validate remaining keys
+  if (restOfRequestAccessItem.type !== restOfGrantAccessItem.type) {
+    return false
+  }
+
+  // Validate identifier, if present on the grant
+  const grantAccessIdentifier = (
+    restOfGrantAccessItem as OutgoingPaymentOrIncomingPaymentAccess
+  ).identifier
+
+  const requestAccessIdentifier = (
+    restOfRequestAccessItem as OutgoingPaymentOrIncomingPaymentAccess
+  ).identifier
+
   if (
-    restOfRequestAccessItem.type !== restOfGrantAccessItem.type ||
-    (restOfRequestAccessItem as OutgoingPaymentOrIncomingPaymentAccess)
-      .identifier !==
-      (restOfGrantAccessItem as OutgoingPaymentOrIncomingPaymentAccess)
-        .identifier
+    grantAccessIdentifier &&
+    requestAccessIdentifier !== grantAccessIdentifier
   ) {
     return false
   }

--- a/packages/backend/src/open_payments/auth/middleware.test.ts
+++ b/packages/backend/src/open_payments/auth/middleware.test.ts
@@ -46,7 +46,7 @@ type IntrospectionCallObject = {
   access: {
     type: AccessType
     actions: AccessAction[]
-    identifier?: string
+    identifier: string
   }[]
 }
 
@@ -193,7 +193,8 @@ describe('Auth Middleware', (): void => {
       access: [
         {
           type: type,
-          actions: [action]
+          actions: [action],
+          identifier: ctx.walletAddressUrl
         }
       ]
     })
@@ -217,7 +218,8 @@ describe('Auth Middleware', (): void => {
       access: [
         {
           type: type,
-          actions: [action]
+          actions: [action],
+          identifier: ctx.walletAddressUrl
         }
       ]
     })
@@ -286,13 +288,10 @@ describe('Auth Middleware', (): void => {
             access: [
               {
                 type,
-                actions: [action]
+                actions: [action],
+                identifier: ctx.walletAddressUrl
               }
             ]
-          }
-
-          if (type === AccessType.OutgoingPayment) {
-            expectedCallObject.access[0].identifier = ctx.walletAddressUrl
           }
 
           expect(introspectSpy).toHaveBeenCalledWith(expectedCallObject)
@@ -313,7 +312,8 @@ describe('Auth Middleware', (): void => {
             access: [
               {
                 type,
-                actions: [action]
+                actions: [action],
+                identifier: ctx.walletAddressUrl
               }
             ]
           })
@@ -349,7 +349,8 @@ describe('Auth Middleware', (): void => {
               access: [
                 {
                   type,
-                  actions: [subAction]
+                  actions: [subAction],
+                  identifier: ctx.walletAddressUrl
                 }
               ]
             })
@@ -376,7 +377,8 @@ describe('Auth Middleware', (): void => {
               access: [
                 {
                   type,
-                  actions: [superAction]
+                  actions: [superAction],
+                  identifier: ctx.walletAddressUrl
                 }
               ]
             })
@@ -436,12 +438,10 @@ describe('Auth Middleware', (): void => {
                 access: [
                   {
                     type,
-                    actions: [action]
+                    actions: [action],
+                    identifier: ctx.walletAddressUrl
                   }
                 ]
-              }
-              if (type === AccessType.OutgoingPayment) {
-                expectedCallObject.access[0].identifier = ctx.walletAddressUrl
               }
 
               expect(introspectSpy).toHaveBeenCalledWith(expectedCallObject)
@@ -473,7 +473,8 @@ describe('Auth Middleware', (): void => {
             access: [
               {
                 type,
-                actions: [action]
+                actions: [action],
+                identifier: ctx.walletAddressUrl
               }
             ]
           })

--- a/packages/backend/src/open_payments/auth/middleware.ts
+++ b/packages/backend/src/open_payments/auth/middleware.ts
@@ -36,7 +36,7 @@ export interface Grant {
 export interface Access {
   type: string
   actions: AccessAction[]
-  identifier?: string
+  identifier: string
 }
 
 function contextToRequestLike(ctx: HttpSigContext): RequestLike {
@@ -95,13 +95,11 @@ export function createTokenIntrospectionMiddleware({
         tokenInfo = await tokenIntrospectionClient.introspect({
           access_token: token,
           access: [
-            requestType === AccessType.OutgoingPayment
-              ? toOpenPaymentsAccess(
-                  requestType,
-                  requestAction,
-                  ctx.walletAddressUrl
-                )
-              : toOpenPaymentsAccess(requestType, requestAction)
+            toOpenPaymentsAccess(
+              requestType,
+              requestAction,
+              ctx.walletAddressUrl
+            )
           ]
         })
       } catch (err) {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
Update token introspection to always pass in `identifier` instead of just during outgoing payments, this fixes an issue when doing token introspection for incoming payment grant _with_ `identifiers`

[Slack thread](https://interledgerfoundation.slack.com/archives/C05EMHTG6FM/p1724763454737309)

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #2906

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Documentation added
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated
