### PR TITLE
chore:token invalid throw 401 instead of return public incoming payment

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -577,7 +577,7 @@ export class App {
       createTokenIntrospectionMiddleware({
         requestType: AccessType.IncomingPayment,
         requestAction: RequestAction.Read,
-        bypassError: true
+        canSkipAuthValidation: true
       }),
       authenticatedStatusMiddleware,
       getWalletAddressForSubresource,

--- a/packages/backend/src/open_payments/auth/middleware.ts
+++ b/packages/backend/src/open_payments/auth/middleware.ts
@@ -67,11 +67,11 @@ function toOpenPaymentsAccess(
 export function createTokenIntrospectionMiddleware({
   requestType,
   requestAction,
-  bypassError = false
+  canSkipAuthValidation = false
 }: {
   requestType: AccessType
   requestAction: RequestAction
-  bypassError?: boolean
+  canSkipAuthValidation?: boolean 
 }) {
   return async (
     ctx: WalletAddressUrlContext,
@@ -79,14 +79,20 @@ export function createTokenIntrospectionMiddleware({
   ): Promise<void> => {
     const config = await ctx.container.use('config')
     try {
-      const parts = ctx.request.headers.authorization?.split(' ')
-      if (parts?.length !== 2 || parts[0] !== 'GNAP') {
+      if (canSkipAuthValidation && !ctx.request.headers.authorization) {
+        ctx.set('WWW-Authenticate', `GNAP as_uri=${config.authServerGrantUrl}`)
+        await next()
+        return
+      }
+
+      const authSplit = ctx.request.headers.authorization?.split(' ')
+      if (authSplit?.length !== 2 || authSplit[0] !== 'GNAP') {
         throw new OpenPaymentsServerRouteError(
           401,
           'Missing or invalid authorization header value'
         )
       }
-      const token = parts[1]
+      const token = authSplit[1]
       const tokenIntrospectionClient = await ctx.container.use(
         'tokenIntrospectionClient'
       )
@@ -145,19 +151,16 @@ export function createTokenIntrospectionMiddleware({
               : undefined
         }
       }
+
+      await next()
     } catch (err) {
       if (!(err instanceof OpenPaymentsServerRouteError)) {
         throw err
       }
 
       ctx.set('WWW-Authenticate', `GNAP as_uri=${config.authServerGrantUrl}`)
-
-      if (!bypassError) {
-        throw err
-      }
+      throw err
     }
-
-    await next()
   }
 }
 

--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -178,6 +178,18 @@ You can either trigger the debugger by adding `debugger` statements in the code 
 #### Debugging with VS Code:
 
 To debug with VS Code, add this configuration to your `.vscode/launch.json`:
+```json
+{
+    "name": "Attach to docker (cloud-nine-backend)",
+    "type": "node",
+    "request": "attach",
+    "port": 9229,
+    "address": "localhost",
+    "localRoot": "${workspaceFolder}",
+    "remoteRoot": "/home/rafiki/",
+    "restart": true
+},
+```
 
 The `localRoot` variable will depend on the location of the `launch.json` file relative to Rafiki’s root directory.
 


### PR DESCRIPTION
## Changes proposed in this pull request
<!--
1.
Moving the `await next()` inside the try catch as I believe this is a good practice.
Letting next() call outside the try-catch creates potential issues:

- error handling inconsistency: some errors are caught and handled, but other errors from next() can propagate up unhandled I think
- unexpected flow: the middleware might partially fail but still continue execution. If an error occurs during token validation, the middleware might still call next() with invalid/incomplete context state

2.
Renaming `bypassError` to `canSkipAuthValidation` to not introspect an access token and respond with "public" incoming payment that does not require an access token at all

-->
- 

## Context
<!--
 If an `accessToken` is provided with the request to get an incoming payment, and the token is invalid, it fails with a 401 error instead of returning a public incoming payment
Link issues here -  fixes #2889 
-->

## Checklist

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
