### PR TITLE
fix: fixed error where no assets were found when opening create peer page

### DIFF
--- a/packages/frontend/app/components/RedirectDialog.tsx
+++ b/packages/frontend/app/components/RedirectDialog.tsx
@@ -1,0 +1,107 @@
+import { Dialog, Transition } from '@headlessui/react'
+import { useNavigate } from '@remix-run/react'
+import { Button } from './ui'
+import { Fragment } from 'react/jsx-runtime'
+import { forwardRef, useImperativeHandle, useState } from 'react'
+
+export type RedirectDialogRef = {
+  display: () => void
+}
+
+type RedirectDialogProps = {
+  title: string
+  message: string
+  redirectPath: string
+  redirectButtonText: string
+  closeButtonText?: string
+}
+
+export const RedirectDialog = forwardRef<
+  RedirectDialogRef,
+  RedirectDialogProps
+>(
+  (
+    { title, message, redirectPath, redirectButtonText, closeButtonText },
+    ref
+  ) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const navigate = useNavigate()
+    const onClose = () => setIsOpen(false)
+
+    const onRedirect = () => {
+      setIsOpen(false)
+      navigate(redirectPath)
+    }
+
+    const display = (): void => {
+      setIsOpen(true)
+    }
+
+    useImperativeHandle(ref, () => ({ display }))
+
+    return (
+      <Transition show={isOpen} as={Fragment}>
+        <Dialog
+          as='div'
+          className='relative z-10'
+          onClose={() => null}
+          open={isOpen}
+        >
+          <Transition.Child
+            as={Fragment}
+            enter='ease-out duration-300'
+            enterFrom='opacity-0'
+            enterTo='opacity-100'
+            leave='ease-in duration-200'
+            leaveFrom='opacity-100'
+            leaveTo='opacity-0'
+          >
+            <div className='fixed inset-0 bg-tealish/30 bg-opacity-75 transition-opacity' />
+          </Transition.Child>
+          <Transition.Child
+            as={Fragment}
+            enter='ease-out duration-300'
+            enterFrom='opacity-0'
+            enterTo='opacity-100'
+            leave='ease-in duration-200'
+            leaveFrom='opacity-100'
+            leaveTo='opacity-0'
+          >
+            <div className='fixed inset-0 z-10 overflow-y-auto'>
+              <div className='flex min-h-full items-center justify-center p-4 text-center'>
+                <Dialog.Panel className='relative transform overflow-hidden rounded-lg max-w-full transition-all bg-white px-4 pb-4 pt-5 text-left shadow-xl w-full sm:max-w-lg'>
+                  <Dialog.Title
+                    as='h3'
+                    className='font-semibold leading-6 text-lg text-center mb-2'
+                  >
+                    {title}
+                  </Dialog.Title>
+                  <Dialog.Description className='m-6 mx-4 text-center'>
+                    {message}
+                  </Dialog.Description>
+                  <div className='flex justify-end space-x-4'>
+                    <Button
+                      className='mr-1'
+                      aria-label={redirectButtonText}
+                      onClick={onRedirect}
+                    >
+                      {redirectButtonText}
+                    </Button>
+                    <Button
+                      className='bg-black/50'
+                      aria-label={closeButtonText ?? 'Close'}
+                      onClick={onClose}
+                    >
+                      {closeButtonText ?? 'Close'}
+                    </Button>
+                  </div>
+                </Dialog.Panel>
+              </div>
+            </div>
+          </Transition.Child>
+        </Dialog>
+      </Transition>
+    )
+  }
+)
+RedirectDialog.displayName = 'RedirectDialog'

--- a/packages/frontend/app/lib/api/asset.server.ts
+++ b/packages/frontend/app/lib/api/asset.server.ts
@@ -281,6 +281,9 @@ export const loadAssets = async () => {
   while (hasNextPage) {
     const response = await listAssets({ first: 100, after })
 
+    if (!response.edges.length) {
+      return []
+    }
     if (response.edges) {
       assets = [...assets, ...response.edges]
     }

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -46,7 +46,7 @@ export default function CreatePeerPage() {
       <RedirectDialog
         ref={dialogRef}
         title='Before You Continue'
-        message='Please note, the required asset type must already exist before you can create a peer.'
+        message='Please note: you must have at least one asset before you can create a peer.'
         redirectPath={'/assets/create'}
         redirectButtonText={'Create Asset'}
       ></RedirectDialog>

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -17,6 +17,9 @@ import { messageStorage, setMessageAndRedirect } from '~/lib/message.server'
 import { createPeerSchema } from '~/lib/validate.server'
 import type { ZodFieldErrors } from '~/shared/types'
 import { checkAuthAndRedirect } from '../lib/kratos_checks.server'
+import type { RedirectDialogRef } from '~/components/RedirectDialog'
+import { RedirectDialog } from '~/components/RedirectDialog'
+import { useEffect, useRef } from 'react'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const cookies = request.headers.get('cookie')
@@ -30,193 +33,211 @@ export default function CreatePeerPage() {
   const response = useActionData<typeof action>()
   const { state } = useNavigation()
   const isSubmitting = state === 'submitting'
+  const dialogRef = useRef<RedirectDialogRef>(null)
+
+  useEffect(() => {
+    if (assets.length === 0) {
+      dialogRef.current?.display()
+    }
+  }, [])
 
   return (
-    <div className='pt-4 flex flex-col space-y-4'>
-      <div className='flex flex-col rounded-md bg-offwhite px-6'>
-        <PageHeader>
-          <h3 className='text-xl'>Create Peer</h3>
-          <Button aria-label='go back to peers page' to='/peers'>
-            Go to peers page
-          </Button>
-        </PageHeader>
-        {/* Create Peer form */}
-        <Form method='post' replace>
-          <div className='px-6 pt-5'>
-            <ErrorPanel errors={response?.errors.message} />
-          </div>
+    <>
+      <RedirectDialog
+        ref={dialogRef}
+        title='Before You Continue'
+        message='Please note, the required asset type must already exist before you can create a peer.'
+        redirectPath={'/assets/create'}
+        redirectButtonText={'Create Asset'}
+      ></RedirectDialog>
 
-          <fieldset disabled={isSubmitting}>
-            {/* Peer General Info */}
-            <div className='grid grid-cols-1 px-0 py-3 gap-6 md:grid-cols-3 border-b border-pearl'>
-              <div className='col-span-1 pt-3'>
-                <h3 className='text-lg font-medium'>General Information</h3>
-              </div>
-              <div className='md:col-span-2 bg-white rounded-md shadow-md'>
-                <div className='w-full p-4 space-y-3'>
-                  <Input
-                    name='name'
-                    label='Name'
-                    placeholder='Peer name'
-                    error={response?.errors?.fieldErrors.name}
-                    description={
-                      <>
-                        The name of the{' '}
-                        <a
-                          className='default-link'
-                          href='https://rafiki.dev/resources/glossary#peer'
-                        >
-                          peer
-                        </a>{' '}
-                        to be added.
-                      </>
-                    }
-                  />
-                  <Input
-                    name='staticIlpAddress'
-                    label='Static ILP Address'
-                    placeholder='ILP Address'
-                    required
-                    error={response?.errors?.fieldErrors?.staticIlpAddress}
-                    description={
-                      <>
-                        {"The peer's "}
-                        <a
-                          className='default-link'
-                          href='https://interledger.org/developers/rfcs/ilp-addresses/'
-                        >
-                          address on the Interledger network.
-                        </a>
-                      </>
-                    }
-                  />
-                  <Input
-                    name='maxPacketAmount'
-                    label='Max Packet Amount'
-                    placeholder='Max Packet Amount'
-                    error={response?.errors?.fieldErrors?.maxPacketAmount}
-                    description={
-                      <>
-                        The maximum amount of value that can be sent in a single{' '}
-                        <a
-                          className='default-link'
-                          href='https://interledger.org/developers/rfcs/stream-protocol/#35-packets-and-frames'
-                        >
-                          Interledger STREAM Packet
-                        </a>
-                        .
-                      </>
-                    }
-                  />
+      <div className='pt-4 flex flex-col space-y-4'>
+        <div className='flex flex-col rounded-md bg-offwhite px-6'>
+          <PageHeader>
+            <h3 className='text-xl'>Create Peer</h3>
+            <Button aria-label='go back to peers page' to='/peers'>
+              Go to peers page
+            </Button>
+          </PageHeader>
+          {/* Create Peer form */}
+          <Form method='post' replace>
+            <div className='px-6 pt-5'>
+              <ErrorPanel errors={response?.errors.message} />
+            </div>
+
+            <fieldset disabled={isSubmitting}>
+              {/* Peer General Info */}
+              <div className='grid grid-cols-1 px-0 py-3 gap-6 md:grid-cols-3 border-b border-pearl'>
+                <div className='col-span-1 pt-3'>
+                  <h3 className='text-lg font-medium'>General Information</h3>
+                </div>
+                <div className='md:col-span-2 bg-white rounded-md shadow-md'>
+                  <div className='w-full p-4 space-y-3'>
+                    <Input
+                      name='name'
+                      label='Name'
+                      placeholder='Peer name'
+                      error={response?.errors?.fieldErrors.name}
+                      description={
+                        <>
+                          The name of the{' '}
+                          <a
+                            className='default-link'
+                            href='https://rafiki.dev/resources/glossary#peer'
+                          >
+                            peer
+                          </a>{' '}
+                          to be added.
+                        </>
+                      }
+                    />
+                    <Input
+                      name='staticIlpAddress'
+                      label='Static ILP Address'
+                      placeholder='ILP Address'
+                      required
+                      error={response?.errors?.fieldErrors?.staticIlpAddress}
+                      description={
+                        <>
+                          {"The peer's "}
+                          <a
+                            className='default-link'
+                            href='https://interledger.org/developers/rfcs/ilp-addresses/'
+                          >
+                            address on the Interledger network.
+                          </a>
+                        </>
+                      }
+                    />
+                    <Input
+                      name='maxPacketAmount'
+                      label='Max Packet Amount'
+                      placeholder='Max Packet Amount'
+                      error={response?.errors?.fieldErrors?.maxPacketAmount}
+                      description={
+                        <>
+                          The maximum amount of value that can be sent in a
+                          single{' '}
+                          <a
+                            className='default-link'
+                            href='https://interledger.org/developers/rfcs/stream-protocol/#35-packets-and-frames'
+                          >
+                            Interledger STREAM Packet
+                          </a>
+                          .
+                        </>
+                      }
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-            {/* Peer General Info - END */}
-            {/* Peer HTTP Info */}
-            <div className='grid grid-cols-1 py-3 gap-6 md:grid-cols-3 border-b border-pearl'>
-              <div className='col-span-1 pt-3'>
-                <h3 className='text-lg font-medium'>HTTP Information</h3>
-              </div>
-              <div className='md:col-span-2 bg-white rounded-md shadow-md'>
-                <div className='w-full p-4 space-y-3'>
-                  <Input
-                    name='incomingAuthTokens'
-                    label='Incoming Auth Tokens'
-                    placeholder='Accepts a comma separated list of tokens'
-                    error={response?.errors?.fieldErrors?.incomingAuthTokens}
-                    description={
-                      <>
-                        List of valid tokens to accept when receiving incoming{' '}
-                        <a
-                          className='default-link'
-                          href='https://rafiki.dev/integration/services/backend-service/#interledger-connector'
-                        >
-                          ILP packets
-                        </a>{' '}
-                        from the peer.
-                      </>
-                    }
-                  />
-                  <Input
-                    name='outgoingAuthToken'
-                    label='Outgoing Auth Token'
-                    placeholder='Outgoing HTTP Auth Token'
-                    required
-                    error={response?.errors?.fieldErrors?.outgoingAuthToken}
-                    description={
-                      <>
-                        Valid auth token to present when sending outgoing{' '}
-                        <a
-                          className='default-link'
-                          href='https://rafiki.dev/integration/services/backend-service/#interledger-connector'
-                        >
-                          ILP packets
-                        </a>{' '}
-                        to the peer.
-                      </>
-                    }
-                  />
-                  <Input
-                    name='outgoingEndpoint'
-                    label='Outgoing Endpoint'
-                    placeholder='Outgoing HTTP Endpoint'
-                    required
-                    error={response?.errors?.fieldErrors?.outgoingEndpoint}
-                    description={
-                      <>
-                        Endpoint on the peer to which outgoing ILP packets will
-                        be sent.
-                      </>
-                    }
-                  />
+              {/* Peer General Info - END */}
+              {/* Peer HTTP Info */}
+              <div className='grid grid-cols-1 py-3 gap-6 md:grid-cols-3 border-b border-pearl'>
+                <div className='col-span-1 pt-3'>
+                  <h3 className='text-lg font-medium'>HTTP Information</h3>
+                </div>
+                <div className='md:col-span-2 bg-white rounded-md shadow-md'>
+                  <div className='w-full p-4 space-y-3'>
+                    <Input
+                      name='incomingAuthTokens'
+                      label='Incoming Auth Tokens'
+                      placeholder='Accepts a comma separated list of tokens'
+                      error={response?.errors?.fieldErrors?.incomingAuthTokens}
+                      description={
+                        <>
+                          List of valid tokens to accept when receiving incoming{' '}
+                          <a
+                            className='default-link'
+                            href='https://rafiki.dev/integration/services/backend-service/#interledger-connector'
+                          >
+                            ILP packets
+                          </a>{' '}
+                          from the peer.
+                        </>
+                      }
+                    />
+                    <Input
+                      name='outgoingAuthToken'
+                      label='Outgoing Auth Token'
+                      placeholder='Outgoing HTTP Auth Token'
+                      required
+                      error={response?.errors?.fieldErrors?.outgoingAuthToken}
+                      description={
+                        <>
+                          Valid auth token to present when sending outgoing{' '}
+                          <a
+                            className='default-link'
+                            href='https://rafiki.dev/integration/services/backend-service/#interledger-connector'
+                          >
+                            ILP packets
+                          </a>{' '}
+                          to the peer.
+                        </>
+                      }
+                    />
+                    <Input
+                      name='outgoingEndpoint'
+                      label='Outgoing Endpoint'
+                      placeholder='Outgoing HTTP Endpoint'
+                      required
+                      error={response?.errors?.fieldErrors?.outgoingEndpoint}
+                      description={
+                        <>
+                          Endpoint on the peer to which outgoing ILP packets
+                          will be sent.
+                        </>
+                      }
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-            {/* Peer HTTP Info - END */}
-            {/* Peer Asset */}
-            <div className='grid grid-cols-1 py-3 gap-6 md:grid-cols-3 border-b border-pearl'>
-              <div className='col-span-1 pt-3'>
-                <h3 className='text-lg font-medium'>Asset Information</h3>
-              </div>
-              <div className='md:col-span-2 bg-white rounded-md shadow-md'>
-                <div className='w-full p-4 space-y-3'>
-                  <Select
-                    options={assets.map((asset) => ({
-                      value: asset.node.id,
-                      label: `${asset.node.code} (Scale: ${asset.node.scale})`
-                    }))}
-                    error={response?.errors.fieldErrors.asset}
-                    name='asset'
-                    placeholder='Select asset...'
-                    label='Asset'
-                    description={
-                      <>
-                        The type of{' '}
-                        <a
-                          className='default-link'
-                          href='https://rafiki.dev/overview/concepts/accounting#assets'
-                        >
-                          asset
-                        </a>{' '}
-                        that is sent to & received from the peer.
-                      </>
-                    }
-                    required
-                  />
+              {/* Peer HTTP Info - END */}
+              {/* Peer Asset */}
+              <div className='grid grid-cols-1 py-3 gap-6 md:grid-cols-3 border-b border-pearl'>
+                <div className='col-span-1 pt-3'>
+                  <h3 className='text-lg font-medium'>Asset Information</h3>
+                </div>
+                <div className='md:col-span-2 bg-white rounded-md shadow-md'>
+                  <div className='w-full p-4 space-y-3'>
+                    <Select
+                      options={assets.map((asset) => ({
+                        value: asset.node.id,
+                        label: `${asset.node.code} (Scale: ${asset.node.scale})`
+                      }))}
+                      error={response?.errors.fieldErrors.asset}
+                      name='asset'
+                      placeholder='Select asset...'
+                      label='Asset'
+                      description={
+                        <>
+                          The type of{' '}
+                          <a
+                            className='default-link'
+                            href='https://rafiki.dev/overview/concepts/accounting#assets'
+                          >
+                            asset
+                          </a>{' '}
+                          that is sent to & received from the peer.
+                        </>
+                      }
+                      required
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-            {/* Peer Asset - End */}
-            <div className='flex justify-end py-3'>
-              <Button aria-label='create peer' type='submit'>
-                {isSubmitting ? 'Creating peer ...' : 'Create'}
-              </Button>
-            </div>
-          </fieldset>
-        </Form>
-        {/* Create Peer form - END */}
+              {/* Peer Asset - End */}
+              <div className='flex justify-end py-3'>
+                <Button aria-label='create peer' type='submit'>
+                  {isSubmitting ? 'Creating peer ...' : 'Create'}
+                </Button>
+              </div>
+            </fieldset>
+          </Form>
+          {/* Create Peer form - END */}
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Fixed error when trying to create an peer with no existing assets.
- Added a dialog when opening the create peer page that can route the user to create asset page.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3046 
When trying to create a peer with no existing assets, a 'cannot read properties of undefined' error occurred, because there was a mapper on the assets list. I fixed this by updating `loadAssets` to return `[]` in this case.

However, the user might start filling in the form and when he gets to the assets select field (which is the last one) there will be nothing. To prevent this, I added a dialog that warns the user that an asset should be created first and can go to create assets page.

<img width="1512" alt="No assets dialog" src="https://github.com/user-attachments/assets/dc138cfe-db3b-490c-843b-76108a985266">

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
