### PR TITLE
docs: rafiki admin auth optional

### DIFF
--- a/packages/documentation/src/content/docs/admin/admin-user-guide.mdx
+++ b/packages/documentation/src/content/docs/admin/admin-user-guide.mdx
@@ -70,6 +70,17 @@ Kratos also enhances security with features like built-in breach detection, secu
 
 Ory Kratos provides frontend components (such as forms and buttons) for identity management flows like login, and account settings. These components are not fixed in design; they are fetched via API calls which allows us to match the identity management components with Rafiki Admin's overall look and feel.
 
+:::danger[Disabling authentication]
+
+Rafiki Admin provides access to sensitive data like peering relationships and wallet addresses. Authentication is enabled by default to restrict access to authorized users only.
+
+In the [Local Playground](/integration/playground/overview#rafiki-admin), authentication is disabled by default to simplify local development and testing. To disable it in other environments, set the environment variable `AUTH_ENABLED` to `false`. This should be done with **extreme caution** and only in specific scenarios:
+
+- Secure, non-production environments like the Local Playground for local development and testing.
+- Internal systems where Rafiki Admin is not exposed externally and other access controls (firewalls, local-only access) ensure that the system is secured.
+
+:::
+
 ## Navigation
 
 After logging in, you’ll be greeted by the main landing page with a left-hand navigation menu. This menu provides access to all of the main functionality needed to manage your Rafiki instance.

--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -85,39 +85,61 @@ The following components are made available via the Local Playground:
 
 #### Mock account servicing entity 1 - Cloud Nine Wallet
 
-| Label | Component              | URL                           |
-| ----- | ---------------------- | ----------------------------- |
-| a     | User Interface         | http://localhost:3030         |
-| b     | Backend Admin API      | http://localhost:3001/graphql |
-| c     | Open Payments API      | http://localhost:3000         |
-| d     | Auth Admin API         | http://localhost:3003/graphql |
-| e     | Open Payments Auth API | http://localhost:3006         |
-| f     | Rafiki Admin UI        | http://localhost:3010         |
-| g     | Kratos API             | http://localhost:4433         |
+| Label | Component                          | URL                           |
+| ----- | ---------------------------------- | ----------------------------- |
+| a     | User Interface                     | http://localhost:3030         |
+| b     | Backend Admin API                  | http://localhost:3001/graphql |
+| c     | Open Payments API                  | http://localhost:3000         |
+| d     | Auth Admin API                     | http://localhost:3003/graphql |
+| e     | Open Payments Auth API             | http://localhost:3006         |
+| f     | Rafiki Admin UI                    | http://localhost:3010         |
+| g     | Kratos API - _disabled by default_ | http://localhost:4433         |
 
 #### Mock account servicing entity 2 - Happy Life Bank
 
-| Label | Component              | URL                           |
-| ----- | ---------------------- | ----------------------------- |
-| h     | User Interface         | http://localhost:3031         |
-| i     | Backend Admin API      | http://localhost:4001/graphql |
-| j     | Open Payments API      | http://localhost:4000         |
-| k     | Auth Admin API         | http://localhost:4003/graphql |
-| l     | Open Payments Auth API | http://localhost:4006         |
-| m     | Rafiki Admin UI        | http://localhost:4010         |
-| n     | Kratos API             | http://localhost:4432         |
+| Label | Component                          | URL                           |
+| ----- | ---------------------------------- | ----------------------------- |
+| h     | User Interface                     | http://localhost:3031         |
+| i     | Backend Admin API                  | http://localhost:4001/graphql |
+| j     | Open Payments API                  | http://localhost:4000         |
+| k     | Auth Admin API                     | http://localhost:4003/graphql |
+| l     | Open Payments Auth API             | http://localhost:4006         |
+| m     | Rafiki Admin UI                    | http://localhost:4010         |
+| n     | Kratos API - _disabled by default_ | http://localhost:4432         |
 
 #### Mail Slurper
 
-| Label | Component | URL                   |
-| ----- | --------- | --------------------- |
-| o     | Mail UI   | http://localhost:4436 |
+| Label | Component                        | URL                   |
+| ----- | -------------------------------- | --------------------- |
+| o     | Mail UI - _disabled by default_  | http://localhost:4436 |
 
 #### Database
 
 | Component       | URL                   |
 | --------------- | --------------------- |
 | Postgres Server | http://localhost:5432 |
+
+### Rafiki Admin
+
+Manage and view information about the Rafiki instance(s) through the [Rafiki Admin](/admin/admin-user-guide/) application. Rafiki Admin is a Remix app for querying info and executing mutations against the Rafiki [Backend Admin API](https://rafiki.dev/integration/playground/overview#admin-apis).
+
+- Cloud Nine Wallet - http://localhost:3010
+- Happy Life Bank - http://localhost:4010
+
+We have secured access to Rafiki Admin using <LinkOut href='https://www.ory.sh/docs/kratos/ory-kratos-intro'>Ory Kratos</LinkOut>; however, in our local playground setup we've chosen to disable user authentication for easier development and testing interactions.
+
+:::note[Enabling Rafiki Admin authentication locally]
+If you'd like to enable authentication locally you can run `pnpm localenv:compose:adminauth up`
+
+Separate registrations/users are required for each mock ASE's Admin app as the ASEs are designed to run as separate mock entities. Visit the Rafiki Admin user guide to learn how to [invite](/admin/admin-user-guide#invite-a-user) and [remove](/admin/admin-user-guide#remove-a-user) users via provided scripts.
+
+After you've registered, you can come back to your Rafiki Admin account by navigating to [`localhost:3010`](http://localhost:3010) (Cloud Nine Wallet) or [`localhost:4010`](http://localhost:4010) (Happy Life Bank) and logging in.
+
+Follow these steps to reset a user's Rafiki Admin password.
+
+1. Click the forgot password link and enter an email for a registered user.
+2. Open [Mail Slurper](http://localhost:4436/) to access the recovery link for the account.
+:::
 
 ### Exploring Accounts on Cloud Nine Wallet
 
@@ -178,20 +200,21 @@ pnpm localenv:compose down --volumes --rmi all
 
 The following are the most commonly used commands:
 
-| Command                                        | Description                                      |
-| ---------------------------------------------- | ------------------------------------------------ |
-| pnpm localenv:compose config                   | Show all merged config (with TigerBeetle)        |
-| pnpm localenv:compose up                       | Start (with TigerBeetle)                         |
-| pnpm localenv:compose up -d                    | Start (with TigerBeetle) detached                |
-| pnpm localenv:compose down                     | Down (with TigerBeetle)                          |
-| pnpm localenv:compose down --volumes           | Down and kill volumes (with TigerBeetle)         |
-| pnpm localenv:compose down --volumes --rmi all | Down, kill volumes (with TigerBeetle) and images |
-| pnpm localenv:compose:psql config              | Show all merged config (with PostgreSQL)         |
-| pnpm localenv:compose build                    | Build all the containers (with TigerBeetle)      |
-| pnpm localenv:compose:psql up                  | Start (with PostgreSQL)                          |
-| pnpm localenv:compose:psql down                | Down (with PostgreSQL)                           |
-| pnpm localenv:compose:psql down --volumes      | Down (with PostgreSQL) and kill volumes          |
-| pnpm localenv:compose:psql build               | Build all the containers (with PostgreSQL)       |
+| Command                                        | Description                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------------- |
+| pnpm localenv:compose config                   | Show all merged config (with TigerBeetle)                         |
+| pnpm localenv:compose up                       | Start (with TigerBeetle)                                          |
+| pnpm localenv:compose up -d                    | Start (with TigerBeetle) detached                                 |
+| pnpm localenv:compose down                     | Down (with TigerBeetle)                                           |
+| pnpm localenv:compose down --volumes           | Down and kill volumes (with TigerBeetle)                          |
+| pnpm localenv:compose down --volumes --rmi all | Down, kill volumes (with TigerBeetle) and images                  |
+| pnpm localenv:compose:psql config              | Show all merged config (with PostgreSQL)                          |
+| pnpm localenv:compose build                    | Build all the containers (with TigerBeetle)                       |
+| pnpm localenv:compose:psql up                  | Start (with PostgreSQL)                                           |
+| pnpm localenv:compose:psql down                | Down (with PostgreSQL)                                            |
+| pnpm localenv:compose:psql down --volumes      | Down (with PostgreSQL) and kill volumes                           |
+| pnpm localenv:compose:psql build               | Build all the containers (with PostgreSQL)                        |
+| pnpm localenv:compose:adminauth up             | Start with local admin auth enabled (this is disabled by default) | 
 
 ### Interacting with the Local Playground
 
@@ -222,26 +245,6 @@ You have to go through an interaction flow by clicking on the `redirect` link in
 8.  Continues the grant request
 9.  Creates an outgoing payment on the sender's account
 10. Fetches the outgoing payment on the sender's account
-
-#### Rafiki Admin
-
-Manage and view information about the Rafiki instance(s) through the [Rafiki Admin](/admin/admin-user-guide/) application. Rafiki Admin is a Remix app for querying info and executing mutations against the Rafiki [Backend Admin API](https://rafiki.dev/integration/playground/overview#admin-apis).
-
-- Cloud Nine Wallet - http://localhost:3010
-- Happy Life Bank - http://localhost:4010
-
-Visit the Rafiki Admin user guide to learn how to [invite](/admin/admin-user-guide#invite-a-user) and [remove](/admin/admin-user-guide#remove-a-user) users via provided scripts.
-
-:::note
-Separate registrations/users are required for each mock ASE's Admin app as the ASEs are designed to run as separate mock entities. After you've registered, you can come back to your Rafiki Admin account by navigating to [`localhost:3010`](http://localhost:3010) (Cloud Nine Wallet) or [`localhost:4010`](http://localhost:4010) (Happy Life Bank) and logging in.
-:::
-
-##### Rafiki Admin password recovery
-
-Follow these steps to reset a user's Rafiki Admin password.
-
-1. Click the forgot password link and enter an email for a registered user.
-2. Open [Mail Slurper](http://localhost:4436/) to access the recovery link for the account.
 
 #### Admin APIs
 

--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -109,13 +109,8 @@ The following components are made available via the Local Playground:
 
 #### Mail Slurper
 
-<<<<<<< Updated upstream
 | Label | Component                        | URL                   |
 | ----- | -------------------------------- | --------------------- |
-=======
-| Label | Component | URL                   |
-| ----- | --------- | --------------------- |
->>>>>>> Stashed changes
 | o     | Mail UI - _disabled by default_  | http://localhost:4436 |
 
 #### Database

--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -109,8 +109,13 @@ The following components are made available via the Local Playground:
 
 #### Mail Slurper
 
+<<<<<<< Updated upstream
 | Label | Component                        | URL                   |
 | ----- | -------------------------------- | --------------------- |
+=======
+| Label | Component | URL                   |
+| ----- | --------- | --------------------- |
+>>>>>>> Stashed changes
 | o     | Mail UI - _disabled by default_  | http://localhost:4436 |
 
 #### Database

--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -109,9 +109,9 @@ The following components are made available via the Local Playground:
 
 #### Mail Slurper
 
-| Label | Component                        | URL                   |
-| ----- | -------------------------------- | --------------------- |
-| o     | Mail UI - _disabled by default_  | http://localhost:4436 |
+| Label | Component                       | URL                   |
+| ----- | ------------------------------- | --------------------- |
+| o     | Mail UI - _disabled by default_ | http://localhost:4436 |
 
 #### Database
 
@@ -139,7 +139,7 @@ Follow these steps to reset a user's Rafiki Admin password.
 
 1. Click the forgot password link and enter an email for a registered user.
 2. Open [Mail Slurper](http://localhost:4436/) to access the recovery link for the account.
-:::
+   :::
 
 ### Exploring Accounts on Cloud Nine Wallet
 
@@ -214,7 +214,7 @@ The following are the most commonly used commands:
 | pnpm localenv:compose:psql down                | Down (with PostgreSQL)                                            |
 | pnpm localenv:compose:psql down --volumes      | Down (with PostgreSQL) and kill volumes                           |
 | pnpm localenv:compose:psql build               | Build all the containers (with PostgreSQL)                        |
-| pnpm localenv:compose:adminauth up             | Start with local admin auth enabled (this is disabled by default) | 
+| pnpm localenv:compose:adminauth up             | Start with local admin auth enabled (this is disabled by default) |
 
 ### Interacting with the Local Playground
 

--- a/packages/documentation/src/content/docs/integration/services/frontend-service.mdx
+++ b/packages/documentation/src/content/docs/integration/services/frontend-service.mdx
@@ -12,11 +12,22 @@ Rafiki’s <LinkOut href="https://github.com/interledger/rafiki/tree/main/packag
 The following are required when using the `frontend` service:
 
 - A Rafiki [`backend`](/integration/services/backend-service) service up and running to access the Backend Admin API.
-- An identity provider for authentication and user management. Out of the box, the Rafiki Admin application uses <LinkOut href="https://www.ory.sh/docs/kratos/ory-kratos-intro">Ory Kratos</LinkOut>, a secure and fully open-source identity management solution. Kratos will be made optional in a future Rafiki release, allowing you to run your own solution if you so choose.
+- An identity provider for authentication and user management. Out of the box, the Rafiki Admin application uses <LinkOut href="https://www.ory.sh/docs/kratos/ory-kratos-intro">Ory Kratos</LinkOut>, a secure and fully open-source identity management solution.
+
+:::danger[Disabling authentication]
+
+Rafiki Admin provides access to sensitive data like peering relationships and wallet addresses. Authentication is enabled by default to restrict access to authorized users only.
+
+In the [Local Playground](/integration/playground/overview#rafiki-admin), authentication is disabled by default to simplify local development and testing. To disable it in other environments, set the environment variable `AUTH_ENABLED` to `false`. This should be done with **extreme caution** and only in specific scenarios:
+
+- Secure, non-production environments like the Local Playground for local development and testing.
+- Internal systems where Rafiki Admin is not exposed externally and other access controls (firewalls, local-only access) ensure that the system is secured.
+
+:::
 
 You must also set the environment variables for the `frontend` service.
 
-## Rafiki admin settings
+## Rafiki Admin settings
 
 While the `frontend` service is not required to run a Rafiki instance, it is highly recommended. A number of administrative tasks could be performed programmatically via the Backend Admin API, but the `frontend` service makes these functions available through a user-friendly interface.
 


### PR DESCRIPTION
Updated the following pages:

- Admin user guide - adding caution about disabling Kratos
- Frontend service - adding caution about disabling Kratos
- Local playground - adding information about Kratos being disabled by default and how to enable

Fixes https://github.com/interledger/rafiki/issues/2963