### PR TITLE
feat: Allow configurable cookie SameSite header

### DIFF
--- a/packages/auth/src/app.ts
+++ b/packages/auth/src/app.ts
@@ -13,7 +13,7 @@ import { ApolloServer } from '@apollo/server'
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer'
 import { koaMiddleware } from '@as-integrations/koa'
 
-import { IAppConfig, SameSiteCookieProp } from './config/app'
+import { IAppConfig } from './config/app'
 import { addResolversToSchema } from '@graphql-tools/schema'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
 import { loadSchemaSync } from '@graphql-tools/load'
@@ -345,8 +345,7 @@ export class App {
 
     const redis = await this.container.use('redis')
     const maxAgeMs = this.config.interactionExpirySeconds * 1000
-    const interactionSameSite = this.config
-      .interactionCookieSameSite as SameSiteCookieProp
+    const interactionSameSite = this.config.interactionCookieSameSite
     koa.use(
       session(
         {

--- a/packages/auth/src/app.ts
+++ b/packages/auth/src/app.ts
@@ -13,7 +13,7 @@ import { ApolloServer } from '@apollo/server'
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer'
 import { koaMiddleware } from '@as-integrations/koa'
 
-import { IAppConfig } from './config/app'
+import { IAppConfig, SameSiteCookieProp } from './config/app'
 import { addResolversToSchema } from '@graphql-tools/schema'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
 import { loadSchemaSync } from '@graphql-tools/load'
@@ -345,12 +345,15 @@ export class App {
 
     const redis = await this.container.use('redis')
     const maxAgeMs = this.config.interactionExpirySeconds * 1000
+    const interactionSameSite = this.config
+      .interactionCookieSameSite as SameSiteCookieProp
     koa.use(
       session(
         {
           key: 'sessionId',
           maxAge: maxAgeMs,
           signed: true,
+          sameSite: interactionSameSite,
           store: {
             async get(key) {
               const s = await redis.get(key)

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -20,8 +20,18 @@ function envBool(name: string, value: boolean): boolean {
   const envValue = process.env[name]
   return envValue == null ? value : envValue === 'true'
 }
+function envEnum<T extends string>(
+  name: string,
+  allowedValues: T[],
+  defaultValue: T | undefined
+): T | undefined {
+  const envValue = process.env[name]
+  if (envValue && allowedValues.includes(envValue as T)) {
+    return envValue as T
+  }
+  return defaultValue
+}
 export type IAppConfig = typeof Config
-export type SameSiteCookieProp = boolean | 'strict' | 'lax' | 'none' | undefined
 
 dotenv.config({
   path: process.env.ENV_FILE || '.env'
@@ -51,7 +61,11 @@ export const Config = {
   adminApiSignatureTtl: envInt('ADMIN_API_SIGNATURE_TTL_SECONDS', 30),
   waitTimeSeconds: envInt('WAIT_SECONDS', 5),
   cookieKey: envString('COOKIE_KEY'),
-  interactionCookieSameSite: process.env.INTERACTION_COOKIE_SAME_SITE, // optional
+  interactionCookieSameSite: envEnum(
+    'INTERACTION_COOKIE_SAME_SITE',
+    ['lax', 'none'],
+    undefined
+  ),
   interactionExpirySeconds: envInt('INTERACTION_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes
   accessTokenExpirySeconds: envInt('ACCESS_TOKEN_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes
   databaseCleanupWorkers: envInt('DATABASE_CLEANUP_WORKERS', 1),

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -21,6 +21,7 @@ function envBool(name: string, value: boolean): boolean {
   return envValue == null ? value : envValue === 'true'
 }
 export type IAppConfig = typeof Config
+export type SameSiteCookieProp = boolean | 'strict' | 'lax' | 'none' | undefined
 
 dotenv.config({
   path: process.env.ENV_FILE || '.env'
@@ -50,6 +51,7 @@ export const Config = {
   adminApiSignatureTtl: envInt('ADMIN_API_SIGNATURE_TTL_SECONDS', 30),
   waitTimeSeconds: envInt('WAIT_SECONDS', 5),
   cookieKey: envString('COOKIE_KEY'),
+  interactionCookieSameSite: process.env.INTERACTION_COOKIE_SAME_SITE, // optional
   interactionExpirySeconds: envInt('INTERACTION_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes
   accessTokenExpirySeconds: envInt('ACCESS_TOKEN_EXPIRY_SECONDS', 10 * 60), // Default 10 minutes
   databaseCleanupWorkers: envInt('DATABASE_CLEANUP_WORKERS', 1),

--- a/packages/auth/src/tests/context.ts
+++ b/packages/auth/src/tests/context.ts
@@ -24,8 +24,7 @@ export function createContext<T extends AppContext>(
       {
         key: 'sessionId',
         maxAge: 60 * 1000,
-        signed: true,
-        sameSite: 'strict' // testing with strict, most restrictive, anything less will work if it does with strict
+        signed: true
       },
       koa
     )

--- a/packages/auth/src/tests/context.ts
+++ b/packages/auth/src/tests/context.ts
@@ -24,7 +24,8 @@ export function createContext<T extends AppContext>(
       {
         key: 'sessionId',
         maxAge: 60 * 1000,
-        signed: true
+        signed: true,
+        sameSite: 'strict' // testing with strict, most restrictive, anything less will work if it does with strict
       },
       koa
     )


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
Added a new ENV flag (INTERACTION_COOKIE_SAME_SITE) that is unset by default and allows the ASE to set it to lax, strict, or none if they want.
<!--
Provide a succinct description of what this pull request entails.
-->

## Context
Added mainly for control over this value in auth.rafiki.money, in order to be able to have payments work in an iframe, needed in WM Tools

