### PR TITLE
fix: Admin UI error Auth redirect

### DIFF
--- a/packages/frontend/app/routes/auth._index.tsx
+++ b/packages/frontend/app/routes/auth._index.tsx
@@ -11,7 +11,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   return null
 }
 
-export const action = () => {
+export async function action() {
   return redirectDocument(
     `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
   )

--- a/packages/frontend/app/routes/auth._index.tsx
+++ b/packages/frontend/app/routes/auth._index.tsx
@@ -14,8 +14,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export const action = () => {
   return redirectDocument(
     `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
-  );
-};
+  )
+}
 
 export default function Auth() {
   return (
@@ -39,7 +39,7 @@ export default function Auth() {
             </a>
           </p>
           <div>
-            <Form method="post">
+            <Form method='post'>
               <Button aria-label='logout' type='submit' className='mr-2'>
                 Login
               </Button>

--- a/packages/frontend/app/routes/auth._index.tsx
+++ b/packages/frontend/app/routes/auth._index.tsx
@@ -11,12 +11,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   return null
 }
 
-export async function action() {
-  return redirectDocument(
-    `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
-  )
-}
-
 export default function Auth() {
   return (
     <div className='pt-4 flex flex-col'>
@@ -40,7 +34,7 @@ export default function Auth() {
           </p>
           <div>
             <Form method='post'>
-              <Button aria-label='logout' type='submit' className='mr-2'>
+              <Button aria-label='login' type='submit' className='mr-2'>
                 Login
               </Button>
             </Form>
@@ -48,5 +42,11 @@ export default function Auth() {
         </div>
       </div>
     </div>
+  )
+}
+
+export async function action() {
+  return redirectDocument(
+    `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
   )
 }

--- a/packages/frontend/app/routes/auth._index.tsx
+++ b/packages/frontend/app/routes/auth._index.tsx
@@ -1,7 +1,8 @@
+import { Form } from '@remix-run/react'
 import { Button } from '../components/ui'
 import variables from '../lib/envConfig.server'
 import { checkAuthAndRedirect } from '../lib/kratos_checks.server'
-import { type LoaderFunctionArgs } from '@remix-run/node'
+import { redirectDocument, type LoaderFunctionArgs } from '@remix-run/node'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const cookies = request.headers.get('cookie')
@@ -10,8 +11,13 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   return null
 }
 
+export const action = () => {
+  return redirectDocument(
+    `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
+  );
+};
+
 export default function Auth() {
-  const loginUrl = `${variables.kratosBrowserPublicUrl}/self-service/login/browser`
   return (
     <div className='pt-4 flex flex-col'>
       <div className='flex flex-col rounded-md bg-offwhite px-6 text-center min-h-[calc(100vh-7rem)] md:min-h-[calc(100vh-3rem)]'>
@@ -33,9 +39,11 @@ export default function Auth() {
             </a>
           </p>
           <div>
-            <Button aria-label='logout' href={loginUrl} className='mr-2'>
-              Login
-            </Button>
+            <Form method="post">
+              <Button aria-label='logout' type='submit' className='mr-2'>
+                Login
+              </Button>
+            </Form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Changes proposed in this pull request

Using the `Form` with `redirectDocument(loginUrl);` By using remix's `action` function and `redirectDocument` instead of `href`, the server processes the request, retrieves the necessary information (such as flow parameters from Ory Kratos), and provides the correct redirect response. The form submit allows remix to handle this routing server-side, ensuring the full URL is correctly generated.

The `href` attribute instead tries to directly navigate to the link client-side. If variables.kratosBrowserPublicUrl is undefined or not available at runtime, Remix will interpret it as `undefined`, creating the `localhost:3010/undefined/self-service/login/browser` URL.

## Context
What were you trying to do?
fixes #2840 