### PR TITLE
feat(frontend): add operator-contextual dropdowns for tenant selection

### DIFF
--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -124,7 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
-  tenantId?: Maybe<Scalars['String']['output']>;
+  tenantId: Scalars['ID']['output'];
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -201,7 +201,7 @@ export type CreateAssetInput = {
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
   /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
-  tenantId?: InputMaybe<Scalars['String']['input']>;
+  tenantId?: InputMaybe<Scalars['ID']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };
@@ -2176,7 +2176,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tenantId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -124,6 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
+  tenantId?: Maybe<Scalars['String']['output']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -2173,6 +2174,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
+  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -200,6 +200,8 @@ export type CreateAssetInput = {
   liquidityThreshold?: InputMaybe<Scalars['UInt64']['input']>;
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
+  /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
+  tenantId?: InputMaybe<Scalars['String']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -718,6 +718,18 @@
             "deprecationReason": null
           },
           {
+            "name": "tenantId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "withdrawalThreshold",
             "description": "Minimum amount of liquidity that can be withdrawn from the asset.",
             "args": [],

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -722,9 +722,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1135,7 +1139,7 @@
             "description": "Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature.",
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "ID",
               "ofType": null
             },
             "defaultValue": null,

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1131,6 +1131,18 @@
             "deprecationReason": null
           },
           {
+            "name": "tenantId",
+            "description": "Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "withdrawalThreshold",
             "description": "Minimum amount of liquidity that can be withdrawn from the asset.",
             "type": {

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -124,7 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
-  tenantId?: Maybe<Scalars['String']['output']>;
+  tenantId: Scalars['ID']['output'];
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -201,7 +201,7 @@ export type CreateAssetInput = {
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
   /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
-  tenantId?: InputMaybe<Scalars['String']['input']>;
+  tenantId?: InputMaybe<Scalars['ID']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };
@@ -2176,7 +2176,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tenantId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -124,6 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
+  tenantId?: Maybe<Scalars['String']['output']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -2173,6 +2174,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
+  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -200,6 +200,8 @@ export type CreateAssetInput = {
   liquidityThreshold?: InputMaybe<Scalars['UInt64']['input']>;
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
+  /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
+  tenantId?: InputMaybe<Scalars['String']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };

--- a/packages/backend/src/graphql/resolvers/asset.ts
+++ b/packages/backend/src/graphql/resolvers/asset.ts
@@ -23,14 +23,14 @@ export const getAssets: QueryResolvers<TenantedApolloContext>['assets'] =
     const assets = await assetService.getPage({
       pagination,
       sortOrder: order,
-      tenantId: ctx.tenant.id
+      tenantId: ctx.isOperator ? undefined : ctx.tenant.id
     })
     const pageInfo = await getPageInfo({
       getPage: (pagination: Pagination, sortOrder?: SortOrder) =>
         assetService.getPage({
           pagination,
           sortOrder,
-          tenantId: ctx.tenant.id
+          tenantId: ctx.isOperator ? undefined : ctx.tenant.id
         }),
       page: assets,
       sortOrder: order
@@ -203,5 +203,6 @@ export const assetToGraphql = (asset: Asset): SchemaAsset => ({
   scale: asset.scale,
   withdrawalThreshold: asset.withdrawalThreshold,
   liquidityThreshold: asset.liquidityThreshold,
-  createdAt: new Date(+asset.createdAt).toISOString()
+  createdAt: new Date(+asset.createdAt).toISOString(),
+  tenantId: asset.tenantId
 })

--- a/packages/backend/src/graphql/resolvers/asset.ts
+++ b/packages/backend/src/graphql/resolvers/asset.ts
@@ -91,7 +91,6 @@ export const createAsset: MutationResolvers<ForTenantIdContext>['createAsset'] =
           }
         }
       )
-    ctx.logger.info({ tenantId }, 'tenantId for create asset')
     const assetService = await ctx.container.use('assetService')
     const assetOrError = await assetService.create({
       ...args.input,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -675,7 +675,7 @@ type Asset implements Model {
   ): FeesConnection
   "The date and time when the asset was created."
   createdAt: String!
-  tenantId: String
+  tenantId: ID!
 }
 
 enum SortOrder {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -394,6 +394,8 @@ input CreateAssetInput {
   liquidityThreshold: UInt64
   "Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency)."
   idempotencyKey: String
+  "Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature."
+  tenantId: ID
 }
 
 input UpdateAssetInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -673,6 +673,7 @@ type Asset implements Model {
   ): FeesConnection
   "The date and time when the asset was created."
   createdAt: String!
+  tenantId: String
 }
 
 enum SortOrder {

--- a/packages/frontend/app/components/ui/Select.tsx
+++ b/packages/frontend/app/components/ui/Select.tsx
@@ -21,6 +21,8 @@ type SelectProps = {
   error?: string | string[]
   defaultValue?: SelectOption
   description?: ReactNode
+  onChange?: (value: React.SetStateAction<SelectOption | undefined>) => void
+  bringForward?: boolean
 }
 
 export const Select = ({
@@ -35,7 +37,9 @@ export const Select = ({
     label: '',
     value: ''
   },
-  description
+  description,
+  onChange,
+  bringForward
 }: SelectProps) => {
   const id = useId()
   const [internalValue, setInternalValue] = useState<SelectOption>(defaultValue)
@@ -54,13 +58,18 @@ export const Select = ({
   return (
     <Combobox
       value={internalValue}
-      onChange={setInternalValue}
+      onChange={(value) => {
+        setInternalValue(value)
+        if (onChange) {
+          onChange(value)
+        }
+      }}
       disabled={disabled}
     >
       {name ? (
         <input type='hidden' name={name} value={internalValue.value} />
       ) : null}
-      <div className='relative'>
+      <div className={`relative ${bringForward ? 'forward' : ''}`}>
         {label ? (
           <Combobox.Label as={Label} htmlFor={id} required={required}>
             {label}

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -200,6 +200,8 @@ export type CreateAssetInput = {
   liquidityThreshold?: InputMaybe<Scalars['UInt64']['input']>;
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
+  /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
+  tenantId?: InputMaybe<Scalars['String']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -124,7 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
-  tenantId?: Maybe<Scalars['String']['output']>;
+  tenantId: Scalars['ID']['output'];
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -201,7 +201,7 @@ export type CreateAssetInput = {
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
   /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
-  tenantId?: InputMaybe<Scalars['String']['input']>;
+  tenantId?: InputMaybe<Scalars['ID']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };
@@ -2176,7 +2176,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tenantId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2794,7 +2794,7 @@ export type ListAssetsQueryVariables = Exact<{
 }>;
 
 
-export type ListAssetsQuery = { __typename?: 'Query', assets: { __typename?: 'AssetsConnection', edges: Array<{ __typename?: 'AssetEdge', node: { __typename?: 'Asset', code: string, id: string, scale: number, withdrawalThreshold?: bigint | null, createdAt: string, tenantId?: string | null } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
+export type ListAssetsQuery = { __typename?: 'Query', assets: { __typename?: 'AssetsConnection', edges: Array<{ __typename?: 'AssetEdge', node: { __typename?: 'Asset', code: string, id: string, scale: number, withdrawalThreshold?: bigint | null, createdAt: string, tenantId: string } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
 
 export type CreateAssetMutationVariables = Exact<{
   input: CreateAssetInput;
@@ -2978,11 +2978,6 @@ export type GetTenantQueryVariables = Exact<{
 
 
 export type GetTenantQuery = { __typename?: 'Query', tenant: { __typename?: 'Tenant', id: string, email?: string | null, apiSecret: string, idpConsentUrl?: string | null, idpSecret?: string | null, publicName?: string | null, createdAt: string, deletedAt?: string | null } };
-
-export type WhoAmIQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type WhoAmIQuery = { __typename?: 'Query', whoami: { __typename?: 'WhoamiResponse', id: string, isOperator: boolean } };
 
 export type GetWalletAddressQueryVariables = Exact<{
   id: Scalars['String']['input'];

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -124,6 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
+  tenantId?: Maybe<Scalars['String']['output']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -2173,6 +2174,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
+  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -2790,7 +2792,7 @@ export type ListAssetsQueryVariables = Exact<{
 }>;
 
 
-export type ListAssetsQuery = { __typename?: 'Query', assets: { __typename?: 'AssetsConnection', edges: Array<{ __typename?: 'AssetEdge', node: { __typename?: 'Asset', code: string, id: string, scale: number, withdrawalThreshold?: bigint | null, createdAt: string } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
+export type ListAssetsQuery = { __typename?: 'Query', assets: { __typename?: 'AssetsConnection', edges: Array<{ __typename?: 'AssetEdge', node: { __typename?: 'Asset', code: string, id: string, scale: number, withdrawalThreshold?: bigint | null, createdAt: string, tenantId?: string | null } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
 
 export type CreateAssetMutationVariables = Exact<{
   input: CreateAssetInput;
@@ -2931,6 +2933,11 @@ export type WithdrawPeerLiquidityVariables = Exact<{
 
 
 export type WithdrawPeerLiquidity = { __typename?: 'Mutation', createPeerLiquidityWithdrawal?: { __typename?: 'LiquidityMutationResponse', success: boolean } | null };
+
+export type WhoAmIVariables = Exact<{ [key: string]: never; }>;
+
+
+export type WhoAmI = { __typename?: 'Query', whoami: { __typename?: 'WhoamiResponse', id: string, isOperator: boolean } };
 
 export type ListTenantsQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;

--- a/packages/frontend/app/lib/api/asset.server.ts
+++ b/packages/frontend/app/lib/api/asset.server.ts
@@ -123,6 +123,7 @@ export const listAssets = async (request: Request, args: QueryAssetsArgs) => {
               scale
               withdrawalThreshold
               createdAt
+              tenantId
             }
           }
           pageInfo {
@@ -139,8 +140,12 @@ export const listAssets = async (request: Request, args: QueryAssetsArgs) => {
   return response.data.assets
 }
 
-export const createAsset = async (request: Request, args: CreateAssetInput) => {
-  const apolloClient = await getApolloClient(request)
+export const createAsset = async (
+  request: Request,
+  args: CreateAssetInput,
+  tenantId?: string
+) => {
+  const apolloClient = await getApolloClient(request, tenantId)
   const response = await apolloClient.mutate<
     CreateAssetMutation,
     CreateAssetMutationVariables

--- a/packages/frontend/app/lib/api/asset.server.ts
+++ b/packages/frontend/app/lib/api/asset.server.ts
@@ -140,12 +140,8 @@ export const listAssets = async (request: Request, args: QueryAssetsArgs) => {
   return response.data.assets
 }
 
-export const createAsset = async (
-  request: Request,
-  args: CreateAssetInput,
-  tenantId?: string
-) => {
-  const apolloClient = await getApolloClient(request, tenantId)
+export const createAsset = async (request: Request, args: CreateAssetInput) => {
+  const apolloClient = await getApolloClient(request)
   const response = await apolloClient.mutate<
     CreateAssetMutation,
     CreateAssetMutationVariables

--- a/packages/frontend/app/lib/apollo.server.ts
+++ b/packages/frontend/app/lib/apollo.server.ts
@@ -23,7 +23,7 @@ BigInt.prototype.toJSON = function (this: bigint) {
   return this.toString()
 }
 
-async function createAuthLink(request: Request, tenantId?: string) {
+async function createAuthLink(request: Request) {
   return setContext(async (gqlRequest, { headers }) => {
     const timestamp = Date.now()
     const version = process.env.SIGNATURE_VERSION
@@ -53,10 +53,9 @@ async function createAuthLink(request: Request, tenantId?: string) {
       }
     }
 
-    const sessionTenantId = session.get('tenantId')
-    if (sessionTenantId || tenantId) {
-      // Use session tenant id if operator does not specify other tenant
-      link.headers['tenant-id'] = tenantId ?? sessionTenantId
+    const tenantId = session.get('tenantId')
+    if (tenantId) {
+      link.headers['tenant-id'] = tenantId
     }
 
     return link
@@ -67,9 +66,9 @@ const httpLink = createHttpLink({
   uri: process.env.GRAPHQL_URL
 })
 
-export async function getApolloClient(request: Request, tenantId?: string) {
+export async function getApolloClient(request: Request) {
   return new ApolloClient({
     cache: new InMemoryCache({}),
-    link: ApolloLink.from([await createAuthLink(request, tenantId), httpLink])
+    link: ApolloLink.from([await createAuthLink(request), httpLink])
   })
 }

--- a/packages/frontend/app/lib/validate.server.ts
+++ b/packages/frontend/app/lib/validate.server.ts
@@ -104,7 +104,8 @@ export const createAssetSchema = z
       })
       .int()
       .min(0, { message: 'Scale should be from 0 to 255' })
-      .max(255, { message: 'Scale should be from 0 to 255' })
+      .max(255, { message: 'Scale should be from 0 to 255' }),
+    tenantId: z.string().optional()
   })
   .merge(updateAssetSchema)
   .omit({ id: true })
@@ -118,7 +119,8 @@ export const amountSchema = z.coerce
 export const createWalletAddressSchema = z.object({
   name: z.string().min(1),
   publicName: z.string().optional(),
-  asset: z.string().uuid()
+  asset: z.string().uuid(),
+  tenantId: z.string().uuid().optional()
 })
 
 export const updateWalletAddressSchema = z

--- a/packages/frontend/app/routes/assets.create.tsx
+++ b/packages/frontend/app/routes/assets.create.tsx
@@ -24,16 +24,15 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const sessionTenantId = session.get('tenantId')
 
   const { isOperator } = await whoAmI(request)
-  let tenantIds
+  let tenants
   if (isOperator) {
-    const tenantEdges = await loadTenants(request)
-    tenantIds = tenantEdges.map((edge) => edge.node.id)
+    tenants = await loadTenants(request)
   }
-  return json({ tenantIds, sessionTenantId })
+  return json({ tenants, sessionTenantId })
 }
 
 export default function CreateAssetPage() {
-  const { tenantIds, sessionTenantId } = useLoaderData<typeof loader>()
+  const { tenants, sessionTenantId } = useLoaderData<typeof loader>()
   const response = useActionData<typeof action>()
   const { state } = useNavigation()
   const isSubmitting = state === 'submitting'
@@ -81,11 +80,11 @@ export default function CreateAssetPage() {
                     label='Withdrawal Threshold'
                     error={response?.errors.fieldErrors.withdrawalThreshold}
                   />
-                  {tenantIds && (
+                  {tenants && (
                     <Dropdown
-                      options={tenantIds.map((tenantId) => ({
-                        label: tenantId,
-                        value: tenantId
+                      options={tenants.map((tenant) => ({
+                        label: tenant.node.id,
+                        value: `${tenant.node.id} ${tenant.node.publicName ? `(${tenant.node.publicName})` : ''}`
                       }))}
                       name='tenantId'
                       placeholder='Select tenant...'

--- a/packages/frontend/app/routes/assets.create.tsx
+++ b/packages/frontend/app/routes/assets.create.tsx
@@ -6,7 +6,7 @@ import {
   useNavigation
 } from '@remix-run/react'
 import { PageHeader } from '~/components'
-import { Button, Dropdown, ErrorPanel, Input } from '~/components/ui'
+import { Button, Select, ErrorPanel, Input } from '~/components/ui'
 import { createAsset } from '~/lib/api/asset.server'
 import { messageStorage, setMessageAndRedirect } from '~/lib/message.server'
 import { createAssetSchema } from '~/lib/validate.server'
@@ -81,10 +81,10 @@ export default function CreateAssetPage() {
                     error={response?.errors.fieldErrors.withdrawalThreshold}
                   />
                   {tenants && (
-                    <Dropdown
+                    <Select
                       options={tenants.map((tenant) => ({
-                        label: tenant.node.id,
-                        value: `${tenant.node.id} ${tenant.node.publicName ? `(${tenant.node.publicName})` : ''}`
+                        label: `${tenant.node.id}${tenant.node.publicName ? ` (${tenant.node.publicName})` : ''}`,
+                        value: tenant.node.id
                       }))}
                       name='tenantId'
                       placeholder='Select tenant...'
@@ -130,8 +130,6 @@ export async function action({ request }: ActionFunctionArgs) {
     return json({ errors }, { status: 400 })
   }
 
-  // Make input fields match GraphQL schema
-  delete result.data.tenantId
   const response = await createAsset(request, {
     ...result.data,
     ...(result.data.withdrawalThreshold

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -224,7 +224,7 @@ export default function CreatePeerPage() {
                       <Select
                         options={tenants.map((tenant) => ({
                           value: tenant.node.id,
-                          label: tenant.node.id
+                          label: `${tenant.node.id} ${tenant.node.publicName ? `(${tenant.node.publicName})` : ''}`
                         }))}
                         name='tenantId'
                         placeholder='Select tenant...'

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -10,6 +10,7 @@ import {
   useNavigation
 } from '@remix-run/react'
 import { PageHeader } from '~/components/PageHeader'
+import type { SelectOption } from '~/components/ui'
 import { Button, ErrorPanel, Input, Select } from '~/components/ui'
 import { loadAssets } from '~/lib/api/asset.server'
 import { createPeer } from '~/lib/api/peer.server'
@@ -19,21 +20,40 @@ import type { ZodFieldErrors } from '~/shared/types'
 import { checkAuthAndRedirect } from '../lib/kratos_checks.server'
 import type { RedirectDialogRef } from '~/components/RedirectDialog'
 import { RedirectDialog } from '~/components/RedirectDialog'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { loadTenants, whoAmI } from '~/lib/api/tenant.server'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const cookies = request.headers.get('cookie')
   await checkAuthAndRedirect(request.url, cookies)
 
-  return json({ assets: await loadAssets(request) })
+  const assets = await loadAssets(request)
+  const { isOperator } = await whoAmI(request)
+  let tenants
+  if (isOperator) {
+    tenants = await loadTenants(request)
+  }
+
+  return json({ assets, tenants })
 }
 
 export default function CreatePeerPage() {
-  const { assets } = useLoaderData<typeof loader>()
+  const { assets, tenants } = useLoaderData<typeof loader>()
   const response = useActionData<typeof action>()
   const { state } = useNavigation()
   const isSubmitting = state === 'submitting'
   const dialogRef = useRef<RedirectDialogRef>(null)
+  const [tenantId, setTenantId] = useState<SelectOption | undefined>()
+
+  const getAssetsOfTenant = (): SelectOption[] => {
+    const assetsOfTenant = assets.filter(
+      (asset) => asset.node.tenantId === tenantId?.value
+    )
+    return assetsOfTenant.map((asset) => ({
+      value: asset.node.id,
+      label: `${asset.node.code} (Scale: ${asset.node.scale})`
+    }))
+  }
 
   useEffect(() => {
     if (assets.length === 0) {
@@ -200,29 +220,77 @@ export default function CreatePeerPage() {
                 </div>
                 <div className='md:col-span-2 bg-white rounded-md shadow-md'>
                   <div className='w-full p-4 space-y-3'>
-                    <Select
-                      options={assets.map((asset) => ({
-                        value: asset.node.id,
-                        label: `${asset.node.code} (Scale: ${asset.node.scale})`
-                      }))}
-                      error={response?.errors.fieldErrors.asset}
-                      name='asset'
-                      placeholder='Select asset...'
-                      label='Asset'
-                      description={
-                        <>
-                          The type of{' '}
-                          <a
-                            className='default-link'
-                            href='https://rafiki.dev/overview/concepts/accounting#assets'
-                          >
-                            asset
-                          </a>{' '}
-                          that is sent to & received from the peer.
-                        </>
-                      }
-                      required
-                    />
+                    {tenants ? (
+                      <Select
+                        options={tenants.map((tenant) => ({
+                          value: tenant.node.id,
+                          label: tenant.node.id
+                        }))}
+                        name='tenantId'
+                        placeholder='Select tenant...'
+                        required
+                        onChange={(value) => setTenantId(value)}
+                        description={
+                          <>
+                            The tenant whose{' '}
+                            <a
+                              className='default-link'
+                              href='https://rafiki.dev/overview/concepts/accounting#assets'
+                            >
+                              asset
+                            </a>{' '}
+                            will sent to & received from the peer.
+                          </>
+                        }
+                        bringForward
+                      />
+                    ) : (
+                      <Select
+                        options={assets.map((asset) => ({
+                          value: asset.node.id,
+                          label: `${asset.node.code} (Scale: ${asset.node.scale})`
+                        }))}
+                        error={response?.errors.fieldErrors.asset}
+                        name='asset'
+                        placeholder='Select asset...'
+                        label='Asset'
+                        description={
+                          <>
+                            The type of{' '}
+                            <a
+                              className='default-link'
+                              href='https://rafiki.dev/overview/concepts/accounting#assets'
+                            >
+                              asset
+                            </a>{' '}
+                            that is sent to & received from the peer.
+                          </>
+                        }
+                        required
+                      />
+                    )}
+                    {tenants && tenantId && (
+                      <Select
+                        options={getAssetsOfTenant()}
+                        error={response?.errors.fieldErrors.asset}
+                        name='asset'
+                        placeholder='Select asset...'
+                        label='Asset'
+                        description={
+                          <>
+                            The type of{' '}
+                            <a
+                              className='default-link'
+                              href='https://rafiki.dev/overview/concepts/accounting#assets'
+                            >
+                              asset
+                            </a>{' '}
+                            that is sent to & received from the peer.
+                          </>
+                        }
+                        required
+                      />
+                    )}
                   </div>
                 </div>
               </div>

--- a/packages/frontend/app/routes/wallet-addresses.create.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.create.tsx
@@ -93,7 +93,7 @@ export default function CreateWalletAddressPage() {
                     <Select
                       options={tenants.map((tenant) => ({
                         value: tenant.node.id,
-                        label: `${tenant.node.id}`
+                        label: `${tenant.node.id} ${tenant.node.publicName ? `(${tenant.node.publicName})` : ''}`
                       }))}
                       name='tenantId'
                       placeholder='Select tenant...'

--- a/packages/frontend/app/routes/wallet-addresses.create.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.create.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react'
 import { json, type ActionFunctionArgs } from '@remix-run/node'
 import {
   Form,
@@ -6,6 +7,7 @@ import {
   useNavigation
 } from '@remix-run/react'
 import { PageHeader } from '~/components'
+import type { SelectOption } from '~/components/ui'
 import { Button, ErrorPanel, Input, Select } from '~/components/ui'
 import { loadAssets } from '~/lib/api/asset.server'
 import { createWalletAddress } from '~/lib/api/wallet-address.server'
@@ -18,18 +20,37 @@ import {
 } from '~/shared/utils'
 import { checkAuthAndRedirect } from '../lib/kratos_checks.server'
 import { type LoaderFunctionArgs } from '@remix-run/node'
+import { whoAmI, loadTenants } from '~/lib/api/tenant.server'
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const cookies = request.headers.get('cookie')
   await checkAuthAndRedirect(request.url, cookies)
-  return json({ assets: await loadAssets(request) })
+
+  const assets = await loadAssets(request)
+  const { isOperator } = await whoAmI(request)
+  let tenants
+  if (isOperator) {
+    tenants = await loadTenants(request)
+  }
+  return json({ assets, tenants })
 }
 
 export default function CreateWalletAddressPage() {
-  const { assets } = useLoaderData<typeof loader>()
+  const { assets, tenants } = useLoaderData<typeof loader>()
   const response = useActionData<typeof action>()
   const { state } = useNavigation()
   const isSubmitting = state === 'submitting'
+  const [tenantId, setTenantId] = useState<SelectOption | undefined>()
+
+  const getAssetsOfTenant = (): SelectOption[] => {
+    const assetsOfTenant = assets.filter(
+      (asset) => asset.node.tenantId === tenantId?.value
+    )
+    return assetsOfTenant.map((asset) => ({
+      value: asset.node.id,
+      label: `${asset.node.code} (Scale: ${asset.node.scale})`
+    }))
+  }
 
   return (
     <div className='pt-4 flex flex-col space-y-4'>
@@ -68,17 +89,42 @@ export default function CreateWalletAddressPage() {
                     placeholder='Public name'
                     error={response?.errors?.fieldErrors.publicName}
                   />
-                  <Select
-                    options={assets.map((asset) => ({
-                      value: asset.node.id,
-                      label: `${asset.node.code} (Scale: ${asset.node.scale})`
-                    }))}
-                    error={response?.errors.fieldErrors.asset}
-                    name='asset'
-                    placeholder='Select asset...'
-                    label='Asset'
-                    required
-                  />
+                  {tenants ? (
+                    <Select
+                      options={tenants.map((tenant) => ({
+                        value: tenant.node.id,
+                        label: `${tenant.node.id}`
+                      }))}
+                      name='tenantId'
+                      placeholder='Select tenant...'
+                      label='Tenant'
+                      required
+                      onChange={(value) => setTenantId(value)}
+                      bringForward
+                    />
+                  ) : (
+                    <Select
+                      options={assets.map((asset) => ({
+                        value: asset.node.id,
+                        label: `${asset.node.code} (Scale: ${asset.node.scale})`
+                      }))}
+                      error={response?.errors.fieldErrors.asset}
+                      name='asset'
+                      placeholder='Select asset...'
+                      label='Asset'
+                      required
+                    />
+                  )}
+                  {tenants && tenantId && (
+                    <Select
+                      options={getAssetsOfTenant()}
+                      error={response?.errors.fieldErrors.asset}
+                      name='asset'
+                      placeholder='Select asset...'
+                      label='Asset'
+                      required
+                    />
+                  )}
                 </div>
               </div>
             </div>
@@ -119,6 +165,7 @@ export async function action({ request }: ActionFunctionArgs) {
     url: `${baseUrl}/${path}`,
     publicName: result.data.publicName,
     assetId: result.data.asset,
+    tenantId: result.data.tenantId,
     additionalProperties: []
   })
 

--- a/packages/frontend/app/styles/tailwind.css
+++ b/packages/frontend/app/styles/tailwind.css
@@ -6,3 +6,7 @@ a.default-link {
   color: revert;
   text-decoration: revert;
 }
+
+div.forward {
+  z-index: 1;
+}

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -124,7 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
-  tenantId?: Maybe<Scalars['String']['output']>;
+  tenantId: Scalars['ID']['output'];
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -201,7 +201,7 @@ export type CreateAssetInput = {
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
   /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
-  tenantId?: InputMaybe<Scalars['String']['input']>;
+  tenantId?: InputMaybe<Scalars['ID']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };
@@ -2176,7 +2176,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tenantId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -124,6 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
+  tenantId?: Maybe<Scalars['String']['output']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -2173,6 +2174,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
+  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -200,6 +200,8 @@ export type CreateAssetInput = {
   liquidityThreshold?: InputMaybe<Scalars['UInt64']['input']>;
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
+  /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
+  tenantId?: InputMaybe<Scalars['String']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -124,7 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
-  tenantId?: Maybe<Scalars['String']['output']>;
+  tenantId: Scalars['ID']['output'];
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -201,7 +201,7 @@ export type CreateAssetInput = {
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
   /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
-  tenantId?: InputMaybe<Scalars['String']['input']>;
+  tenantId?: InputMaybe<Scalars['ID']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };
@@ -2176,7 +2176,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
-  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tenantId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -124,6 +124,7 @@ export type Asset = Model & {
   scale: Scalars['UInt8']['output'];
   /** The sending fee structure for the asset. */
   sendingFee?: Maybe<Fee>;
+  tenantId?: Maybe<Scalars['String']['output']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: Maybe<Scalars['UInt64']['output']>;
 };
@@ -2173,6 +2174,7 @@ export type AssetResolvers<ContextType = any, ParentType extends ResolversParent
   receivingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
   scale?: Resolver<ResolversTypes['UInt8'], ParentType, ContextType>;
   sendingFee?: Resolver<Maybe<ResolversTypes['Fee']>, ParentType, ContextType>;
+  tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   withdrawalThreshold?: Resolver<Maybe<ResolversTypes['UInt64']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -200,6 +200,8 @@ export type CreateAssetInput = {
   liquidityThreshold?: InputMaybe<Scalars['UInt64']['input']>;
   /** Difference in order of magnitude between the standard unit of an asset and its corresponding fractional unit. */
   scale: Scalars['UInt8']['input'];
+  /** Unique identifier of the tenant associated with the asset. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
+  tenantId?: InputMaybe<Scalars['String']['input']>;
   /** Minimum amount of liquidity that can be withdrawn from the asset. */
   withdrawalThreshold?: InputMaybe<Scalars['UInt64']['input']>;
 };


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds tenant dropdown menus if the user is an operator for the following `frontend` pages:
  - Asset creation
  - Wallet Address creation
  - Peer creation
  - These resources will be created with the selected tenant, or with the selected asset associated with a given tenant.
- Does not display this option if the user is a tenant.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3273.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [x] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
