### PR TITLE
feat(backend): make payment retry attempts configurable via env

### DIFF
--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -187,7 +187,11 @@ export const Config = {
     'INCOMING_PAYMENT_EXPIRY_MAX_MS',
     2592000000
   ), // 30 days
-  enableSpspPaymentPointers: envBool('ENABLE_SPSP_PAYMENT_POINTERS', true)
+  enableSpspPaymentPointers: envBool('ENABLE_SPSP_PAYMENT_POINTERS', true),
+  maxOutgoingPaymentRetryAttempts: envInt(
+    'MAX_OUTGOING_PAYMENT_RETRY_ATTEMPTS',
+    5
+  )
 }
 
 function parseRedisTlsConfig(

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -464,6 +464,7 @@ export function initIocContainer(
 
   container.singleton('outgoingPaymentService', async (deps) => {
     return await createOutgoingPaymentService({
+      config: await deps.use('config'),
       logger: await deps.use('logger'),
       knex: await deps.use('knex'),
       accountingService: await deps.use('accountingService'),

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -42,6 +42,7 @@ import { QuoteService } from '../../quote/service'
 import { isQuoteError } from '../../quote/errors'
 import { Pagination, SortOrder } from '../../../shared/baseModel'
 import { FilterString } from '../../../shared/filters'
+import { IAppConfig } from '../../../config/app'
 
 export interface OutgoingPaymentService
   extends WalletAddressSubresourceService<OutgoingPayment> {
@@ -59,6 +60,7 @@ export interface OutgoingPaymentService
 }
 
 export interface ServiceDependencies extends BaseService {
+  config: IAppConfig
   knex: TransactionOrKnex
   accountingService: AccountingService
   receiverService: ReceiverService

--- a/packages/backend/src/open_payments/payment/outgoing/worker.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/worker.ts
@@ -10,8 +10,6 @@ import { trace, Span } from '@opentelemetry/api'
 // First retry waits 10 seconds, second retry waits 20 (more) seconds, etc.
 export const RETRY_BACKOFF_SECONDS = 10
 
-const MAX_STATE_ATTEMPTS = 5
-
 // Returns the id of the processed payment (if any).
 export async function processPendingPayment(
   deps_: ServiceDependencies
@@ -94,7 +92,10 @@ async function onLifecycleError(
   const error = typeof err === 'string' ? err : err.message
   const stateAttempts = payment.stateAttempts + 1
 
-  if (stateAttempts < MAX_STATE_ATTEMPTS && isRetryableError(err)) {
+  if (
+    stateAttempts < deps.config.maxOutgoingPaymentRetryAttempts &&
+    isRetryableError(err)
+  ) {
     deps.logger.warn(
       { state: payment.state, error, stateAttempts },
       'payment lifecycle failed; retrying'


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Added a new ENV `MAX_OUTGOING_PAYMENT_RETRY_ATTEMPTS` for configuring the number of payment sending attempts, with a default value of `5`.
 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- Closes #3017

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #3017`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
