### PR TITLE
Docs: adding information about wallet address URLs being case-insensitive

### DIFF
--- a/packages/documentation/src/content/docs/admin/admin-user-guide.mdx
+++ b/packages/documentation/src/content/docs/admin/admin-user-guide.mdx
@@ -244,12 +244,13 @@ Fill out the following fields to create a new wallet address:
 
 | Section             | Field               | Description                                                                 |
 | ------------------- | ------------------- | --------------------------------------------------------------------------- |
-| General Information | Wallet address name | The URL of the wallet. Once set, it cannot be changed.                      |
+| General Information | Wallet address name | The case-insensitive URL of the wallet. Once set, it cannot be changed.     |
 |                     | Public name         | The name associated with the wallet that is visible to anyone with the URL. |
 |                     | Asset               | Select an asset to associate with this wallet.                              |
 
-:::note
-At least one asset has to be created prior to creating a new wallet address. Refer to [Create asset](#create-asset) for more information.
+:::note[Wallet address requirements]
+- At least one asset has to be created prior to creating a new wallet address. Refer to [Create asset](#create-asset) for more information.
+- Wallet address URLs are treated as case-insensitive, meaning that both lowercase and uppercase variations of the same address will be recognized as identical.
 :::
 
 After completing this section, select **Create** to add the new wallet address.

--- a/packages/documentation/src/content/docs/integration/prod/helm-k8s.mdx
+++ b/packages/documentation/src/content/docs/integration/prod/helm-k8s.mdx
@@ -28,7 +28,7 @@ helm install rafiki PATH_TO_RAFIKI_REPO/infrastructure/helm/rafiki
 
 #### Tigerbeetle
 
-For Rafiki's accounting database, you may opt to run Tigerbeetle in place of Postres. Though you must run one Postgres instance that's used for the `auth` services and Open Payments resources.
+For Rafiki's accounting database, you may opt to run Tigerbeetle in place of Postgres. Though you must run one Postgres instance that's used for the `auth` services and Open Payments resources.
 
 To change the version of Tigerbeetle you must change the respective tag in the <LinkOut href='https://github.com/interledger/rafiki/blob/main/infrastructure/helm/tigerbeetle/values.yaml'>values.yaml</LinkOut> file for Tigerbeetle.
 

--- a/packages/documentation/src/content/docs/integration/requirements/wallet-addresses.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/wallet-addresses.mdx
@@ -7,8 +7,9 @@ import { CodeBlock } from '@interledger/docs-design-system'
 
 Each payment account belonging to your users (e.g., customers) must have at least one associated wallet address for the account to be able to send and receive payments over Interledger and Open Payments. A wallet address serves as a publicly shareable standardized ID for a payment account.
 
-:::note
-Your Rafiki instance must be set up for at least one asset before wallet addresses can be created as each wallet address must have an asset assigned to it.
+:::note[Wallet address requirements]
+- Your Rafiki instance must be set up for at least one asset before wallet addresses can be created as each wallet address must have an asset assigned to it.
+- Wallet address URLs are treated as case-insensitive, meaning that both lowercase and uppercase variations of the same address will be recognized as identical.
 :::
 
 ## Create wallet addresses
@@ -84,7 +85,7 @@ We strongly recommend you store at least the `walletAddress.id` in your internal
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `assetId`              | The unique ID of the asset, assigned by Rafiki when the asset was created, that the wallet address's underlying payment account is denominated in |
 | `publicName`           | The public name associated with the wallet address                                                                                                |
-| `url`                  | The wallet address's URL                                                                                                                          |
+| `url`                  | The wallet address's case-insensitive URL                                                                                                         |
 | `additionalProperties` | Optional [additional properties](/apis/graphql/backend/inputobjects/#additionalpropertyinput) associated with the wallet address                  |
 
 <CodeBlock title="Example JSON response">

--- a/packages/documentation/src/content/docs/resources/glossary.mdx
+++ b/packages/documentation/src/content/docs/resources/glossary.mdx
@@ -102,7 +102,7 @@ A distributed financial accounting database designed for mission-critical safety
 
 ## Wallet address
 
-A secure, unique URL that identifies an Open Payments-enabled account. It acts as an entry point to the Open Payments APIs, facilitating interactions like sending and receiving payments. Similar to how an email address serves as a public identifier for an email account, a wallet address is publicly shareable and used to interact with the underlying payment account without compromising its security.
+A secure, unique URL that identifies an Open Payments-enabled account. It acts as an entry point to the Open Payments APIs, facilitating interactions like sending and receiving payments. Similar to how an email address serves as a public identifier for an email account, a wallet address is publicly shareable and used to interact with the underlying payment account without compromising its security. Wallet address URLs are treated as case-insensitive, meaning that both lowercase and uppercase variations of the same address will be recognized as identical.
 
 ## Web Monetization
 


### PR DESCRIPTION
Made updates in the following places:
- Admin user guide in the creating wallet address section
- Requirements > Wallet address overview
- Glossary (even though I know we are going to revisit the glossary)

Also minor spelling correction from "Postres" to "Postgres" I happened to see

Fixes https://github.com/interledger/rafiki/issues/3008