### PR TITLE
fix(backend): update packet expiry error handling

### DIFF
--- a/packages/backend/src/payment-method/ilp/connector/core/middleware/expire.ts
+++ b/packages/backend/src/payment-method/ilp/connector/core/middleware/expire.ts
@@ -12,7 +12,7 @@ export function createOutgoingExpireMiddleware() {
     { request, services: { logger } }: ILPContext,
     next: () => Promise<void>
   ): Promise<void> => {
-    const { expiresAt } = request.prepare
+    const { expiresAt, destination } = request.prepare
     const duration = expiresAt.getTime() - Date.now()
 
     let timeoutId
@@ -30,7 +30,7 @@ export function createOutgoingExpireMiddleware() {
       await Promise.race([next(), timeout()])
     } catch (error) {
       if (error instanceof TransferTimedOutError) {
-        logger.debug({ request }, 'packet expired')
+        logger.debug({ expiresAt, destination }, 'packet expired')
       }
       throw error
     } finally {


### PR DESCRIPTION
## Changes proposed in this pull request

- This PR updates error handling logic of packet expiry middleware so that node process does not crash/exit if a packet from the sending connector expires.


## Context

- fixes #3075 

## Checklist

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
