### PR TITLE
chore(backend): dont wait 30s when completing/expiring incoming payment

### DIFF
--- a/packages/auth/src/graphql/schema.graphql
+++ b/packages/auth/src/graphql/schema.graphql
@@ -16,10 +16,7 @@ type Query {
   ): GrantsConnection!
 
   "Fetch a specific grant by its ID."
-  grant(
-    "Unique identifier of the grant."
-    id: ID!
-  ): Grant!
+  grant("Unique identifier of the grant." id: ID!): Grant!
 }
 
 type Mutation {

--- a/packages/backend/src/open_payments/payment/incoming/model.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.ts
@@ -155,8 +155,7 @@ export class IncomingPayment
       incomingPayment = await IncomingPayment.query()
         .patchAndFetchById(this.id, {
           state: IncomingPaymentState.Completed,
-          // Add 30 seconds to allow a prepared (but not yet fulfilled/rejected) packet to finish before sending webhook event.
-          processAt: new Date(Date.now() + 30_000)
+          processAt: new Date()
         })
         .whereNotIn('state', [
           IncomingPaymentState.Expired,

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -587,8 +587,7 @@ describe('Incoming Payment Service', (): void => {
 
     test('Sets state of fully paid incoming payment to "completed"', async (): Promise<void> => {
       const now = new Date()
-      jest.useFakeTimers()
-      jest.setSystemTime(now)
+      jest.useFakeTimers({ now })
       await expect(
         incomingPayment.onCredit({
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -597,7 +596,7 @@ describe('Incoming Payment Service', (): void => {
       ).resolves.toMatchObject({
         id: incomingPayment.id,
         state: IncomingPaymentState.Completed,
-        processAt: new Date(now.getTime() + 30_000)
+        processAt: now
       })
       await expect(
         incomingPaymentService.get({
@@ -605,7 +604,7 @@ describe('Incoming Payment Service', (): void => {
         })
       ).resolves.toMatchObject({
         state: IncomingPaymentState.Completed,
-        processAt: new Date(now.getTime() + 30_000)
+        processAt: now
       })
     })
   })
@@ -662,9 +661,8 @@ describe('Incoming Payment Service', (): void => {
           })
         ).resolves.toBeUndefined()
 
-        const now = incomingPayment.expiresAt
         jest.useFakeTimers()
-        jest.setSystemTime(now)
+        jest.setSystemTime(incomingPayment.expiresAt)
         await expect(incomingPaymentService.processNext()).resolves.toBe(
           incomingPayment.id
         )
@@ -674,7 +672,7 @@ describe('Incoming Payment Service', (): void => {
           })
         ).resolves.toMatchObject({
           state: IncomingPaymentState.Expired,
-          processAt: new Date(now.getTime() + 30_000)
+          processAt: new Date()
         })
       })
 
@@ -820,13 +818,14 @@ describe('Incoming Payment Service', (): void => {
     })
     test('updates state of pending incoming payment to complete', async (): Promise<void> => {
       const now = new Date()
-      jest.spyOn(global.Date, 'now').mockImplementation(() => now.valueOf())
+      jest.useFakeTimers({ now })
+
       await expect(
         incomingPaymentService.complete(incomingPayment.id)
       ).resolves.toMatchObject({
         id: incomingPayment.id,
         state: IncomingPaymentState.Completed,
-        processAt: new Date(now.getTime() + 30_000)
+        processAt: now
       })
       await expect(
         incomingPaymentService.get({
@@ -834,7 +833,7 @@ describe('Incoming Payment Service', (): void => {
         })
       ).resolves.toMatchObject({
         state: IncomingPaymentState.Completed,
-        processAt: new Date(now.getTime() + 30_000)
+        processAt: now
       })
     })
 
@@ -845,6 +844,9 @@ describe('Incoming Payment Service', (): void => {
     })
 
     test('updates state of processing incoming payment to complete', async (): Promise<void> => {
+      const now = new Date()
+      jest.useFakeTimers({ now })
+
       await incomingPayment.onCredit({
         totalReceived: BigInt(100)
       })
@@ -860,7 +862,7 @@ describe('Incoming Payment Service', (): void => {
       ).resolves.toMatchObject({
         id: incomingPayment.id,
         state: IncomingPaymentState.Completed,
-        processAt: new Date(incomingPayment.expiresAt.getTime())
+        processAt: now
       })
       await expect(
         incomingPaymentService.get({
@@ -868,7 +870,7 @@ describe('Incoming Payment Service', (): void => {
         })
       ).resolves.toMatchObject({
         state: IncomingPaymentState.Completed,
-        processAt: new Date(incomingPayment.expiresAt.getTime())
+        processAt: now
       })
     })
 

--- a/packages/backend/src/open_payments/payment/incoming/service.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.ts
@@ -268,8 +268,7 @@ async function handleExpired(
     )
     await incomingPayment.$query(deps.knex).patch({
       state: IncomingPaymentState.Expired,
-      // Add 30 seconds to allow a prepared (but not yet fulfilled/rejected) packet to finish before sending webhook event.
-      processAt: new Date(Date.now() + 30_000)
+      processAt: new Date()
     })
   } else {
     deps.logger.debug({ amountReceived }, 'deleting expired incoming payment')
@@ -437,7 +436,7 @@ async function completeIncomingPayment(
     }
     await payment.$query(trx).patch({
       state: IncomingPaymentState.Completed,
-      processAt: new Date(Date.now() + 30_000)
+      processAt: new Date()
     })
     return await addReceivedAmount(deps, payment)
   })

--- a/packages/backend/src/payment-method/ilp/connector/core/middleware/account.ts
+++ b/packages/backend/src/payment-method/ilp/connector/core/middleware/account.ts
@@ -87,10 +87,6 @@ export function createAccountMiddleware(serverAddress: string): ILPMiddleware {
               LiquidityAccountType.INCOMING
             )
           }
-          ctx.services.logger.debug(
-            { incomingPaymentId: incomingPayment.id },
-            'destination account is incoming payment'
-          )
           return incomingPayment
         }
         // Open Payments SPSP fallback account
@@ -104,20 +100,12 @@ export function createAccountMiddleware(serverAddress: string): ILPMiddleware {
               LiquidityAccountType.WEB_MONETIZATION
             )
           }
-          ctx.services.logger.debug(
-            { walletAddressId: walletAddress.id },
-            'destination account is wallet address'
-          )
           return walletAddress
         }
       }
       const address = ctx.request.prepare.destination
       const peer = await peers.getByDestinationAddress(address)
       if (peer) {
-        ctx.services.logger.debug(
-          { peerId: peer.id },
-          'destination account is peer'
-        )
         return peer
       }
       if (


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Removing the 30 second wait time when completing or expiring an incoming payment. 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- The reason for the incoming payment would wait 30 seconds before "finalizing" it (via `processAt`), was to check for any packets that we're sent but not received, essentially, trying to make sure that we wouldn't "lose" any that should be delivered to the payment. However, in practice, it looks like this delay wouldn't have mattered/worked to begin with. Because we also update the status of the payment when changing `processAt`:
https://github.com/interledger/rafiki/blob/6b971bf4636bbc658530e8447c52866054db2aec/packages/backend/src/open_payments/payment/incoming/model.ts#L154-L164  _and_ we check for the incoming payment status when we received packets: https://github.com/interledger/rafiki/blob/6b971bf4636bbc658530e8447c52866054db2aec/packages/backend/src/payment-method/ilp/connector/core/middleware/account.ts#L60-L80 we wouldn't have been able to receive any packets after the payment was marked as Completed/Expired _anyway_. This is why we can just remove this artificial waiting period, and just complete/expire the payment directly.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->
Fixes #2922 

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
