### PR TITLE
Bc/2929/filter op resources by tenantid

### DIFF
--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Outgoing Payment.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  ~x-operator-secret: tXhxCNRWuVOJs5W/CUgjsc+vBnKj0CVdqSb87EXN64E=
+}
+
 body:graphql {
   mutation CreateOutgoingPayment($input: CreateOutgoingPaymentInput!) {
     createOutgoingPayment(input: $input) {
@@ -46,7 +50,7 @@ body:graphql:vars {
   {
     "input": {
       "walletAddressId": "{{gfranklinWalletAddressId}}",
-      "quoteId": "{{quoteId}}"
+      "quoteId": "{{quoteId}}", "tenantId": ""
     }
   }
 }

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Quote.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Quote.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  ~x-operator-secret: {{operatorApiSecret}}
+}
+
 body:graphql {
   mutation CreateQuote($input: CreateQuoteInput!) {
     createQuote(input: $input) {
@@ -38,7 +42,8 @@ body:graphql:vars {
   {
     "input": {
       "walletAddressId": "{{gfranklinWalletAddressId}}",
-      "receiver": "{{receiverId}}"
+      "receiver": "{{receiverId}}",
+      "tenantId": ""
     }
   }
 }
@@ -53,7 +58,7 @@ script:pre-request {
 
 script:post-response {
   const body = res.getBody();
-
+  
   if (body?.data) {
     bru.setEnvVar("quoteId", body.data.createQuote.quote.id);
   }

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Receiver -remote Incoming Payment-.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Create Receiver -remote Incoming Payment-.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  ~x-operator-secret: {{operatorApiSecret}}
+}
+
 body:graphql {
   mutation CreateReceiver($input: CreateReceiverInput!) {
     createReceiver(input: $input) {
@@ -60,7 +64,7 @@ script:pre-request {
 
 script:post-response {
   const body = res.getBody();
-
+  
   if (body?.data) {
     bru.setEnvVar("receiverId", body.data.createReceiver.receiver.id);
   }

--- a/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Get Outgoing Payment.bru
+++ b/bruno/collections/Rafiki/Examples/Admin API -  only locally/Peer-to-Peer Payment/Get Outgoing Payment.bru
@@ -10,6 +10,10 @@ post {
   auth: none
 }
 
+headers {
+  ~x-operator-secret: tXhxCNRWuVOJs5W/CUgjsc+vBnKj0CVdqSb87EXN64E=
+}
+
 body:graphql {
   query GetOutgoingPayment($id: String!) {
   outgoingPayment(id: $id) {

--- a/bruno/collections/Rafiki/scripts.js
+++ b/bruno/collections/Rafiki/scripts.js
@@ -181,7 +181,8 @@ const scripts = {
       method: 'post',
       headers: {
         signature: this.generateBackendApiSignature(postBody),
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'x-operator-secret': bru.getEnvVar('operatorApiSecret')
       },
       body: JSON.stringify(postBody)
     }

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -443,24 +443,24 @@ export class App {
       } else {
         // TODO: cache. adds network call to every gql resolver and
         // not all resolvers need tenantId/isOperator.
-        // await getTenantIdFromRequestHeaders(ctx, this.config)
+        await getTenantIdFromRequestHeaders(ctx, this.config)
 
         // TODO: remove this and restore getTenantIdFromRequestHeaders.
         // This is just a hack to be able to test normal tenant (non-operator)
         // case from bruno
-        const tenantService = await this.container.use('tenantService')
-        const tenant = await tenantService.getByEmail(
-          'c9PrimaryTenant@example.com' ??
-            (await tenantService.getByEmail('hlbPrimaryTenant@example.com'))
-        )
-        console.log(tenant)
+        // const tenantService = await this.container.use('tenantService')
+        // const tenant = await tenantService.getByEmail(
+        //   'c9PrimaryTenant@example.com' ??
+        //     (await tenantService.getByEmail('hlbPrimaryTenant@example.com'))
+        // )
+        // console.log(tenant)
 
-        if (!tenant) {
-          throw new Error('could not find tenantId')
-        }
+        // if (!tenant) {
+        //   throw new Error('could not find tenantId')
+        // }
 
-        ctx.tenantId = tenant.id
-        ctx.isOperator = false
+        // ctx.tenantId = tenant.id
+        // ctx.isOperator = false
         return next()
       }
     })

--- a/packages/backend/src/graphql/resolvers/incoming_payment.ts
+++ b/packages/backend/src/graphql/resolvers/incoming_payment.ts
@@ -148,19 +148,19 @@ export const cancelIncomingPayment: MutationResolvers<ApolloContext>['cancelInco
 
     // ACCESS CONTROL CASE: Update/Deletes. Check existing resource's tenantId before mutating.
 
-    // If from operator use tenantId given on input, otherwise use the requestor's tenant's id.
-    // In other words, dont use the operator's tenantId
-    const tenantId = ctx.isOperator ? args.input.tenantId : ctx.tenantId
-    const incomingPayment = await incomingPaymentService.get({
-      id: args.input.id
-    })
-    if (!incomingPayment || tenantId !== incomingPayment.tenantId) {
-      throw new GraphQLError('Unknown incoming payment', {
-        extensions: {
-          code: GraphQLErrorCode.NotFound,
-          id: args.input.id
-        }
+    // TODO: move into incomingPaymentService.canAccess(isOperator, tenantId, incomingPaymentId)?
+    if (!ctx.isOperator) {
+      const incomingPayment = await incomingPaymentService.get({
+        id: args.input.id
       })
+      if (!incomingPayment || ctx.tenantId !== incomingPayment.tenantId) {
+        throw new GraphQLError('Unknown incoming payment', {
+          extensions: {
+            code: GraphQLErrorCode.NotFound,
+            id: args.input.id
+          }
+        })
+      }
     }
 
     const incomingPaymentOrError = await incomingPaymentService.cancel(

--- a/packages/backend/src/graphql/resolvers/quote.ts
+++ b/packages/backend/src/graphql/resolvers/quote.ts
@@ -62,12 +62,9 @@ export const createQuote: MutationResolvers<ApolloContext>['createQuote'] =
     }
 
     const quoteService = await ctx.container.use('quoteService')
-    // Optionally, quoteService.create could implicity add the correct tenantId
-    // based on the the wallet address tenantId. This would circumvent need for
-    // operator to pass in tenantId - is there any downside? Could the operator
-    // accidentally create it for the wrong tenant this way? I dont think so...
-    // Haven't fully thought through the implications, but consider this use case is
-    // atypical and tenant will usually be creating these (does that inform anything?)
+    // Optionally for creates, we could not require the tenantId from an operator and
+    // just use the tenantId associated with args.input.walletAddressId. Is there any downside?
+    // Could the operator accidentally create it for the wrong tenant this way? I dont think so...
     const options: CreateQuoteOptions = {
       walletAddressId: args.input.walletAddressId,
       tenantId: args.input.tenantId,

--- a/packages/backend/src/graphql/resolvers/quote.ts
+++ b/packages/backend/src/graphql/resolvers/quote.ts
@@ -82,7 +82,7 @@ export const createQuote: MutationResolvers<ApolloContext>['createQuote'] =
       }
   }
 
-// TODO: tenancy - need to add tenantId to getWalletAddressPage
+// TODO: access control. need to add tenantId to getPage
 export const getWalletAddressQuotes: WalletAddressResolvers<ApolloContext>['quotes'] =
   async (parent, args, ctx): Promise<ResolversTypes['QuoteConnection']> => {
     if (!parent.id) {

--- a/packages/backend/src/graphql/resolvers/quote.ts
+++ b/packages/backend/src/graphql/resolvers/quote.ts
@@ -27,13 +27,17 @@ export const getQuote: QueryResolvers<ApolloContext>['quote'] = async (
   const quote = await quoteService.get({
     id: args.id
   })
-  if (!quote) {
+  if (
+    !quote ||
+    !(await quoteService.canAccess(ctx.isOperator, ctx.tenantId, quote))
+  ) {
     throw new GraphQLError('quote does not exist', {
       extensions: {
         code: GraphQLErrorCode.NotFound
       }
     })
   }
+
   return quoteToGraphql(quote)
 }
 
@@ -78,6 +82,7 @@ export const createQuote: MutationResolvers<ApolloContext>['createQuote'] =
       }
   }
 
+// TODO: tenancy - need to add tenantId to getWalletAddressPage
 export const getWalletAddressQuotes: WalletAddressResolvers<ApolloContext>['quotes'] =
   async (parent, args, ctx): Promise<ResolversTypes['QuoteConnection']> => {
     if (!parent.id) {

--- a/packages/backend/src/graphql/resolvers/quote.ts
+++ b/packages/backend/src/graphql/resolvers/quote.ts
@@ -43,10 +43,8 @@ export const getQuote: QueryResolvers<ApolloContext>['quote'] = async (
 
 export const createQuote: MutationResolvers<ApolloContext>['createQuote'] =
   async (parent, args, ctx): Promise<ResolversTypes['QuoteResponse']> => {
-    // ACCESS CONTROL CASE: Creates. If operator, OK. Else, get associated wallet address
-    // tenantId and compare to requestor's tenantId before creating.
     const walletAddressService = await ctx.container.use('walletAddressService')
-    const canAccess = walletAddressService.canAccess(
+    const canAccess = await walletAddressService.canAccess(
       ctx.isOperator,
       ctx.tenantId,
       args.input.walletAddressId

--- a/packages/backend/src/graphql/resolvers/receiver.ts
+++ b/packages/backend/src/graphql/resolvers/receiver.ts
@@ -41,7 +41,6 @@ export const createReceiver: MutationResolvers<ApolloContext>['createReceiver'] 
     const receiverService = await ctx.container.use('receiverService')
 
     const receiverOrError = await receiverService.create({
-      tenantId: ctx.tenantId,
       walletAddressUrl: args.input.walletAddressUrl,
       expiresAt: args.input.expiresAt
         ? new Date(args.input.expiresAt)

--- a/packages/backend/src/graphql/resolvers/receiver.ts
+++ b/packages/backend/src/graphql/resolvers/receiver.ts
@@ -34,9 +34,14 @@ export const getReceiver: QueryResolvers<ApolloContext>['receiver'] = async (
 
 export const createReceiver: MutationResolvers<ApolloContext>['createReceiver'] =
   async (_, args, ctx): Promise<ResolversTypes['CreateReceiverResponse']> => {
+    // TODO: do we need to check tenantId for remote args.input.walletAddressUrl?
+    // Not found on P2P example because wa url is remote - not sure if we can (probably not?)
+    // nor necessarily need to do such a check
+
     const receiverService = await ctx.container.use('receiverService')
 
     const receiverOrError = await receiverService.create({
+      tenantId: ctx.tenantId,
       walletAddressUrl: args.input.walletAddressUrl,
       expiresAt: args.input.expiresAt
         ? new Date(args.input.expiresAt)

--- a/packages/backend/src/graphql/resolvers/wallet_address.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.ts
@@ -170,7 +170,7 @@ export const updateWalletAddress: MutationResolvers<ApolloContext>['updateWallet
   }
 
 // TODO: access control? operator only, anyone, or tenanted?
-// Perhaps operator only? if tenanted will maybe need to fn
+// Perhaps operator only? if tenanted will maybe need fn
 // like existing processNextWalletAddresses that filters by tenant
 export const triggerWalletAddressEvents: MutationResolvers<ApolloContext>['triggerWalletAddressEvents'] =
   async (

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -373,6 +373,9 @@ export function initIocContainer(
     if (config.enableTelemetry) {
       telemetry = await deps.use('telemetry')
     }
+    // Problem if moving access control check to existing service methods such as:
+    // walletAddressService, incomingPaymentService.
+    // Will not have tenantId/isOperator in connector.
     return await createConnectorService({
       logger: await deps.use('logger'),
       redis: await deps.use('redis'),

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -77,10 +77,9 @@ interface QuoteOptionsWithReceiveAmount extends QuoteOptionsBase {
   debitAmount?: never
 }
 
-export type CreateQuoteOptions = { tenantId: string } & (
+export type CreateQuoteOptions =
   | QuoteOptionsWithDebitAmount
   | QuoteOptionsWithReceiveAmount
-)
 
 async function createQuote(
   deps: ServiceDependencies,

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -46,7 +46,9 @@ export async function createQuoteService(
   return {
     get: (options) => getQuote(deps, options),
     create: (options: CreateQuoteOptions) => createQuote(deps, options),
-    getWalletAddressPage: (options) => getWalletAddressPage(deps, options)
+    getWalletAddressPage: (options) => getWalletAddressPage(deps, options),
+    canAccess: (isOperator, tenantId, idOrResource) =>
+      canAccessQuote(deps, isOperator, tenantId, idOrResource)
   }
 }
 
@@ -359,6 +361,24 @@ async function finalizeQuote(
   await quote.$query(deps.knex).patch(patchOptions)
 
   return quote
+}
+
+async function canAccessQuote(
+  deps: ServiceDependencies,
+  isOperator: boolean,
+  tenantId: string,
+  idOrResource: string | Quote
+) {
+  if (isOperator) return true
+
+  const q =
+    typeof idOrResource === 'string'
+      ? await Quote.query(deps.knex).findById(idOrResource)
+      : idOrResource
+
+  if (q && q.tenantId === tenantId) return true
+
+  return false
 }
 
 async function getWalletAddressPage(

--- a/packages/backend/src/open_payments/receiver/service.ts
+++ b/packages/backend/src/open_payments/receiver/service.ts
@@ -185,6 +185,8 @@ export async function getLocalIncomingPayment(
     return undefined
   }
 
+  // Problem if moving access control check to existing service methods:
+  // - will not have tenantId/isOperator in everywhere this is called (ie outgoing payment worker)
   const incomingPayment = await deps.incomingPaymentService.get({
     id: urlParseResult.id
   })

--- a/packages/backend/src/open_payments/wallet_address/service.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.test.ts
@@ -841,5 +841,23 @@ describe('Open Payments Wallet Address Service', (): void => {
       )
       expect(result).toBe(false)
     })
+
+    it('should return true if the user is not an operator and the wallet address is passed directly with matching tenantId', async () => {
+      const result = await walletAddressService.canAccess(
+        false,
+        tenantId,
+        walletAddress
+      )
+      expect(result).toBe(true)
+    })
+
+    it('should return false if the user is not an operator and the wallet address is passed directly with non-matching tenantId', async () => {
+      const result = await walletAddressService.canAccess(
+        false,
+        uuid(),
+        walletAddress
+      )
+      expect(result).toBe(false)
+    })
   })
 })

--- a/packages/backend/src/open_payments/wallet_address/service.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.test.ts
@@ -798,4 +798,48 @@ describe('Open Payments Wallet Address Service', (): void => {
       }
     )
   })
+
+  describe('canAccess', () => {
+    let walletAddress: WalletAddress
+
+    beforeEach(async () => {
+      walletAddress = await createWalletAddress(deps, tenantId)
+    })
+
+    it('should return true if the user is an operator', async () => {
+      const result = await walletAddressService.canAccess(
+        true,
+        'tenant1',
+        'wallet1'
+      )
+      expect(result).toBe(true)
+    })
+
+    it('should return true if the user is not an operator and wallet address is found with matching tenantId', async () => {
+      const result = await walletAddressService.canAccess(
+        false,
+        tenantId,
+        walletAddress.id
+      )
+      expect(result).toBe(true)
+    })
+
+    it('should return false if the user is not an operator and wallet address is found with non-matching tenantId', async () => {
+      const result = await walletAddressService.canAccess(
+        false,
+        uuid(),
+        walletAddress.id
+      )
+      expect(result).toBe(false)
+    })
+
+    it('should return false if the wallet address is not found', async () => {
+      const result = await walletAddressService.canAccess(
+        false,
+        tenantId,
+        uuid()
+      )
+      expect(result).toBe(false)
+    })
+  })
 })

--- a/packages/backend/src/tests/app.ts
+++ b/packages/backend/src/tests/app.ts
@@ -93,6 +93,8 @@ export const createTestApp = async (
   })
   const authLink = setContext((_, { headers }) => {
     return {
+      // TODO: enable testing resolvers as tenant? This (and nock)
+      // configuration makes all requests as-if from operator
       headers: {
         'x-operator-secret': config.operatorApiSecret,
         ...headers

--- a/packages/backend/src/tests/app.ts
+++ b/packages/backend/src/tests/app.ts
@@ -94,7 +94,8 @@ export const createTestApp = async (
   const authLink = setContext((_, { headers }) => {
     return {
       // TODO: enable testing resolvers as tenant? This (and nock)
-      // configuration makes all requests as-if from operator
+      // configuration makes all requests as-if from operator. Override with
+      // new optional createTestApp config?
       headers: {
         'x-operator-secret': config.operatorApiSecret,
         ...headers


### PR DESCRIPTION
Trying to determine where to put access control. Basic options are:
- in resolver/middleware
- in service, ie an interface like `incomingPaymentService.get(id, tenantId, isOperator)`. Not sure if this is ultimately viable

There are basically 3 classes of access control that I see so far:
- Gets: check `tenantId`s after retrieving if doing in resolver, or filter by if doing in service
- Creates: check the resource-to-be-created's `walletAddress.tenantId` before creating (either in resolver or service)
- Update/deletes: checks the existing resource's tenantId before mutating (either in resolver or service)

This `getIncomingPayment` resolver and the comment shows the issue more clearly. It does access control in the resolver after getting the resource: https://github.com/interledger/rafiki/blob/173b6b23dd7228f44033bf888c2cb1aeec437fa2/packages/backend/src/graphql/resolvers/outgoing_payment.ts#L21-L57

This `cancelIncomingPayment` resolver exemplifies the Create and Update/Delete cases (largely similar, only difference is if we compare given `tenantId` with existing resource or resource-to-be-created's `walletAddress.tenantId`): 

https://github.com/interledger/rafiki/blob/173b6b23dd7228f44033bf888c2cb1aeec437fa2/packages/backend/src/graphql/resolvers/incoming_payment.ts#L139-L181

will fix: #2929