### PR TITLE
docs: added spec for 'incomingPaymentCreated' and schema for 'amount' in webhooks.yaml

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,9 +12,7 @@
     "build": "pnpm build:deps && pnpm clean && tsc --build tsconfig.json && pnpm copy-files",
     "clean": "rm -fr dist/",
     "copy-files": "cp src/graphql/schema.graphql dist/graphql/ && cp -r ./src/openapi ./dist/",
-    "copy-op-schemas": "cp ./node_modules/@interledger/open-payments/dist/openapi/specs/schemas.yaml ./src/openapi/specs/",
     "prepack": "pnpm build",
-    "postinstall": "pnpm copy-op-schemas",
     "dev": "ts-node-dev --inspect=0.0.0.0:9229 --respawn --transpile-only --require ./src/telemetry/index.ts src/index.ts"
   },
   "devDependencies": {

--- a/packages/backend/src/openapi/specs/webhooks.yaml
+++ b/packages/backend/src/openapi/specs/webhooks.yaml
@@ -8,6 +8,17 @@ info:
 servers:
   - url: 'https://account-servicing-entity.com/webhooks'
 webhooks:
+  incomingPaymentCreated:
+    post:
+      requestBody:
+        description: Notify account servicing entity that an incoming payment was created.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/incomingPaymentEvent'
+      responses:
+        '200':
+          description: Returns a 200 status to indicate that the data was received successfully.
   incomingPaymentCompleted:
     post:
       requestBody:
@@ -148,9 +159,9 @@ components:
             completed:
               type: boolean
             incomingAmount:
-              $ref: ./schemas.yaml#/components/schemas/amount
+              $ref: '#/components/schemas/amount'
             receivedAmount:
-              $ref: ./schemas.yaml#/components/schemas/amount
+              $ref: '#/components/schemas/amount'
             metadata:
               type: object
               additionalProperties: true
@@ -214,9 +225,9 @@ components:
               type: string
               format: uri
             debitAmount:
-              $ref: ./schemas.yaml#/components/schemas/amount
+              $ref: '#/components/schemas/amount'
             sentAmount:
-              $ref: ./schemas.yaml#/components/schemas/amount
+              $ref: '#/components/schemas/amount'
             metadata:
               type: object
               additionalProperties: true
@@ -293,7 +304,7 @@ components:
                   type: string
                   format: date-time
                 receivedAmount:
-                  $ref: ./schemas.yaml#/components/schemas/amount
+                  $ref: '#/components/schemas/amount'
       additionalProperties: false
     liquidityEvent:
       required:
@@ -341,3 +352,29 @@ components:
         scale:
           type: number
       additionalProperties: false
+    amount:
+      title: amount
+      type: object
+      properties:
+        value:
+          type: string
+          format: uint64
+          description: 'The value is an unsigned 64-bit integer amount, represented as a string.'
+        assetCode:
+          $ref: '#/components/schemas/assetCode'
+        assetScale:
+          $ref: '#/components/schemas/assetScale'
+      required:
+        - value
+        - assetCode
+        - assetScale
+    assetCode:
+      title: Asset code
+      type: string
+      description: The assetCode is a code that indicates the underlying asset. This SHOULD be an ISO4217 currency code.
+    assetScale:
+      title: Asset scale
+      type: integer
+      minimum: 0
+      maximum: 255
+      description: The scale of amounts denoted in the corresponding asset code.

--- a/packages/backend/src/openapi/specs/webhooks.yaml
+++ b/packages/backend/src/openapi/specs/webhooks.yaml
@@ -353,7 +353,6 @@ components:
           type: number
       additionalProperties: false
     amount:
-      title: amount
       type: object
       properties:
         value:
@@ -361,20 +360,15 @@ components:
           format: uint64
           description: 'The value is an unsigned 64-bit integer amount, represented as a string.'
         assetCode:
-          $ref: '#/components/schemas/assetCode'
+          type: string
+          description: The assetCode is a code that indicates the underlying asset. This SHOULD be an ISO4217 currency code.
         assetScale:
-          $ref: '#/components/schemas/assetScale'
+          type: integer
+          minimum: 0
+          maximum: 255
+          description: The scale of amounts denoted in the corresponding asset code.
       required:
         - value
         - assetCode
         - assetScale
-    assetCode:
-      title: Asset code
-      type: string
-      description: The assetCode is a code that indicates the underlying asset. This SHOULD be an ISO4217 currency code.
-    assetScale:
-      title: Asset scale
-      type: integer
-      minimum: 0
-      maximum: 255
-      description: The scale of amounts denoted in the corresponding asset code.
+      additionalProperties: false


### PR DESCRIPTION
Updated the webhooks.yaml for OpenAPI by adding spec for `incomingPaymentCreated` event and for `amount` schema. Removed `postinstall` and `copy-op-schemas` from backend scripts.
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Added spec for `incomingPaymentCreated` event.
- Added spec for `amount` schema.
- Removed `postinstall` and `copy-op-schemas` scripts from `backend`.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Added missing spec for `incomingPaymentCreated` event and `amount` schema in OpenAPI specs file, `webhooks.yaml`. This schema was already defined in the Open Payments resource server specs and copied using `postinstall` and `copy-op-schemas` scripts. These scripts were removed from `package.json` as they are no longer necessary.
This issue fixes #2920 
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
