### PR TITLE
feat(auth): return GNAP 404 error if token cannot be rotated

### DIFF
--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -484,12 +484,12 @@ describe('Access Token Routes', (): void => {
       )
     })
 
-    test('Returns status 400 if could not rotate token', async (): Promise<void> => {
+    test('Returns status 404 if could not rotate token', async (): Promise<void> => {
       const ctx = createTokenHttpSigContext(token, grant)
       jest.spyOn(accessTokenService, 'rotate').mockResolvedValueOnce(undefined)
 
       await expect(accessTokenRoutes.rotate(ctx)).rejects.toMatchObject({
-        status: 400,
+        status: 404,
         code: GNAPErrorCode.InvalidRotation,
         message: 'invalid access token'
       })

--- a/packages/auth/src/accessToken/routes.ts
+++ b/packages/auth/src/accessToken/routes.ts
@@ -164,7 +164,7 @@ async function rotateToken(
     const errorMessage =
       error instanceof Error ? error.message : 'Could not rotate token'
     throw new GNAPServerRouteError(
-      400,
+      404,
       GNAPErrorCode.InvalidRotation,
       errorMessage
     )


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Instead of returning 400 return 404 if token cannot be rotated

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #3100

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
