### PR TITLE
build: containers will now run as the non-root rafiki user

### DIFF
--- a/packages/auth/Dockerfile.dev
+++ b/packages/auth/Dockerfile.dev
@@ -1,24 +1,37 @@
 FROM node:20-alpine3.20
 
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-RUN corepack enable
+# Install Corepack and pnpm as the Rafiki user
+USER rafiki
+RUN mkdir -p /home/rafiki/.local/bin
+ENV PATH="/home/rafiki/.local/bin:$PATH"
+RUN corepack enable --install-directory ~/.local/bin
 RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 
+# Fetch the pnpm dependencies, but use a local cache.
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
+# Copy the source code and chown the relevant folders back to the Rafiki user
+USER root
 COPY . ./
+RUN chown -v -R rafiki:rafiki /home/rafiki/localenv
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+RUN chown -v -R rafiki:rafiki /home/rafiki/test
 
+# As the Rafiki user, install the rest of the dependencies and build the source code
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
     --offline \
     --frozen-lockfile
-
 RUN pnpm --filter auth build:deps
 
 CMD pnpm --filter auth dev

--- a/packages/auth/Dockerfile.prod
+++ b/packages/auth/Dockerfile.prod
@@ -1,36 +1,26 @@
 FROM node:20-alpine3.20 AS base
 
-RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-# As the Rafiki user, install Corepack and pnpm
-USER rafiki
-RUN mkdir -p /home/rafiki/.local/bin
-ENV PATH="/home/rafiki/.local/bin:$PATH"
-ENV PNPM_HOME="/home/rafiki/pnpm"
+ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable --install-directory ~/.local/bin
+
+RUN corepack enable
 RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml ./
 
-# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
 FROM base AS prod-deps
-# Copy the package.json files and install the production dependencies
+
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY packages/auth/knexfile.js ./packages/auth/knexfile.js
 COPY packages/auth/package.json ./packages/auth/package.json
 COPY packages/token-introspection/package.json ./packages/token-introspection/package.json
-# Chown the copied packages folder back to the Rafiki user
-USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
 
-# As the Rafiki user, install the production dependencies
-USER rafiki
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
@@ -46,10 +36,6 @@ COPY package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json .
 COPY packages/auth ./packages/auth
 COPY packages/token-introspection ./packages/token-introspection
 
-USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
-
-USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
@@ -75,7 +61,10 @@ COPY --from=builder /home/rafiki/packages/auth/dist ./packages/auth/dist
 COPY --from=builder /home/rafiki/packages/token-introspection/dist ./packages/token-introspection/dist
 
 USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+# For additional paranoia, we make it so that the Rafiki user has no write access to the packages
+RUN chown -R :rafiki /home/rafiki/packages
+RUN chmod -R 750 /home/rafiki/packages
 
 USER rafiki
 CMD ["node", "/home/rafiki/packages/auth/dist/index.js"]

--- a/packages/auth/Dockerfile.prod
+++ b/packages/auth/Dockerfile.prod
@@ -1,26 +1,36 @@
 FROM node:20-alpine3.20 AS base
 
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-ENV PNPM_HOME="/pnpm"
+# As the Rafiki user, install Corepack and pnpm
+USER rafiki
+RUN mkdir -p /home/rafiki/.local/bin
+ENV PATH="/home/rafiki/.local/bin:$PATH"
+ENV PNPM_HOME="/home/rafiki/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-
-RUN corepack enable
+RUN corepack enable --install-directory ~/.local/bin
 RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml ./
 
+# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
 FROM base AS prod-deps
-
+# Copy the package.json files and install the production dependencies
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY packages/auth/knexfile.js ./packages/auth/knexfile.js
 COPY packages/auth/package.json ./packages/auth/package.json
 COPY packages/token-introspection/package.json ./packages/token-introspection/package.json
+# Chown the copied packages folder back to the Rafiki user
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
 
+# As the Rafiki user, install the production dependencies
+USER rafiki
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
@@ -36,6 +46,10 @@ COPY package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json .
 COPY packages/auth ./packages/auth
 COPY packages/token-introspection ./packages/token-introspection
 
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
@@ -44,6 +58,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 RUN pnpm --filter auth build
 
 FROM node:20-alpine3.20 AS runner
+
+RUN adduser -D rafiki
 
 WORKDIR /home/rafiki
 
@@ -58,4 +74,8 @@ COPY --from=builder /home/rafiki/packages/auth/migrations/ ./packages/auth/migra
 COPY --from=builder /home/rafiki/packages/auth/dist ./packages/auth/dist
 COPY --from=builder /home/rafiki/packages/token-introspection/dist ./packages/token-introspection/dist
 
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+USER rafiki
 CMD ["node", "/home/rafiki/packages/auth/dist/index.js"]

--- a/packages/backend/Dockerfile.dev
+++ b/packages/backend/Dockerfile.dev
@@ -1,24 +1,35 @@
 FROM node:20-alpine3.20
 
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-RUN corepack enable
+# Install Corepack and pnpm as the Rafiki user
+USER rafiki
+RUN mkdir -p /home/rafiki/.local/bin
+ENV PATH="/home/rafiki/.local/bin:$PATH"
+RUN corepack enable --install-directory ~/.local/bin
 RUN corepack prepare pnpm@8.7.4 --activate
-
 COPY pnpm-lock.yaml package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 
+# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
+# Copy the source code and chown the relevant folders back to the Rafiki user
+USER root
 COPY . ./
+RUN chown -v -R rafiki:rafiki /home/rafiki/localenv
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+RUN chown -v -R rafiki:rafiki /home/rafiki/test
 
+# As the Rafiki user, install the rest of the dependencies and build the source code
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
     --offline \
     --frozen-lockfile
-
 RUN pnpm --filter backend build:deps
 
 CMD pnpm --filter backend dev

--- a/packages/backend/Dockerfile.prod
+++ b/packages/backend/Dockerfile.prod
@@ -1,26 +1,36 @@
 FROM node:20-alpine3.20 AS base
 
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-
-RUN corepack enable
+# As the Rafiki user, install Corepack and pnpm
+USER rafiki
+RUN mkdir -p /home/rafiki/.local/bin
+ENV PATH="/home/rafiki/.local/bin:$PATH"
+RUN corepack enable --install-directory ~/.local/bin
 RUN corepack prepare pnpm@8.7.4 --activate
+
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 
 COPY pnpm-lock.yaml ./
 
+# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
 FROM base AS prod-deps
-
+# Copy the package.json files and install the production dependencies
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY packages/backend/knexfile.js ./packages/backend/knexfile.js
 COPY packages/backend/package.json ./packages/backend/package.json
 COPY packages/token-introspection/package.json ./packages/token-introspection/package.json
 
+# Chown the copied packages folder back to the Rafiki user
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+# As the Rafiki user, install the production dependencies
+USER rafiki
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
@@ -32,10 +42,16 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 
 FROM base AS builder   
 
+# Copy the source code and chown the relevant folders into the builder
 COPY package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 COPY packages/backend ./packages/backend
 COPY packages/token-introspection ./packages/token-introspection
 
+# Make sure they are owned by Rafiki
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
@@ -45,6 +61,8 @@ RUN pnpm --filter backend build
 
 FROM node:20-alpine3.20 AS runner
 
+# Since this is from a fresh image, we need to first create the Rafiki user
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
 COPY --from=prod-deps /home/rafiki/node_modules ./node_modules
@@ -59,4 +77,8 @@ COPY --from=builder /home/rafiki/packages/backend/dist ./packages/backend/dist
 COPY --from=builder /home/rafiki/packages/token-introspection/dist ./packages/token-introspection/dist
 COPY --from=builder /home/rafiki/packages/backend/knexfile.js ./packages/backend/knexfile.js
 
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+USER rafiki
 CMD ["node", "-r", "/home/rafiki/packages/backend/dist/telemetry/index.js", "/home/rafiki/packages/backend/dist/index.js"]

--- a/packages/backend/Dockerfile.prod
+++ b/packages/backend/Dockerfile.prod
@@ -1,36 +1,26 @@
 FROM node:20-alpine3.20 AS base
 
-RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-# As the Rafiki user, install Corepack and pnpm
-USER rafiki
-RUN mkdir -p /home/rafiki/.local/bin
-ENV PATH="/home/rafiki/.local/bin:$PATH"
-RUN corepack enable --install-directory ~/.local/bin
-RUN corepack prepare pnpm@8.7.4 --activate
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
 
-COPY pnpm-lock.yaml package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
+RUN corepack enable
+RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml ./
 
-# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
 FROM base AS prod-deps
-# Copy the package.json files and install the production dependencies
+
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY packages/backend/knexfile.js ./packages/backend/knexfile.js
 COPY packages/backend/package.json ./packages/backend/package.json
 COPY packages/token-introspection/package.json ./packages/token-introspection/package.json
 
-# Chown the copied packages folder back to the Rafiki user
-USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
-# As the Rafiki user, install the production dependencies
-USER rafiki
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
@@ -42,16 +32,10 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 
 FROM base AS builder   
 
-# Copy the source code and chown the relevant folders into the builder
 COPY package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 COPY packages/backend ./packages/backend
 COPY packages/token-introspection ./packages/token-introspection
 
-# Make sure they are owned by Rafiki
-USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
-
-USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
@@ -78,7 +62,10 @@ COPY --from=builder /home/rafiki/packages/token-introspection/dist ./packages/to
 COPY --from=builder /home/rafiki/packages/backend/knexfile.js ./packages/backend/knexfile.js
 
 USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+# For additional paranoia, we make it so that the Rafiki user has no write access to the packages
+RUN chown -R :rafiki /home/rafiki/packages
+RUN chmod -R 750 /home/rafiki/packages
 
 USER rafiki
 CMD ["node", "-r", "/home/rafiki/packages/backend/dist/telemetry/index.js", "/home/rafiki/packages/backend/dist/index.js"]

--- a/packages/frontend/Dockerfile.dev
+++ b/packages/frontend/Dockerfile.dev
@@ -1,16 +1,24 @@
 FROM node:20-alpine3.20 AS base
 
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-
-RUN corepack enable
+# Install Corepack and pnpm as the Rafiki user
+USER rafiki
+RUN mkdir -p /home/rafiki/.local/bin
+ENV PATH="/home/rafiki/.local/bin:$PATH"
+RUN corepack enable --install-directory ~/.local/bin
 RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 COPY packages/frontend ./packages/frontend
 
+# Chown the copied packages folder back to the Rafiki user
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+# Fetch the pnpm dependencies, but use a local cache.
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"

--- a/packages/frontend/Dockerfile.prod
+++ b/packages/frontend/Dockerfile.prod
@@ -52,7 +52,8 @@ COPY --from=builder /home/rafiki/packages/frontend/build ./packages/frontend/bui
 COPY --from=builder /home/rafiki/packages/frontend/public ./packages/frontend/public
 
 USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+RUN chown -R :rafiki /home/rafiki/packages
+RUN chmod -R 750 /home/rafiki/packages
 
 USER rafiki
 

--- a/packages/frontend/Dockerfile.prod
+++ b/packages/frontend/Dockerfile.prod
@@ -2,23 +2,33 @@ FROM node:20-alpine3.20 AS base
 
 WORKDIR /home/rafiki
 
-ENV PNPM_HOME="/pnpm"
+# As the Rafiki user, install Corepack and pnpm
+USER rafiki
+RUN mkdir -p /home/rafiki/.local/bin
+ENV PATH="/home/rafiki/.local/bin:$PATH"
+ENV PNPM_HOME="/home/rafiki/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-
-RUN corepack enable
+RUN corepack enable --install-directory ~/.local/bin
 RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml ./
 
+# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
 FROM base AS prod-deps
 
+# Copy the package.json files and install the production dependencies
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY packages/frontend/package.json ./packages/frontend/package.json
 
+# Chown the copied packages folder back to the Rafiki user
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+# As the Rafiki user, install the production dependencies
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
@@ -33,6 +43,10 @@ FROM base AS builder
 COPY package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 COPY packages/frontend ./packages/frontend
 
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+# As the Rafiki user, install the development dependencies and build the source code
+USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \
@@ -41,7 +55,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 RUN pnpm --filter frontend build
 
 FROM node:20-alpine3.20 AS runner
-
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
 COPY --from=prod-deps /home/rafiki/node_modules ./node_modules
@@ -50,6 +64,11 @@ COPY --from=prod-deps /home/rafiki/packages/frontend/package.json ./packages/fro
 
 COPY --from=builder /home/rafiki/packages/frontend/build ./packages/frontend/build
 COPY --from=builder /home/rafiki/packages/frontend/public ./packages/frontend/public
+
+USER root
+RUN chown -v -R rafiki:rafiki /home/rafiki/packages
+
+USER rafiki
 
 WORKDIR /home/rafiki/packages/frontend
 CMD ["sh", "./node_modules/.bin/remix-serve", "./build/index.js"]

--- a/packages/frontend/Dockerfile.prod
+++ b/packages/frontend/Dockerfile.prod
@@ -1,5 +1,6 @@
 FROM node:20-alpine3.20 AS base
 
+RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
 # As the Rafiki user, install Corepack and pnpm
@@ -29,6 +30,7 @@ USER root
 RUN chown -v -R rafiki:rafiki /home/rafiki/packages
 
 # As the Rafiki user, install the production dependencies
+USER rafiki
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \

--- a/packages/frontend/Dockerfile.prod
+++ b/packages/frontend/Dockerfile.prod
@@ -1,36 +1,24 @@
 FROM node:20-alpine3.20 AS base
 
-RUN adduser -D rafiki
 WORKDIR /home/rafiki
 
-# As the Rafiki user, install Corepack and pnpm
-USER rafiki
-RUN mkdir -p /home/rafiki/.local/bin
-ENV PATH="/home/rafiki/.local/bin:$PATH"
-ENV PNPM_HOME="/home/rafiki/pnpm"
+ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable --install-directory ~/.local/bin
+
+RUN corepack enable
 RUN corepack prepare pnpm@8.7.4 --activate
 
 COPY pnpm-lock.yaml ./
 
-# Fetch the pnpm dependencies, but use a local cache.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm fetch \
     | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
 FROM base AS prod-deps
 
-# Copy the package.json files and install the production dependencies
 COPY package.json pnpm-workspace.yaml .npmrc ./
 COPY packages/frontend/package.json ./packages/frontend/package.json
 
-# Chown the copied packages folder back to the Rafiki user
-USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
-
-# As the Rafiki user, install the production dependencies
-USER rafiki
 RUN pnpm clean
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
@@ -45,10 +33,6 @@ FROM base AS builder
 COPY package.json pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 COPY packages/frontend ./packages/frontend
 
-USER root
-RUN chown -v -R rafiki:rafiki /home/rafiki/packages
-# As the Rafiki user, install the development dependencies and build the source code
-USER rafiki
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install \
     --recursive \


### PR DESCRIPTION
## Changes proposed in this pull request
- Modified both the dev and prod Dockerfiles of all the services to run as the non-root Rafiki user.
- To achieve this we have to chown the packages back to rafiki after each copy to ensure the ownership is correct. Otherwise the build process create the symlinks it wants to make.

## Context
As part of me trying to get into understanding the build pipeline, I noticed that the docker containers currently run as the root user which can be considered a security issue.

- For dev builds we have to switch between Rafiki and root user during the build process to ensure everything links correctly
- For prod builds, only the run-container will now run as Rafiki user, but with read-only access to the packages folder

Just to make it clear, after the change this is the status:
```sh
$ docker exec rafiki-happy-life-backend-1 touch /etc/danger-zone
touch: /etc/danger-zone: Permission denied
$ docker exec rafiki-happy-life-backend-1 whoami
rafiki
```


## Checklist
- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Make sure that all checks pass
- [x] Bruno collection updated (if necessary)
- [x] Documentation issue created with `user-docs` label (if necessary)
- [x] OpenAPI specs updated (if necessary)
