### PR TITLE
fix(backend): allow admin api to query all receivers and move checks

### DIFF
--- a/packages/backend/src/open_payments/payment/incoming/model.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.test.ts
@@ -122,7 +122,7 @@ describe('Models', (): void => {
       })
 
       test.each([IncomingPaymentState.Completed, IncomingPaymentState.Expired])(
-        'returns incoming payment with empty methods if payment state is %s',
+        'returns incoming payment with existing methods if payment state is %s',
         async (paymentState): Promise<void> => {
           incomingPayment.state = paymentState
 
@@ -148,7 +148,13 @@ describe('Models', (): void => {
             metadata: incomingPayment.metadata ?? undefined,
             updatedAt: incomingPayment.updatedAt.toISOString(),
             createdAt: incomingPayment.createdAt.toISOString(),
-            methods: []
+            methods: [
+              expect.objectContaining({
+                type: 'ilp',
+                ilpAddress: streamCredentials.ilpAddress,
+                sharedSecret: expect.any(String)
+              })
+            ]
           })
         }
       )

--- a/packages/backend/src/open_payments/payment/incoming/model.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.ts
@@ -243,16 +243,15 @@ export class IncomingPayment
   ): OpenPaymentsIncomingPaymentWithPaymentMethod {
     return {
       ...this.toOpenPaymentsType(walletAddress),
-      methods:
-        this.isExpiredOrComplete() || !ilpStreamCredentials
-          ? []
-          : [
-              {
-                type: 'ilp',
-                ilpAddress: ilpStreamCredentials.ilpAddress,
-                sharedSecret: base64url(ilpStreamCredentials.sharedSecret)
-              }
-            ]
+      methods: !ilpStreamCredentials
+        ? []
+        : [
+            {
+              type: 'ilp',
+              ilpAddress: ilpStreamCredentials.ilpAddress,
+              sharedSecret: base64url(ilpStreamCredentials.sharedSecret)
+            }
+          ]
     }
   }
 

--- a/packages/backend/src/open_payments/payment/incoming/routes.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.ts
@@ -97,7 +97,7 @@ async function getIncomingPaymentPrivate(
     client: ctx.accessAction === AccessAction.Read ? ctx.client : undefined
   })
 
-  if (!incomingPayment || incomingPayment.isExpiredOrComplete()) {
+  if (!incomingPayment) {
     throw new OpenPaymentsServerRouteError(
       404,
       'Incoming payment does not exist',

--- a/packages/backend/src/open_payments/payment/incoming/routes.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.ts
@@ -97,7 +97,7 @@ async function getIncomingPaymentPrivate(
     client: ctx.accessAction === AccessAction.Read ? ctx.client : undefined
   })
 
-  if (!incomingPayment) {
+  if (!incomingPayment || incomingPayment.isExpiredOrComplete()) {
     throw new OpenPaymentsServerRouteError(
       404,
       'Incoming payment does not exist',

--- a/packages/backend/src/open_payments/payment/incoming/routes.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.ts
@@ -107,7 +107,9 @@ async function getIncomingPaymentPrivate(
     )
   }
 
-  const streamCredentials = deps.streamCredentialsService.get(incomingPayment)
+  const streamCredentials = incomingPayment.isExpiredOrComplete()
+    ? undefined
+    : deps.streamCredentialsService.get(incomingPayment)
 
   ctx.body = incomingPayment.toOpenPaymentsTypeWithMethods(
     ctx.walletAddress,

--- a/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
@@ -25,7 +25,7 @@ export async function handleSending(
     throw LifecycleError.MissingBalance
   }
 
-  if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
+  if (!Receiver.isActive(receiver)) {
     // Payment is already (unexpectedly) done. Maybe this is a retry and the previous attempt failed to save the state to Postgres. Or the incoming payment could have been paid by a totally different payment in the time since the quote.
     deps.logger.warn(
       {

--- a/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
@@ -25,7 +25,7 @@ export async function handleSending(
     throw LifecycleError.MissingBalance
   }
 
-  if (!Receiver.isActive(receiver)) {
+  if (!receiver || !receiver.isActive()) {
     // Payment is already (unexpectedly) done. Maybe this is a retry and the previous attempt failed to save the state to Postgres. Or the incoming payment could have been paid by a totally different payment in the time since the quote.
     deps.logger.warn(
       {

--- a/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
@@ -25,7 +25,7 @@ export async function handleSending(
     throw LifecycleError.MissingBalance
   }
 
-  if (!receiver) {
+  if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
     // Payment is already (unexpectedly) done. Maybe this is a retry and the previous attempt failed to save the state to Postgres. Or the incoming payment could have been paid by a totally different payment in the time since the quote.
     deps.logger.warn(
       {

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -930,7 +930,7 @@ describe('OutgoingPaymentService', (): void => {
           method: 'ilp'
         })
         await quote.$query(knex).patch({
-          expiresAt: new Date()
+          expiresAt: new Date(Date.now() - 1000)
         })
         await expect(
           outgoingPaymentService.create({

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -44,6 +44,7 @@ import { Pagination, SortOrder } from '../../../shared/baseModel'
 import { FilterString } from '../../../shared/filters'
 import { IAppConfig } from '../../../config/app'
 import { AssetService } from '../../../asset/service'
+import { Receiver } from '../../receiver/model'
 
 export interface OutgoingPaymentService
   extends WalletAddressSubresourceService<OutgoingPayment> {
@@ -369,7 +370,7 @@ async function createOutgoingPayment(
       )
       const receiver = await deps.receiverService.get(payment.receiver)
       stopTimerReceiver()
-      if (!receiver) {
+      if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
         throw OutgoingPaymentError.InvalidQuote
       }
       const stopTimerPeer = deps.telemetry.startTimer(

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -44,7 +44,6 @@ import { Pagination, SortOrder } from '../../../shared/baseModel'
 import { FilterString } from '../../../shared/filters'
 import { IAppConfig } from '../../../config/app'
 import { AssetService } from '../../../asset/service'
-import { Receiver } from '../../receiver/model'
 
 export interface OutgoingPaymentService
   extends WalletAddressSubresourceService<OutgoingPayment> {
@@ -370,7 +369,7 @@ async function createOutgoingPayment(
       )
       const receiver = await deps.receiverService.get(payment.receiver)
       stopTimerReceiver()
-      if (!Receiver.isActive(receiver)) {
+      if (!receiver || !receiver.isActive()) {
         throw OutgoingPaymentError.InvalidQuote
       }
       const stopTimerPeer = deps.telemetry.startTimer(

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -370,7 +370,7 @@ async function createOutgoingPayment(
       )
       const receiver = await deps.receiverService.get(payment.receiver)
       stopTimerReceiver()
-      if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
+      if (!Receiver.isActive(receiver)) {
         throw OutgoingPaymentError.InvalidQuote
       }
       const stopTimerPeer = deps.telemetry.startTimer(

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -252,7 +252,7 @@ export async function resolveReceiver(
   options: CreateQuoteOptions
 ): Promise<Receiver> {
   const receiver = await deps.receiverService.get(options.receiver)
-  if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
+  if (!Receiver.isActive(receiver)) {
     deps.logger.info(
       { receiver: options.receiver },
       'Could not create quote. Receiver not found'

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -252,7 +252,7 @@ export async function resolveReceiver(
   options: CreateQuoteOptions
 ): Promise<Receiver> {
   const receiver = await deps.receiverService.get(options.receiver)
-  if (!receiver) {
+  if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
     deps.logger.info(
       { receiver: options.receiver },
       'Could not create quote. Receiver not found'

--- a/packages/backend/src/open_payments/quote/service.ts
+++ b/packages/backend/src/open_payments/quote/service.ts
@@ -252,7 +252,7 @@ export async function resolveReceiver(
   options: CreateQuoteOptions
 ): Promise<Receiver> {
   const receiver = await deps.receiverService.get(options.receiver)
-  if (!Receiver.isActive(receiver)) {
+  if (!receiver || !receiver.isActive()) {
     deps.logger.info(
       { receiver: options.receiver },
       'Could not create quote. Receiver not found'

--- a/packages/backend/src/open_payments/receiver/model.test.ts
+++ b/packages/backend/src/open_payments/receiver/model.test.ts
@@ -81,49 +81,6 @@ describe('Receiver Model', (): void => {
       })
     })
 
-    test('throws if incoming payment is completed', async () => {
-      const walletAddress = await createWalletAddress(deps)
-      const incomingPayment = await createIncomingPayment(deps, {
-        walletAddressId: walletAddress.id
-      })
-
-      incomingPayment.state = IncomingPaymentState.Completed
-      const streamCredentials: IlpStreamCredentials = {
-        ilpAddress: 'test.ilp' as IlpAddress,
-        sharedSecret: Buffer.from('')
-      }
-
-      const openPaymentsIncomingPayment =
-        incomingPayment.toOpenPaymentsTypeWithMethods(
-          walletAddress,
-          streamCredentials
-        )
-
-      expect(() => new Receiver(openPaymentsIncomingPayment, false)).toThrow(
-        'Cannot create receiver from completed incoming payment'
-      )
-    })
-
-    test('throws if incoming payment is expired', async () => {
-      const walletAddress = await createWalletAddress(deps)
-      const incomingPayment = await createIncomingPayment(deps, {
-        walletAddressId: walletAddress.id
-      })
-
-      incomingPayment.expiresAt = new Date(Date.now() - 1)
-      const streamCredentials = streamCredentialsService.get(incomingPayment)
-      assert(streamCredentials)
-      const openPaymentsIncomingPayment =
-        incomingPayment.toOpenPaymentsTypeWithMethods(
-          walletAddress,
-          streamCredentials
-        )
-
-      expect(() => new Receiver(openPaymentsIncomingPayment, false)).toThrow(
-        'Cannot create receiver from expired incoming payment'
-      )
-    })
-
     test('throws if stream credentials has invalid ILP address', async () => {
       const walletAddress = await createWalletAddress(deps)
       const incomingPayment = await createIncomingPayment(deps, {
@@ -143,6 +100,51 @@ describe('Receiver Model', (): void => {
       expect(() => new Receiver(openPaymentsIncomingPayment, false)).toThrow(
         'Invalid ILP address on ilp payment method'
       )
+    })
+  })
+
+  describe('isActive', () => {
+    test('returns false if incoming payment is completed', async () => {
+      const walletAddress = await createWalletAddress(deps)
+      const incomingPayment = await createIncomingPayment(deps, {
+        walletAddressId: walletAddress.id
+      })
+
+      incomingPayment.state = IncomingPaymentState.Completed
+      const streamCredentials: IlpStreamCredentials = {
+        ilpAddress: 'test.ilp' as IlpAddress,
+        sharedSecret: Buffer.from('')
+      }
+
+      const openPaymentsIncomingPayment =
+        incomingPayment.toOpenPaymentsTypeWithMethods(
+          walletAddress,
+          streamCredentials
+        )
+
+      const receiver = new Receiver(openPaymentsIncomingPayment, false)
+
+      expect(receiver.isActive()).toEqual(false)
+    })
+
+    test('returns false if incoming payment is expired', async () => {
+      const walletAddress = await createWalletAddress(deps)
+      const incomingPayment = await createIncomingPayment(deps, {
+        walletAddressId: walletAddress.id
+      })
+
+      incomingPayment.expiresAt = new Date(Date.now() - 1)
+      const streamCredentials = streamCredentialsService.get(incomingPayment)
+      assert(streamCredentials)
+      const openPaymentsIncomingPayment =
+        incomingPayment.toOpenPaymentsTypeWithMethods(
+          walletAddress,
+          streamCredentials
+        )
+
+      const receiver = new Receiver(openPaymentsIncomingPayment, false)
+
+      expect(receiver.isActive()).toEqual(false)
     })
   })
 })

--- a/packages/backend/src/open_payments/receiver/model.ts
+++ b/packages/backend/src/open_payments/receiver/model.ts
@@ -35,21 +35,9 @@ export class Receiver {
     incomingPayment: OpenPaymentsIncomingPaymentWithPaymentMethod,
     isLocal: boolean
   ) {
-    if (incomingPayment.completed) {
-      throw new Error('Cannot create receiver from completed incoming payment')
-    }
-
     const expiresAt = incomingPayment.expiresAt
       ? new Date(incomingPayment.expiresAt)
       : undefined
-
-    if (expiresAt && expiresAt.getTime() <= Date.now()) {
-      throw new Error('Cannot create receiver from expired incoming payment')
-    }
-
-    if (!incomingPayment.methods.length) {
-      throw new Error('Missing payment method(s) on incoming payment')
-    }
 
     const incomingAmount = incomingPayment.incomingAmount
       ? parseAmount(incomingPayment.incomingAmount)
@@ -119,5 +107,31 @@ export class Receiver {
       sharedSecret: this.sharedSecret,
       requestCounter: Counter.from(0) as Counter
     }
+  }
+
+  public static isInvalidExpiredOrCompleted(
+    receiver: Receiver | undefined
+  ): receiver is undefined {
+    if (!receiver) {
+      return true
+    }
+    const incomingPayment = receiver.incomingPayment
+    if (incomingPayment.completed) {
+      // throw new Error('Cannot create receiver from completed incoming payment')
+      return true
+    }
+    if (
+      incomingPayment.expiresAt &&
+      incomingPayment.expiresAt.getTime() <= Date.now()
+    ) {
+      // throw new Error('Cannot create receiver from expired incoming payment')
+      return true
+    }
+    if (!incomingPayment.methods.length) {
+      // throw new Error('Missing payment method(s) on incoming payment')
+      return true
+    }
+
+    return false
   }
 }

--- a/packages/backend/src/open_payments/receiver/model.ts
+++ b/packages/backend/src/open_payments/receiver/model.ts
@@ -111,25 +111,25 @@ export class Receiver {
 
   public static isActive(receiver: Receiver | undefined): receiver is Receiver {
     if (!receiver) {
-      return true
+      return false
     }
     const incomingPayment = receiver.incomingPayment
     if (incomingPayment.completed) {
       // throw new Error('Cannot create receiver from completed incoming payment')
-      return true
+      return false
     }
     if (
       incomingPayment.expiresAt &&
       incomingPayment.expiresAt.getTime() <= Date.now()
     ) {
       // throw new Error('Cannot create receiver from expired incoming payment')
-      return true
+      return false
     }
     if (!incomingPayment.methods.length) {
       // throw new Error('Missing payment method(s) on incoming payment')
-      return true
+      return false
     }
 
-    return false
+    return true
   }
 }

--- a/packages/backend/src/open_payments/receiver/model.ts
+++ b/packages/backend/src/open_payments/receiver/model.ts
@@ -45,7 +45,7 @@ export class Receiver {
     const receivedAmount = parseAmount(incomingPayment.receivedAmount)
 
     // TODO: handle multiple payment methods
-    const ilpMethod = incomingPayment.methods.find(
+    const ilpMethod = incomingPayment.methods?.find(
       (method) => method.type === 'ilp'
     )
     if (!ilpMethod) {
@@ -109,24 +109,19 @@ export class Receiver {
     }
   }
 
-  public static isActive(receiver: Receiver | undefined): receiver is Receiver {
-    if (!receiver) {
-      return false
-    }
-    const incomingPayment = receiver.incomingPayment
+  public isActive(): boolean {
+    const incomingPayment = this.incomingPayment
+
     if (incomingPayment.completed) {
-      // throw new Error('Cannot create receiver from completed incoming payment')
       return false
     }
     if (
       incomingPayment.expiresAt &&
       incomingPayment.expiresAt.getTime() <= Date.now()
     ) {
-      // throw new Error('Cannot create receiver from expired incoming payment')
       return false
     }
     if (!incomingPayment.methods.length) {
-      // throw new Error('Missing payment method(s) on incoming payment')
       return false
     }
 

--- a/packages/backend/src/open_payments/receiver/model.ts
+++ b/packages/backend/src/open_payments/receiver/model.ts
@@ -109,9 +109,7 @@ export class Receiver {
     }
   }
 
-  public static isInvalidExpiredOrCompleted(
-    receiver: Receiver | undefined
-  ): receiver is undefined {
+  public static isActive(receiver: Receiver | undefined): receiver is Receiver {
     if (!receiver) {
       return true
     }

--- a/packages/backend/src/open_payments/receiver/service.test.ts
+++ b/packages/backend/src/open_payments/receiver/service.test.ts
@@ -251,7 +251,7 @@ describe('Receiver Service', (): void => {
         expect(remoteIncomingPaymentServiceGetSpy).toHaveBeenCalledTimes(1)
       })
 
-      test('returns undefined if error getting receiver from remote incoming payment', async () => {
+      test('gets receiver from completed remote incoming payment', async () => {
         const mockedIncomingPayment = mockIncomingPaymentWithPaymentMethods({
           completed: true // cannot get receiver with a completed incoming payment
         })
@@ -266,7 +266,36 @@ describe('Receiver Service', (): void => {
 
         await expect(
           receiverService.get(mockedIncomingPayment.id)
-        ).resolves.toBeUndefined()
+        ).resolves.toEqual({
+          assetCode: mockedIncomingPayment.receivedAmount.assetCode,
+          assetScale: mockedIncomingPayment.receivedAmount.assetScale,
+          ilpAddress: mockedIncomingPayment.methods[0].ilpAddress,
+          sharedSecret: expect.any(Buffer),
+          incomingPayment: {
+            id: mockedIncomingPayment.id,
+            walletAddress: mockedIncomingPayment.walletAddress,
+            incomingAmount: mockedIncomingPayment.incomingAmount
+              ? parseAmount(mockedIncomingPayment.incomingAmount)
+              : undefined,
+            receivedAmount: parseAmount(mockedIncomingPayment.receivedAmount),
+            completed: mockedIncomingPayment.completed,
+            metadata: mockedIncomingPayment.metadata,
+            expiresAt: mockedIncomingPayment.expiresAt
+              ? new Date(mockedIncomingPayment.expiresAt)
+              : undefined,
+            createdAt: new Date(mockedIncomingPayment.createdAt),
+            updatedAt: new Date(mockedIncomingPayment.updatedAt),
+            methods: [
+              {
+                type: 'ilp',
+                ilpAddress: expect.any(String),
+                sharedSecret: expect.any(String)
+              }
+            ]
+          },
+          isLocal: false
+        })
+
         expect(localIncomingPaymentServiceGetSpy).toHaveBeenCalledTimes(1)
         expect(remoteIncomingPaymentServiceGetSpy).toHaveBeenCalledTimes(1)
       })

--- a/packages/backend/src/open_payments/receiver/service.test.ts
+++ b/packages/backend/src/open_payments/receiver/service.test.ts
@@ -253,7 +253,7 @@ describe('Receiver Service', (): void => {
 
       test('gets receiver from completed remote incoming payment', async () => {
         const mockedIncomingPayment = mockIncomingPaymentWithPaymentMethods({
-          completed: true // cannot get receiver with a completed incoming payment
+          completed: true
         })
 
         const localIncomingPaymentServiceGetSpy = jest

--- a/packages/backend/src/open_payments/receiver/service.ts
+++ b/packages/backend/src/open_payments/receiver/service.ts
@@ -75,7 +75,13 @@ async function createReceiver(
   }
 
   try {
-    return new Receiver(incomingPaymentOrError, isLocal)
+    const receiver = new Receiver(incomingPaymentOrError, isLocal)
+
+    if (!receiver.isActive()) {
+      throw new Error('Receiver is not active')
+    }
+
+    return receiver
   } catch (error) {
     const errorMessage = 'Could not create receiver from incoming payment'
     deps.logger.error(

--- a/packages/backend/src/open_payments/receiver/service.ts
+++ b/packages/backend/src/open_payments/receiver/service.ts
@@ -210,14 +210,6 @@ export async function getLocalIncomingPayment(
 
   const streamCredentials = deps.streamCredentialsService.get(incomingPayment)
 
-  if (!streamCredentials) {
-    const errorMessage =
-      'Could not get stream credentials for local incoming payment'
-    deps.logger.error({ incomingPaymentId: incomingPayment.id }, errorMessage)
-
-    throw new Error(errorMessage)
-  }
-
   return incomingPayment.toOpenPaymentsTypeWithMethods(
     incomingPayment.walletAddress,
     streamCredentials

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.test.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.test.ts
@@ -56,14 +56,19 @@ describe('Stream Credentials Service', (): void => {
       ${IncomingPaymentState.Completed}
       ${IncomingPaymentState.Expired}
     `(
-      `returns undefined for $state incoming payment`,
+      `returns stream credentials for $state incoming payment`,
       async ({ state }): Promise<void> => {
         await incomingPayment.$query(knex).patch({
           state,
           expiresAt:
             state === IncomingPaymentState.Expired ? new Date() : undefined
         })
-        expect(streamCredentialsService.get(incomingPayment)).toBeUndefined()
+        expect(streamCredentialsService.get(incomingPayment)).toMatchObject({
+          ilpAddress: expect.stringMatching(
+            /^test\.rafiki\.[a-zA-Z0-9_-]{95}$/
+          ),
+          sharedSecret: expect.any(Buffer)
+        })
       }
     )
   })

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
@@ -33,9 +33,6 @@ function getStreamCredentials(
   deps: ServiceDependencies,
   payment: IncomingPayment
 ): IlpStreamCredentials | undefined {
-  if (payment.isExpiredOrComplete()) {
-    return undefined
-  }
   const credentials = deps.streamServer.generateCredentials({
     paymentTag: payment.id,
     asset: {

--- a/packages/backend/src/tests/quote.ts
+++ b/packages/backend/src/tests/quote.ts
@@ -87,7 +87,7 @@ export async function createQuote(
   if (validDestination) {
     const receiverService = await deps.use('receiverService')
     const receiver = await receiverService.get(receiverUrl)
-    if (!Receiver.isActive(receiver)) {
+    if (!receiver || !receiver.isActive()) {
       throw new Error('receiver not found')
     }
     if (!receiver.incomingAmount && !receiveAmount && !debitAmount) {

--- a/packages/backend/src/tests/quote.ts
+++ b/packages/backend/src/tests/quote.ts
@@ -87,7 +87,7 @@ export async function createQuote(
   if (validDestination) {
     const receiverService = await deps.use('receiverService')
     const receiver = await receiverService.get(receiverUrl)
-    if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
+    if (!Receiver.isActive(receiver)) {
       throw new Error('receiver not found')
     }
     if (!receiver.incomingAmount && !receiveAmount && !debitAmount) {

--- a/packages/backend/src/tests/quote.ts
+++ b/packages/backend/src/tests/quote.ts
@@ -87,7 +87,7 @@ export async function createQuote(
   if (validDestination) {
     const receiverService = await deps.use('receiverService')
     const receiver = await receiverService.get(receiverUrl)
-    if (!receiver) {
+    if (Receiver.isInvalidExpiredOrCompleted(receiver)) {
       throw new Error('receiver not found')
     }
     if (!receiver.incomingAmount && !receiveAmount && !debitAmount) {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- moved validation checks (completed, expired and methods availability) to createOutgoingPayment, handleSending, resolveReceiver via `Resolver.isInvalidExpiredOrCompleted`

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
fixes #3253 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
