### PR TITLE
fix: add border to overflow tables

### DIFF
--- a/packages/documentation/src/styles/rafiki.css
+++ b/packages/documentation/src/styles/rafiki.css
@@ -98,6 +98,8 @@
     0 0,
     100%;
   background-attachment: local, local, scroll, scroll;
+  box-shadow: var(--sl-shadow-sm);
+  border-radius: var(--border-radius);
 }
 
 .overflow-table thead th {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- This PR adds a bottom styling to overflow tables so it looks more obvious where the table ends and the next block of content begins.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
