### PR TITLE
feat(backend,localenv): add tenant id to mockAccounts class

### DIFF
--- a/localenv/mock-account-servicing-entity/app/lib/apolloClient.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/apolloClient.ts
@@ -68,7 +68,8 @@ const authLink = setContext((request, { headers }) => {
   return {
     headers: {
       ...headers,
-      signature: `t=${timestamp}, v${version}=${digest}`
+      signature: `t=${timestamp}, v${version}=${digest}`,
+      'x-operator-secret': process.env.OPERATOR_API_SECRET
     }
   }
 })

--- a/localenv/mock-account-servicing-entity/app/lib/requesters.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/requesters.ts
@@ -81,7 +81,8 @@ export async function depositAssetLiquidity(
 export async function createWalletAddress(
   accountName: string,
   accountUrl: string,
-  assetId: string
+  assetId: string,
+  tenantId: string
 ): Promise<WalletAddress> {
   const createWalletAddressMutation = gql`
     mutation CreateWalletAddress($input: CreateWalletAddressInput!) {
@@ -98,7 +99,8 @@ export async function createWalletAddress(
     assetId,
     url: accountUrl,
     publicName: accountName,
-    additionalProperties: []
+    additionalProperties: [],
+    tenantId
   }
 
   return apolloClient

--- a/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
@@ -254,6 +254,9 @@ export async function handleWalletAddressWebMonetization(wh: Webhook) {
 }
 
 export async function handleWalletAddressNotFound(wh: Webhook) {
+  if (!mockAccounts.tenantId) {
+    throw new Error('No tenantId set')
+  }
   const walletAddressUrl = wh.data['walletAddressUrl'] as string | undefined
 
   if (!walletAddressUrl) {
@@ -271,7 +274,8 @@ export async function handleWalletAddressNotFound(wh: Webhook) {
   const walletAddress = await createWalletAddress(
     account.name,
     walletAddressUrl,
-    account.assetId
+    account.assetId,
+    mockAccounts.tenantId
   )
 
   await mockAccounts.setWalletAddress(

--- a/packages/backend/src/tenant/service.ts
+++ b/packages/backend/src/tenant/service.ts
@@ -92,9 +92,11 @@ async function getByIdentity(
   deps: ServiceDependencies,
   id: string
 ): Promise<Tenant | undefined> {
-  return Tenant.query(deps.knex).findOne({
-    kratosIdentityId: id
-  }).withGraphFetched('endpoints')
+  return Tenant.query(deps.knex)
+    .findOne({
+      kratosIdentityId: id
+    })
+    .withGraphFetched('endpoints')
 }
 
 async function createTenant(

--- a/packages/mock-account-service-lib/src/account-provider.ts
+++ b/packages/mock-account-service-lib/src/account-provider.ts
@@ -14,6 +14,7 @@ interface Account {
 }
 
 interface AccountsServer {
+  tenantId?: string
   clearAccounts(): Promise<void>
   setWalletAddress(
     id: string,
@@ -44,6 +45,11 @@ interface AccountsServer {
 
 export class AccountProvider implements AccountsServer {
   accounts = new Map<string, Account>()
+  public tenantId?: string
+
+  setTenantId(tenantId: string) {
+    this.tenantId = tenantId
+  }
 
   async clearAccounts(): Promise<void> {
     this.accounts.clear()

--- a/packages/mock-account-service-lib/src/seed.ts
+++ b/packages/mock-account-service-lib/src/seed.ts
@@ -57,6 +57,9 @@ export async function setupFromSeed(
     tenants[name] = tenant.id
   }
 
+  // Realistically there would only be one tenant per ASE
+  mockAccounts.setTenantId(tenants[config.seed.tenants[0].name])
+
   const assets: Record<string, Asset> = {}
   for (const { code, scale, liquidity, liquidityThreshold } of config.seed
     .assets) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds a `tenantId` instance variable to the `AccountProvider` class in the 	`mock-account-service-lib`.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #2992. 

If a mock ASE is queried for a wallet address that doesn't exist, it tries to create the wallet address. With the introduction of tenants, this breaks that request as it now expects a tenant id in the input. An instance variable allows the mock ase to configure the `AccountProvider` class with a tenant id with which to create wallet addresses.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
