### PR TITLE
docs: added missing responses to id-provider requests

### DIFF
--- a/packages/auth/src/openapi/specs/id-provider.yaml
+++ b/packages/auth/src/openapi/specs/id-provider.yaml
@@ -39,6 +39,8 @@ paths:
               description: Interaction id
         '401':
           description: Unauthorized
+        '500':
+          description: Request denied
       operationId: get-interact
       parameters:
         - schema:
@@ -89,6 +91,8 @@ paths:
               description: Client finish endpoint
         '401':
           description: Unauthorized
+        '404':
+          description: Unknown interaction
       description: "To finish the user interaction for grant approval, this endpoint redirects the user to the client's finish url."
       parameters:
         - schema:

--- a/packages/auth/src/openapi/specs/id-provider.yaml
+++ b/packages/auth/src/openapi/specs/id-provider.yaml
@@ -39,8 +39,6 @@ paths:
               description: Interaction id
         '401':
           description: Unauthorized
-        '500':
-          description: Request denied
       operationId: get-interact
       parameters:
         - schema:
@@ -92,7 +90,7 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: Unknown interaction
+          description: Not Found
       description: "To finish the user interaction for grant approval, this endpoint redirects the user to the client's finish url."
       parameters:
         - schema:


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Added missing response codes to id-provider specs

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
After reviewing all the OpenAPI specs, I have found two missing response statuses in the `id-provider.yaml`:

- `500` code at the request that starts the user interaction
- `404` code at the request that finishes the user interaction

Fixes #2958 
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
