### PR TITLE
feat(wallet-address)!: possibility to specify wallet address range

### DIFF
--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{RafikiGraphqlHost}}/graphql
+  address: {{RafikiGraphqlHost}}/graphql
   body: graphql
   auth: none
 }
@@ -17,7 +17,7 @@ body:graphql {
         id
         createdAt
         publicName
-        url
+        address
         status
         asset {
           code

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Get Tenant Settings.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Get Tenant Settings.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Get Tenant Settings
+  type: graphql
+  seq: 60
+}
+
+post {
+  url: {{RafikiGraphqlHost}}/graphql
+  body: graphql
+  auth: none
+}
+
+headers {
+  tenant-id: 438fa74a-fa7d-4317-9ced-dde32ece1787
+}
+
+body:graphql {
+  mutation CreateTenantSettings($input: CreateTenantSettingsInput!) {
+    createTenantSettings(input:$input) {
+      settings {
+        key
+        value
+      }
+    }
+  }
+}
+
+body:graphql:vars {
+  {
+    "input": {
+      "settings": [
+        { "key": "EXCHANGE_RATES_URL", "value": "https://example.com" }
+      ]    
+    }
+  }
+  
+}
+
+script:pre-request {
+  const scripts = require('./scripts');
+  
+  scripts.addApiSignatureHeader();
+}

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Get Wallet Addresses Keys.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Get Wallet Addresses Keys.bru
@@ -18,7 +18,7 @@ body:graphql {
               node {
                   id
                   publicName
-                  url
+                  address
                   walletAddressKeys {
                     edges {
                       cursor

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Get Wallet Addresses.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Get Wallet Addresses.bru
@@ -18,7 +18,7 @@ body:graphql {
               node {
                   id
                   publicName
-                  url
+                  address
               }
           }
       }

--- a/localenv/mock-account-servicing-entity/app/lib/requesters.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/requesters.ts
@@ -88,7 +88,7 @@ export async function createWalletAddress(
       createWalletAddress(input: $input) {
         walletAddress {
           id
-          url
+          address
           publicName
         }
       }

--- a/localenv/mock-account-servicing-entity/app/lib/requesters.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/requesters.ts
@@ -96,7 +96,7 @@ export async function createWalletAddress(
   `
   const createWalletAddressInput: CreateWalletAddressInput = {
     assetId,
-    url: accountUrl,
+    address: accountUrl,
     publicName: accountName,
     additionalProperties: []
   }

--- a/localenv/mock-account-servicing-entity/app/lib/wallet.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/wallet.server.ts
@@ -25,7 +25,7 @@ export async function createWallet({
   await mockAccounts.setWalletAddress(
     accountId,
     walletAddress.id,
-    walletAddress.url
+    walletAddress.address
   )
 
   await createWalletAddressKey({

--- a/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
+++ b/localenv/mock-account-servicing-entity/app/lib/webhooks.server.ts
@@ -277,7 +277,7 @@ export async function handleWalletAddressNotFound(wh: Webhook) {
   await mockAccounts.setWalletAddress(
     account.id,
     walletAddress.id,
-    walletAddress.url
+    walletAddress.address
   )
 }
 

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -378,6 +378,8 @@ export type CreateTenantInput = {
   idpSecret?: InputMaybe<Scalars['String']['input']>;
   /** Public name for the tenant. */
   publicName?: InputMaybe<Scalars['String']['input']>;
+  /** Initial settings for tenant. */
+  settings?: InputMaybe<Array<TenantSettingInput>>;
 };
 
 export type CreateTenantSettingsInput = {

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -1490,16 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<TenantSettingsConnection>;
-};
-
-
-export type TenantSettingsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortOrder?: InputMaybe<SortOrder>;
+  settings?: Maybe<Array<TenantSetting>>;
 };
 
 export type TenantEdge = {
@@ -1523,27 +1514,11 @@ export type TenantSetting = {
   value: Scalars['String']['output'];
 };
 
-export type TenantSettingEdge = {
-  __typename?: 'TenantSettingEdge';
-  /** A cursor for paginating through the tenants. */
-  cursor: Scalars['String']['output'];
-  /** A tenant setting node in the list. */
-  node: TenantSetting;
-};
-
 export type TenantSettingInput = {
   /** Key for this setting. */
   key: Scalars['String']['input'];
   /** Value of a setting for this key. */
   value: Scalars['String']['input'];
-};
-
-export type TenantSettingsConnection = {
-  __typename?: 'TenantSettingsConnection';
-  /** A list of edges representing tenant settings and cursors for pagination. */
-  edges: Array<TenantSettingEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
 };
 
 export type TenantsConnection = {
@@ -1917,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
@@ -2034,9 +2009,7 @@ export type ResolversTypes = {
   TenantEdge: ResolverTypeWrapper<Partial<TenantEdge>>;
   TenantMutationResponse: ResolverTypeWrapper<Partial<TenantMutationResponse>>;
   TenantSetting: ResolverTypeWrapper<Partial<TenantSetting>>;
-  TenantSettingEdge: ResolverTypeWrapper<Partial<TenantSettingEdge>>;
   TenantSettingInput: ResolverTypeWrapper<Partial<TenantSettingInput>>;
-  TenantSettingsConnection: ResolverTypeWrapper<Partial<TenantSettingsConnection>>;
   TenantsConnection: ResolverTypeWrapper<Partial<TenantsConnection>>;
   TransferState: ResolverTypeWrapper<Partial<TransferState>>;
   TransferType: ResolverTypeWrapper<Partial<TransferType>>;
@@ -2172,9 +2145,7 @@ export type ResolversParentTypes = {
   TenantEdge: Partial<TenantEdge>;
   TenantMutationResponse: Partial<TenantMutationResponse>;
   TenantSetting: Partial<TenantSetting>;
-  TenantSettingEdge: Partial<TenantSettingEdge>;
   TenantSettingInput: Partial<TenantSettingInput>;
-  TenantSettingsConnection: Partial<TenantSettingsConnection>;
   TenantsConnection: Partial<TenantsConnection>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
@@ -2643,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<ResolversTypes['TenantSettingsConnection']>, ParentType, ContextType, Partial<TenantSettingsArgs>>;
+  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2661,18 +2632,6 @@ export type TenantMutationResponseResolvers<ContextType = any, ParentType extend
 export type TenantSettingResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSetting'] = ResolversParentTypes['TenantSetting']> = {
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingEdge'] = ResolversParentTypes['TenantSettingEdge']> = {
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['TenantSetting'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingsConnection'] = ResolversParentTypes['TenantSettingsConnection']> = {
-  edges?: Resolver<Array<ResolversTypes['TenantSettingEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2851,8 +2810,6 @@ export type Resolvers<ContextType = any> = {
   TenantEdge?: TenantEdgeResolvers<ContextType>;
   TenantMutationResponse?: TenantMutationResponseResolvers<ContextType>;
   TenantSetting?: TenantSettingResolvers<ContextType>;
-  TenantSettingEdge?: TenantSettingEdgeResolvers<ContextType>;
-  TenantSettingsConnection?: TenantSettingsConnectionResolvers<ContextType>;
   TenantsConnection?: TenantsConnectionResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -396,6 +396,8 @@ export type CreateTenantSettingsMutationResponse = {
 export type CreateWalletAddressInput = {
   /** Additional properties associated with the wallet address. */
   additionalProperties?: InputMaybe<Array<AdditionalPropertyInput>>;
+  /** Wallet address. This cannot be changed. */
+  address: Scalars['String']['input'];
   /** Unique identifier of the asset associated with the wallet address. This cannot be changed. */
   assetId: Scalars['String']['input'];
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
@@ -404,8 +406,6 @@ export type CreateWalletAddressInput = {
   publicName?: InputMaybe<Scalars['String']['input']>;
   /** Unique identifier of the tenant associated with the wallet address. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
   tenantId?: InputMaybe<Scalars['ID']['input']>;
-  /** Wallet address URL. This cannot be changed. */
-  url: Scalars['String']['input'];
 };
 
 export type CreateWalletAddressKeyInput = {
@@ -1671,6 +1671,8 @@ export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** Additional properties associated with the wallet address. */
   additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
+  /** Wallet Address. */
+  address: Scalars['String']['output'];
   /** Asset of the wallet address. */
   asset: Asset;
   /** The date and time when the wallet address was created. */
@@ -1691,8 +1693,6 @@ export type WalletAddress = Model & {
   status: WalletAddressStatus;
   /** Tenant ID of the wallet address. */
   tenantId?: Maybe<Scalars['String']['output']>;
-  /** Wallet Address URL. */
-  url: Scalars['String']['output'];
   /** List of keys associated with this wallet address */
   walletAddressKeys?: Maybe<WalletAddressKeyConnection>;
 };
@@ -2707,6 +2707,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
   additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
+  address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2717,7 +2718,6 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;
   status?: Resolver<ResolversTypes['WalletAddressStatus'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   walletAddressKeys?: Resolver<Maybe<ResolversTypes['WalletAddressKeyConnection']>, ParentType, ContextType, Partial<WalletAddressWalletAddressKeysArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -1892,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -1490,7 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<Array<TenantSetting>>;
+  settings: Array<TenantSetting>;
 };
 
 export type TenantEdge = {
@@ -2614,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
+  settings?: Resolver<Array<ResolversTypes['TenantSetting']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/backend/migrations/20250301103930_rename_wallet_address_url_to_address.js
+++ b/packages/backend/migrations/20250301103930_rename_wallet_address_url_to_address.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.alterTable('walletAddresses', (table) => {
+        table.renameColumn('url', 'address')
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.alterTable('walletAddresses', (table) => {
+        table.renameColumn('address', 'url')
+    })
+}

--- a/packages/backend/migrations/20250301103930_rename_wallet_address_url_to_address.js
+++ b/packages/backend/migrations/20250301103930_rename_wallet_address_url_to_address.js
@@ -3,9 +3,9 @@
  * @returns { Promise<void> }
  */
 exports.up = function (knex) {
-    return knex.schema.alterTable('walletAddresses', (table) => {
-        table.renameColumn('url', 'address')
-    })
+  return knex.schema.alterTable('walletAddresses', (table) => {
+    table.renameColumn('url', 'address')
+  })
 }
 
 /**
@@ -13,7 +13,7 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-    return knex.schema.alterTable('walletAddresses', (table) => {
-        table.renameColumn('address', 'url')
-    })
+  return knex.schema.alterTable('walletAddresses', (table) => {
+    table.renameColumn('address', 'url')
+  })
 }

--- a/packages/backend/migrations/20250301203110_unique_tenant_settings_key.js
+++ b/packages/backend/migrations/20250301203110_unique_tenant_settings_key.js
@@ -3,9 +3,9 @@
  * @returns { Promise<void> }
  */
 exports.up = function (knex) {
-    return knex.schema.alterTable('tenantSettings', function(table) {
-        table.unique(['tenantId', 'key']);
-    });
+  return knex.schema.alterTable('tenantSettings', function (table) {
+    table.unique(['tenantId', 'key'])
+  })
 }
 
 /**
@@ -13,7 +13,7 @@ exports.up = function (knex) {
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-    return knex.schema.alterTable('tenantSettings', function(table) {
-        table.dropUnique(['tenantId', 'key']);
-    });
+  return knex.schema.alterTable('tenantSettings', function (table) {
+    table.dropUnique(['tenantId', 'key'])
+  })
 }

--- a/packages/backend/migrations/20250301203110_unique_tenant_settings_key.js
+++ b/packages/backend/migrations/20250301203110_unique_tenant_settings_key.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+    return knex.schema.alterTable('tenantSettings', function(table) {
+        table.unique(['tenantId', 'key']);
+    });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+    return knex.schema.alterTable('tenantSettings', function(table) {
+        table.dropUnique(['tenantId', 'key']);
+    });
+}

--- a/packages/backend/src/asset/service.test.ts
+++ b/packages/backend/src/asset/service.test.ts
@@ -26,6 +26,8 @@ import {
   TenantSettingService
 } from '../tenants/settings/service'
 import { exchangeRatesSetting } from '../tests/tenantSettings'
+import { createTenantSettings } from '../tests/tenantSettings'
+import { TenantSettingKeys } from '../tenants/settings/model'
 
 describe('Asset Service', (): void => {
   let deps: IocContract<AppServices>
@@ -69,6 +71,18 @@ describe('Asset Service', (): void => {
 
   afterAll(async (): Promise<void> => {
     await appContainer.shutdown()
+  })
+
+  beforeEach(async () => {
+    await createTenantSettings(deps, {
+      tenantId: Config.operatorTenantId,
+      setting: [
+        {
+          key: TenantSettingKeys.WALLET_ADDRESS_URL.name,
+          value: 'https://alice.me'
+        }
+      ]
+    })
   })
 
   describe('create', (): void => {
@@ -370,8 +384,8 @@ describe('Asset Service', (): void => {
       const newAssetId = newAsset.id
 
       // make sure there is at least 1 wallet address using asset
-      const walletAddress = walletAddressService.create({
-        url: 'https://alice.me/.well-known/pay',
+      const walletAddress = await walletAddressService.create({
+        address: 'https://alice.me/.well-known/pay',
         tenantId: Config.operatorTenantId,
         assetId: newAssetId
       })

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -2325,6 +2325,22 @@
             "deprecationReason": null
           },
           {
+            "name": "address",
+            "description": "Wallet address. This cannot be changed.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "assetId",
             "description": "Unique identifier of the asset associated with the wallet address. This cannot be changed.",
             "type": {
@@ -2371,22 +2387,6 @@
               "kind": "SCALAR",
               "name": "ID",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "Wallet address URL. This cannot be changed.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -9344,6 +9344,22 @@
             "deprecationReason": null
           },
           {
+            "name": "address",
+            "description": "Wallet Address.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "asset",
             "description": "Asset of the wallet address.",
             "args": [],
@@ -9658,22 +9674,6 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "Wallet Address URL.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -2202,6 +2202,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "settings",
+            "description": "Initial settings for tenant.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TenantSettingInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -8335,72 +8335,19 @@
           {
             "name": "settings",
             "description": "List of settings for the tenant.",
-            "args": [
-              {
-                "name": "after",
-                "description": "Forward pagination: Cursor (wallet address key ID) to start retrieving settings after this point.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": "Backward pagination: Cursor (wallet address key ID) to start retrieving keys before this point.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": "Forward pagination: Limit the result to the first **n** keys after the `after` cursor.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": "Backward pagination: Limit the result to the last **n** keys before the `before` cursor.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "sortOrder",
-                "description": "Specify the sort order of keys based on their creation data, either ascending or descending.",
-                "type": {
-                  "kind": "ENUM",
-                  "name": "SortOrder",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
+            "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "TenantSettingsConnection",
-              "ofType": null
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TenantSetting",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8531,49 +8478,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "TenantSettingEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "cursor",
-            "description": "A cursor for paginating through the tenants.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": "A tenant setting node in the list.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "TenantSetting",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "INPUT_OBJECT",
         "name": "TenantSettingInput",
         "description": null,
@@ -8613,57 +8517,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "TenantSettingsConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": "A list of edges representing tenant settings and cursors for pagination.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "TenantSettingEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": "Information to aid in pagination.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -8337,15 +8337,19 @@
             "description": "List of settings for the tenant.",
             "args": [],
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TenantSetting",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TenantSetting",
+                    "ofType": null
+                  }
                 }
               }
             },

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -378,6 +378,8 @@ export type CreateTenantInput = {
   idpSecret?: InputMaybe<Scalars['String']['input']>;
   /** Public name for the tenant. */
   publicName?: InputMaybe<Scalars['String']['input']>;
+  /** Initial settings for tenant. */
+  settings?: InputMaybe<Array<TenantSettingInput>>;
 };
 
 export type CreateTenantSettingsInput = {

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -1490,16 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<TenantSettingsConnection>;
-};
-
-
-export type TenantSettingsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortOrder?: InputMaybe<SortOrder>;
+  settings?: Maybe<Array<TenantSetting>>;
 };
 
 export type TenantEdge = {
@@ -1523,27 +1514,11 @@ export type TenantSetting = {
   value: Scalars['String']['output'];
 };
 
-export type TenantSettingEdge = {
-  __typename?: 'TenantSettingEdge';
-  /** A cursor for paginating through the tenants. */
-  cursor: Scalars['String']['output'];
-  /** A tenant setting node in the list. */
-  node: TenantSetting;
-};
-
 export type TenantSettingInput = {
   /** Key for this setting. */
   key: Scalars['String']['input'];
   /** Value of a setting for this key. */
   value: Scalars['String']['input'];
-};
-
-export type TenantSettingsConnection = {
-  __typename?: 'TenantSettingsConnection';
-  /** A list of edges representing tenant settings and cursors for pagination. */
-  edges: Array<TenantSettingEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
 };
 
 export type TenantsConnection = {
@@ -1917,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
@@ -2034,9 +2009,7 @@ export type ResolversTypes = {
   TenantEdge: ResolverTypeWrapper<Partial<TenantEdge>>;
   TenantMutationResponse: ResolverTypeWrapper<Partial<TenantMutationResponse>>;
   TenantSetting: ResolverTypeWrapper<Partial<TenantSetting>>;
-  TenantSettingEdge: ResolverTypeWrapper<Partial<TenantSettingEdge>>;
   TenantSettingInput: ResolverTypeWrapper<Partial<TenantSettingInput>>;
-  TenantSettingsConnection: ResolverTypeWrapper<Partial<TenantSettingsConnection>>;
   TenantsConnection: ResolverTypeWrapper<Partial<TenantsConnection>>;
   TransferState: ResolverTypeWrapper<Partial<TransferState>>;
   TransferType: ResolverTypeWrapper<Partial<TransferType>>;
@@ -2172,9 +2145,7 @@ export type ResolversParentTypes = {
   TenantEdge: Partial<TenantEdge>;
   TenantMutationResponse: Partial<TenantMutationResponse>;
   TenantSetting: Partial<TenantSetting>;
-  TenantSettingEdge: Partial<TenantSettingEdge>;
   TenantSettingInput: Partial<TenantSettingInput>;
-  TenantSettingsConnection: Partial<TenantSettingsConnection>;
   TenantsConnection: Partial<TenantsConnection>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
@@ -2643,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<ResolversTypes['TenantSettingsConnection']>, ParentType, ContextType, Partial<TenantSettingsArgs>>;
+  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2661,18 +2632,6 @@ export type TenantMutationResponseResolvers<ContextType = any, ParentType extend
 export type TenantSettingResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSetting'] = ResolversParentTypes['TenantSetting']> = {
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingEdge'] = ResolversParentTypes['TenantSettingEdge']> = {
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['TenantSetting'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingsConnection'] = ResolversParentTypes['TenantSettingsConnection']> = {
-  edges?: Resolver<Array<ResolversTypes['TenantSettingEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2851,8 +2810,6 @@ export type Resolvers<ContextType = any> = {
   TenantEdge?: TenantEdgeResolvers<ContextType>;
   TenantMutationResponse?: TenantMutationResponseResolvers<ContextType>;
   TenantSetting?: TenantSettingResolvers<ContextType>;
-  TenantSettingEdge?: TenantSettingEdgeResolvers<ContextType>;
-  TenantSettingsConnection?: TenantSettingsConnectionResolvers<ContextType>;
   TenantsConnection?: TenantsConnectionResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -396,6 +396,8 @@ export type CreateTenantSettingsMutationResponse = {
 export type CreateWalletAddressInput = {
   /** Additional properties associated with the wallet address. */
   additionalProperties?: InputMaybe<Array<AdditionalPropertyInput>>;
+  /** Wallet address. This cannot be changed. */
+  address: Scalars['String']['input'];
   /** Unique identifier of the asset associated with the wallet address. This cannot be changed. */
   assetId: Scalars['String']['input'];
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
@@ -404,8 +406,6 @@ export type CreateWalletAddressInput = {
   publicName?: InputMaybe<Scalars['String']['input']>;
   /** Unique identifier of the tenant associated with the wallet address. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
   tenantId?: InputMaybe<Scalars['ID']['input']>;
-  /** Wallet address URL. This cannot be changed. */
-  url: Scalars['String']['input'];
 };
 
 export type CreateWalletAddressKeyInput = {
@@ -1671,6 +1671,8 @@ export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** Additional properties associated with the wallet address. */
   additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
+  /** Wallet Address. */
+  address: Scalars['String']['output'];
   /** Asset of the wallet address. */
   asset: Asset;
   /** The date and time when the wallet address was created. */
@@ -1691,8 +1693,6 @@ export type WalletAddress = Model & {
   status: WalletAddressStatus;
   /** Tenant ID of the wallet address. */
   tenantId?: Maybe<Scalars['String']['output']>;
-  /** Wallet Address URL. */
-  url: Scalars['String']['output'];
   /** List of keys associated with this wallet address */
   walletAddressKeys?: Maybe<WalletAddressKeyConnection>;
 };
@@ -2707,6 +2707,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
   additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
+  address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2717,7 +2718,6 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;
   status?: Resolver<ResolversTypes['WalletAddressStatus'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   walletAddressKeys?: Resolver<Maybe<ResolversTypes['WalletAddressKeyConnection']>, ParentType, ContextType, Partial<WalletAddressWalletAddressKeysArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -1892,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -1490,7 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<Array<TenantSetting>>;
+  settings: Array<TenantSetting>;
 };
 
 export type TenantEdge = {
@@ -2614,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
+  settings?: Resolver<Array<ResolversTypes['TenantSetting']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/backend/src/graphql/resolvers/tenant.test.ts
+++ b/packages/backend/src/graphql/resolvers/tenant.test.ts
@@ -10,55 +10,17 @@ import {
 } from '../generated/graphql'
 import { initIocContainer } from '../..'
 import { Config, IAppConfig } from '../../config/app'
-import { createTenant, generateTenantInput } from '../../tests/tenant'
+import {
+  createTenant,
+  createTenantedApolloClient,
+  generateTenantInput
+} from '../../tests/tenant'
 import { ApolloError, gql, NormalizedCacheObject } from '@apollo/client'
 import { getPageTests } from './page.test'
 import { truncateTables } from '../../tests/tableManager'
-import {
-  createHttpLink,
-  ApolloLink,
-  ApolloClient,
-  InMemoryCache
-} from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
+import { ApolloClient } from '@apollo/client'
 import { GraphQLErrorCode } from '../errors'
 import { Tenant as TenantModel } from '../../tenants/model'
-
-function createTenantedApolloClient(
-  appContainer: TestContainer,
-  tenantId: string
-): ApolloClient<NormalizedCacheObject> {
-  const httpLink = createHttpLink({
-    uri: `http://localhost:${appContainer.app.getAdminPort()}/graphql`,
-    fetch
-  })
-  const authLink = setContext((_, { headers }) => {
-    return {
-      headers: {
-        ...headers,
-        'tenant-id': tenantId
-      }
-    }
-  })
-
-  const link = ApolloLink.from([authLink, httpLink])
-
-  return new ApolloClient({
-    cache: new InMemoryCache({}),
-    link: link,
-    defaultOptions: {
-      query: {
-        fetchPolicy: 'no-cache'
-      },
-      mutate: {
-        fetchPolicy: 'no-cache'
-      },
-      watchQuery: {
-        fetchPolicy: 'no-cache'
-      }
-    }
-  })
-}
 
 describe('Tenant Resolvers', (): void => {
   let deps: IocContract<AppServices>

--- a/packages/backend/src/graphql/resolvers/tenant.ts
+++ b/packages/backend/src/graphql/resolvers/tenant.ts
@@ -10,6 +10,7 @@ import { GraphQLErrorCode } from '../errors'
 import { Tenant } from '../../tenants/model'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 import { getPageInfo } from '../../shared/pagination'
+import { tenantSettingsToGraphql } from './tenant_settings'
 
 export const whoami: QueryResolvers<TenantedApolloContext>['whoami'] = async (
   parent,
@@ -182,6 +183,7 @@ export function tenantToGraphQl(tenant: Tenant): SchemaTenant {
     idpConsentUrl: tenant.idpConsentUrl,
     idpSecret: tenant.idpSecret,
     publicName: tenant.publicName,
+    settings: tenantSettingsToGraphql(tenant.settings),
     createdAt: new Date(+tenant.createdAt).toISOString(),
     deletedAt: tenant.deletedAt
       ? new Date(+tenant.deletedAt).toISOString()

--- a/packages/backend/src/graphql/resolvers/tenant_settings.test.ts
+++ b/packages/backend/src/graphql/resolvers/tenant_settings.test.ts
@@ -85,7 +85,7 @@ describe('Tenant Settings Resolvers', (): void => {
   })
 
   afterAll(async (): Promise<void> => {
-    await appContainer.apolloClient.stop()
+    appContainer.apolloClient.stop()
     await appContainer.shutdown()
   })
 
@@ -121,6 +121,49 @@ describe('Tenant Settings Resolvers', (): void => {
         })
 
       expect(response.settings.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Get Tenant Settings', (): void => {
+    test('can get tenant settings', async (): Promise<void> => {
+      const tenant = await createTenant(deps)
+      const client = createTenantedApolloClient(appContainer, tenant.id)
+
+      // Query the settings
+      const response = await client
+        .query({
+          query: gql`
+            query GetTenantSettings($id: String!) {
+              tenant(id: $id) {
+                settings {
+                  key
+                  value
+                }
+              }
+            }
+          `,
+          variables: { id: tenant.id }
+        })
+        .then((query): { key: string; value: string }[] => {
+          if (query.data && query.data.tenant) {
+            return query.data.tenant.settings
+          }
+          throw new Error('Data was empty')
+        })
+
+      expect(response.length).toBeGreaterThan(0)
+      expect(response).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: TenantSettingKeys.WEBHOOK_MAX_RETRY.name,
+            value: String(TenantSettingKeys.WEBHOOK_MAX_RETRY.default)
+          }),
+          expect.objectContaining({
+            key: TenantSettingKeys.WEBHOOK_TIMEOUT.name,
+            value: String(TenantSettingKeys.WEBHOOK_TIMEOUT.default)
+          })
+        ])
+      )
     })
   })
 })

--- a/packages/backend/src/graphql/resolvers/tenant_settings.ts
+++ b/packages/backend/src/graphql/resolvers/tenant_settings.ts
@@ -21,7 +21,7 @@ export const getTenantSettings: TenantResolvers<TenantedApolloContext>['settings
       tenantId: parent.id
     })
 
-    return tenantSettings.map((x) => tenantSettingsToGraphql(x))
+    return tenantSettingsToGraphql(tenantSettings)
   }
 
 export const createTenantSettings: MutationResolvers<TenantedApolloContext>['createTenantSettings'] =
@@ -38,13 +38,22 @@ export const createTenantSettings: MutationResolvers<TenantedApolloContext>['cre
     })
 
     return {
-      settings: tenantSettings.map((x) => tenantSettingsToGraphql(x))
+      settings: tenantSettingsToGraphql(tenantSettings)
     }
   }
 
-export const tenantSettingsToGraphql = (
+const tenantSettingToGraphql = (
   tenantSetting: TenantSetting
 ): SchemaTenantSetting => ({
   key: tenantSetting.key,
   value: tenantSetting.value
 })
+
+export const tenantSettingsToGraphql = (
+  tenantSettings?: TenantSetting[]
+): SchemaTenantSetting[] => {
+  if (!tenantSettings) {
+    return []
+  }
+  return tenantSettings.map((x) => tenantSettingToGraphql(x))
+}

--- a/packages/backend/src/graphql/resolvers/tenant_settings.ts
+++ b/packages/backend/src/graphql/resolvers/tenant_settings.ts
@@ -17,9 +17,9 @@ export const getTenantSettings: TenantResolvers<TenantedApolloContext>['settings
       'tenantSettingService'
     )
 
-    const tenantSettings = (await tenantSettingsService.get({
+    const tenantSettings = await tenantSettingsService.get({
       tenantId: parent.id
-    })) as TenantSetting[]
+    })
 
     return tenantSettings.map((x) => tenantSettingsToGraphql(x))
   }

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -789,7 +789,7 @@ describe('Wallet Address Resolvers', (): void => {
         const newWalletAddress = await walletAddressService.create({
           assetId: (newAsset as Asset).id,
           tenantId: newTenant!.id,
-          url: 'https://alice.me/.well-known/pay-2'
+          address: 'https://alice.me/.well-known/pay-2'
         })
         const id = (newWalletAddress as WalletAddressModel).id
 
@@ -899,7 +899,7 @@ describe('Wallet Address Resolvers', (): void => {
             code: walletAddress.asset.code,
             scale: walletAddress.asset.scale
           },
-          url: walletAddress.url,
+          address: walletAddress.address,
           publicName: publicName ?? null,
           additionalProperties: [
             {
@@ -931,7 +931,7 @@ describe('Wallet Address Resolvers', (): void => {
           publicName,
           createLiquidityAccount: true
         })
-        const args = { url: walletAddress.url }
+        const args = { url: walletAddress.address }
         const query = await appContainer.apolloClient
           .query({
             query: gql`
@@ -943,7 +943,7 @@ describe('Wallet Address Resolvers', (): void => {
                     code
                     scale
                   }
-                  url
+                  address
                   publicName
                   additionalProperties {
                     key
@@ -972,7 +972,7 @@ describe('Wallet Address Resolvers', (): void => {
             code: walletAddress.asset.code,
             scale: walletAddress.asset.scale
           },
-          url: walletAddress.url,
+          address: walletAddress.address,
           publicName: publicName ?? null,
           additionalProperties: []
         })
@@ -1042,7 +1042,7 @@ describe('Wallet Address Resolvers', (): void => {
                       code
                       scale
                     }
-                    url
+                    address
                     publicName
                   }
                   cursor
@@ -1071,7 +1071,7 @@ describe('Wallet Address Resolvers', (): void => {
             code: walletAddress.asset.code,
             scale: walletAddress.asset.scale
           },
-          url: walletAddress.url,
+          address: walletAddress.address,
           publicName: walletAddress.publicName
         })
       })
@@ -1097,7 +1097,7 @@ describe('Wallet Address Resolvers', (): void => {
                       code
                       scale
                     }
-                    url
+                    address
                     publicName
                   }
                   cursor
@@ -1129,7 +1129,7 @@ describe('Wallet Address Resolvers', (): void => {
             code: walletAddress.asset.code,
             scale: walletAddress.asset.scale
           },
-          url: walletAddress.url,
+          address: walletAddress.address,
           publicName: walletAddress.publicName
         })
       })

--- a/packages/backend/src/graphql/resolvers/wallet_address.test.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.test.ts
@@ -400,10 +400,20 @@ describe('Wallet Address Resolvers', (): void => {
         },
         nonOperatorTenant.id
       )
+      await createTenantSettings(deps, {
+        tenantId: nonOperatorTenant.id,
+        setting: [
+          {
+            key: TenantSettingKeys.WALLET_ADDRESS_URL.name,
+            value: 'https://bob.me'
+          }
+        ]
+      })
+
       const input = {
         tenantId: nonOperatorTenant.id,
         assetId: asset.id,
-        url: 'https://bob.me/.well-known/pay'
+        address: 'https://bob.me/.well-known/pay'
       }
       const response = await appContainer.apolloClient // operator client
         .mutate({
@@ -416,7 +426,7 @@ describe('Wallet Address Resolvers', (): void => {
                     code
                     scale
                   }
-                  url
+                  address
                 }
               }
             }
@@ -437,7 +447,7 @@ describe('Wallet Address Resolvers', (): void => {
       expect(response.walletAddress).toEqual({
         __typename: 'WalletAddress',
         id: response.walletAddress.id,
-        url: input.url,
+        address: input.address,
         asset: {
           __typename: 'Asset',
           code: asset.code,

--- a/packages/backend/src/graphql/resolvers/wallet_address.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.ts
@@ -107,6 +107,7 @@ export const createWalletAddress: MutationResolvers<ForTenantIdContext>['createW
       })
 
     const tenantId = ctx.forTenantId
+
     if (!tenantId)
       throw new GraphQLError(
         `Assignment to the specified tenant is not permitted`,
@@ -122,7 +123,8 @@ export const createWalletAddress: MutationResolvers<ForTenantIdContext>['createW
       tenantId,
       additionalProperties: addProps,
       publicName: args.input.publicName,
-      address: args.input.address
+      address: args.input.address,
+      isOperator: ctx.isOperator
     }
 
     const walletAddressOrError = await walletAddressService.create(options)

--- a/packages/backend/src/graphql/resolvers/wallet_address.ts
+++ b/packages/backend/src/graphql/resolvers/wallet_address.ts
@@ -122,7 +122,7 @@ export const createWalletAddress: MutationResolvers<ForTenantIdContext>['createW
       tenantId,
       additionalProperties: addProps,
       publicName: args.input.publicName,
-      url: args.input.url
+      address: args.input.address
     }
 
     const walletAddressOrError = await walletAddressService.create(options)
@@ -206,7 +206,7 @@ export function walletAddressToGraphql(
 ): SchemaWalletAddress {
   return {
     id: walletAddress.id,
-    url: walletAddress.url,
+    address: walletAddress.address,
     asset: assetToGraphql(walletAddress.asset),
     publicName: walletAddress.publicName ?? undefined,
     createdAt: new Date(+walletAddress.createdAt).toISOString(),

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -796,8 +796,8 @@ type WalletAddress implements Model {
   "Current amount of liquidity available for this wallet address."
   liquidity: UInt64
 
-  "Wallet Address URL."
-  url: String!
+  "Wallet Address."
+  address: String!
 
   "Public name associated with the wallet address. This is visible to anyone with the wallet address URL."
   publicName: String
@@ -1302,8 +1302,8 @@ input CreateWalletAddressInput {
   tenantId: ID
   "Unique identifier of the asset associated with the wallet address. This cannot be changed."
   assetId: String!
-  "Wallet address URL. This cannot be changed."
-  url: String!
+  "Wallet address. This cannot be changed."
+  address: String!
   "Public name associated with the wallet address. This is visible to anyone with the wallet address URL."
   publicName: String
   "Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency)."

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1650,6 +1650,8 @@ input CreateTenantInput {
   idpSecret: String
   "Public name for the tenant."
   publicName: String
+  "Initial settings for tenant."
+  settings: [TenantSettingInput!]
 }
 
 input UpdateTenantInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1590,32 +1590,7 @@ type Tenant implements Model {
   "The date and time that this tenant was deleted."
   deletedAt: String
   "List of settings for the tenant."
-  settings(
-    "Forward pagination: Cursor (wallet address key ID) to start retrieving settings after this point."
-    after: String
-    "Backward pagination: Cursor (wallet address key ID) to start retrieving keys before this point."
-    before: String
-    "Forward pagination: Limit the result to the first **n** keys after the `after` cursor."
-    first: Int
-    "Backward pagination: Limit the result to the last **n** keys before the `before` cursor."
-    last: Int
-    "Specify the sort order of keys based on their creation data, either ascending or descending."
-    sortOrder: SortOrder
-  ): TenantSettingsConnection
-}
-
-type TenantSettingsConnection {
-  "Information to aid in pagination."
-  pageInfo: PageInfo!
-  "A list of edges representing tenant settings and cursors for pagination."
-  edges: [TenantSettingEdge!]!
-}
-
-type TenantSettingEdge {
-  "A tenant setting node in the list."
-  node: TenantSetting!
-  "A cursor for paginating through the tenants."
-  cursor: String!
+  settings: [TenantSetting!]
 }
 
 type TenantsConnection {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1590,7 +1590,7 @@ type Tenant implements Model {
   "The date and time that this tenant was deleted."
   deletedAt: String
   "List of settings for the tenant."
-  settings: [TenantSetting!]
+  settings: [TenantSetting!]!
 }
 
 type TenantsConnection {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -420,7 +420,8 @@ export function initIocContainer(
       accountingService: await deps.use('accountingService'),
       webhookService: await deps.use('webhookService'),
       assetService: await deps.use('assetService'),
-      walletAddressCache: await deps.use('walletAddressCache')
+      walletAddressCache: await deps.use('walletAddressCache'),
+      tenantSettingService: await deps.use('tenantSettingService')
     })
   })
   container.singleton('spspRoutes', async (deps) => {

--- a/packages/backend/src/open_payments/payment/incoming/model.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.test.ts
@@ -45,7 +45,7 @@ describe('Models', (): void => {
       walletAddress = await createWalletAddress(deps, {
         tenantId: Config.operatorTenantId
       })
-      baseUrl = new URL(walletAddress.url).origin
+      baseUrl = new URL(walletAddress.address).origin
       incomingPayment = await createIncomingPayment(deps, {
         walletAddressId: walletAddress.id,
         metadata: { description: 'my payment' },
@@ -57,7 +57,7 @@ describe('Models', (): void => {
       test('returns incoming payment', async () => {
         expect(incomingPayment.toOpenPaymentsType(walletAddress)).toEqual({
           id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           completed: incomingPayment.completed,
           receivedAmount: serializeAmount(incomingPayment.receivedAmount),
           incomingAmount: incomingPayment.incomingAmount
@@ -85,7 +85,7 @@ describe('Models', (): void => {
           )
         ).toEqual({
           id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           completed: incomingPayment.completed,
           receivedAmount: serializeAmount(incomingPayment.receivedAmount),
           incomingAmount: incomingPayment.incomingAmount
@@ -110,7 +110,7 @@ describe('Models', (): void => {
           incomingPayment.toOpenPaymentsTypeWithMethods(walletAddress)
         ).toEqual({
           id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           completed: incomingPayment.completed,
           receivedAmount: serializeAmount(incomingPayment.receivedAmount),
           incomingAmount: incomingPayment.incomingAmount
@@ -141,7 +141,7 @@ describe('Models', (): void => {
             )
           ).toEqual({
             id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
-            walletAddress: walletAddress.url,
+            walletAddress: walletAddress.address,
             completed: incomingPayment.completed,
             receivedAmount: serializeAmount(incomingPayment.receivedAmount),
             incomingAmount: incomingPayment.incomingAmount

--- a/packages/backend/src/open_payments/payment/incoming/model.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.ts
@@ -144,7 +144,7 @@ export class IncomingPayment
   }
 
   public getUrl(walletAddress: WalletAddress): string {
-    const url = new URL(walletAddress.url)
+    const url = new URL(walletAddress.address)
     return `${url.origin}/${walletAddress.tenantId}${IncomingPayment.urlPath}/${this.id}`
   }
 
@@ -225,7 +225,7 @@ export class IncomingPayment
   ): OpenPaymentsIncomingPayment {
     return {
       id: this.getUrl(walletAddress),
-      walletAddress: walletAddress.url,
+      walletAddress: walletAddress.address,
       incomingAmount: this.incomingAmount
         ? serializeAmount(this.incomingAmount)
         : undefined,

--- a/packages/backend/src/open_payments/payment/incoming/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.test.ts
@@ -59,7 +59,7 @@ describe('Incoming Payment Routes', (): void => {
       tenantId,
       assetId: asset.id
     })
-    baseUrl = new URL(walletAddress.url).origin
+    baseUrl = new URL(walletAddress.address).origin
     incomingAmount = {
       value: BigInt('123'),
       assetScale: asset.scale,
@@ -97,7 +97,7 @@ describe('Incoming Payment Routes', (): void => {
         const response: Partial<OpenPaymentsIncomingPaymentWithPaymentMethods> =
           {
             id: incomingPayment.getUrl(walletAddress),
-            walletAddress: walletAddress.url,
+            walletAddress: walletAddress.address,
             completed: false,
             incomingAmount:
               incomingPayment.incomingAmount &&
@@ -280,7 +280,7 @@ describe('Incoming Payment Routes', (): void => {
 
         expect(ctx.response.body).toEqual({
           id: `${baseUrl}/${tenantId}/incoming-payments/${incomingPaymentId}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           incomingAmount: incomingAmount ? amount : undefined,
           expiresAt: expiresAt || expect.any(String),
           createdAt: expect.any(String),
@@ -335,7 +335,7 @@ describe('Incoming Payment Routes', (): void => {
       expect(ctx.response).toSatisfyApiSpec()
       expect(ctx.body).toEqual({
         id: incomingPayment.getUrl(walletAddress),
-        walletAddress: walletAddress.url,
+        walletAddress: walletAddress.address,
         incomingAmount: {
           value: '123',
           assetCode: asset.code,

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -60,7 +60,7 @@ describe('Incoming Payment Service', (): void => {
       assetId: asset.id
     })
     walletAddressId = address.id
-    client = address.url
+    client = address.address
   })
 
   afterEach(async (): Promise<void> => {

--- a/packages/backend/src/open_payments/payment/outgoing/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/model.ts
@@ -108,7 +108,7 @@ export class OutgoingPayment
   }
 
   public getUrl(walletAddress: WalletAddress): string {
-    const url = new URL(walletAddress.url)
+    const url = new URL(walletAddress.address)
     return `${url.origin}/${this.tenantId}${OutgoingPayment.urlPath}/${this.id}`
   }
 
@@ -206,7 +206,7 @@ export class OutgoingPayment
   ): OpenPaymentsOutgoingPayment {
     return {
       id: this.getUrl(walletAddress),
-      walletAddress: walletAddress.url,
+      walletAddress: walletAddress.address,
       quoteId: this.quote?.getUrl(walletAddress) ?? undefined,
       receiveAmount: serializeAmount(this.receiveAmount),
       debitAmount: serializeAmount(this.debitAmount),

--- a/packages/backend/src/open_payments/payment/outgoing/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/routes.test.ts
@@ -84,7 +84,7 @@ describe('Outgoing Payment Routes', (): void => {
       tenantId,
       assetId: asset.id
     })
-    baseUrl = new URL(walletAddress.url).origin
+    baseUrl = new URL(walletAddress.address).origin
   })
 
   afterEach(async (): Promise<void> => {
@@ -121,7 +121,7 @@ describe('Outgoing Payment Routes', (): void => {
       getBody: (outgoingPayment) => {
         return {
           id: `${baseUrl}/${tenantId}/outgoing-payments/${outgoingPayment.id}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           receiver: outgoingPayment.receiver,
           quoteId: outgoingPayment.quote.getUrl(walletAddress),
           debitAmount: serializeAmount(outgoingPayment.debitAmount),
@@ -252,7 +252,7 @@ describe('Outgoing Payment Routes', (): void => {
             .pop()
           expect(ctx.response.body).toEqual({
             id: `${baseUrl}/${tenantId}/outgoing-payments/${outgoingPaymentId}`,
-            walletAddress: walletAddress.url,
+            walletAddress: walletAddress.address,
             receiver: payment.receiver,
             quoteId:
               'quoteId' in options ? options.quoteId : expect.any(String),

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -289,7 +289,7 @@ describe('OutgoingPaymentService', (): void => {
       assetId: sendAssetId
     })
     walletAddressId = walletAddress.id
-    client = walletAddress.url
+    client = walletAddress.address
     const { id: destinationAssetId } = await createAsset(deps, destinationAsset)
     receiverWalletAddress = await createWalletAddress(deps, {
       tenantId,

--- a/packages/backend/src/open_payments/quote/model.ts
+++ b/packages/backend/src/open_payments/quote/model.ts
@@ -66,7 +66,7 @@ export class Quote extends WalletAddressSubresource {
   private debitAmountValue!: bigint
 
   public getUrl(walletAddress: WalletAddress): string {
-    const url = new URL(walletAddress.url)
+    const url = new URL(walletAddress.address)
     return `${url.origin}/${this.tenantId}${Quote.urlPath}/${this.id}`
   }
 
@@ -134,7 +134,7 @@ export class Quote extends WalletAddressSubresource {
   public toOpenPaymentsType(walletAddress: WalletAddress): OpenPaymentsQuote {
     return {
       id: this.getUrl(walletAddress),
-      walletAddress: walletAddress.url,
+      walletAddress: walletAddress.address,
       receiveAmount: serializeAmount(this.receiveAmount),
       debitAmount: serializeAmount(this.debitAmount),
       receiver: this.receiver,

--- a/packages/backend/src/open_payments/quote/routes.test.ts
+++ b/packages/backend/src/open_payments/quote/routes.test.ts
@@ -85,7 +85,7 @@ describe('Quote Routes', (): void => {
       tenantId,
       assetId
     })
-    baseUrl = new URL(walletAddress.url).origin
+    baseUrl = new URL(walletAddress.address).origin
   })
 
   afterEach(async (): Promise<void> => {

--- a/packages/backend/src/open_payments/quote/routes.test.ts
+++ b/packages/backend/src/open_payments/quote/routes.test.ts
@@ -109,7 +109,7 @@ describe('Quote Routes', (): void => {
       getBody: (quote) => {
         return {
           id: `${baseUrl}/${quote.tenantId}/quotes/${quote.id}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           receiver: quote.receiver,
           debitAmount: serializeAmount(quote.debitAmount),
           receiveAmount: serializeAmount(quote.receiveAmount),
@@ -145,7 +145,7 @@ describe('Quote Routes', (): void => {
 
     test('returns error on invalid debitAmount asset', async (): Promise<void> => {
       options = {
-        walletAddress: walletAddress.url,
+        walletAddress: walletAddress.address,
         receiver,
         debitAmount: {
           ...debitAmount,
@@ -174,7 +174,7 @@ describe('Quote Routes', (): void => {
         '$description',
         async ({ debitAmount, receiveAmount }): Promise<void> => {
           options = {
-            walletAddress: walletAddress.url,
+            walletAddress: walletAddress.address,
             receiver,
             method: 'ilp'
           }
@@ -227,7 +227,7 @@ describe('Quote Routes', (): void => {
           assert.ok(quote)
           expect(ctx.response.body).toEqual({
             id: `${baseUrl}/${tenantId}/quotes/${quoteId}`,
-            walletAddress: walletAddress.url,
+            walletAddress: walletAddress.address,
             receiver: quote.receiver,
             debitAmount: {
               ...quote.debitAmount,
@@ -246,7 +246,7 @@ describe('Quote Routes', (): void => {
 
       test('receiver.incomingAmount', async (): Promise<void> => {
         options = {
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           receiver,
           method: 'ilp'
         }
@@ -279,7 +279,7 @@ describe('Quote Routes', (): void => {
         assert.ok(quote)
         expect(ctx.response.body).toEqual({
           id: `${baseUrl}/${tenantId}/quotes/${quoteId}`,
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           receiver: options.receiver,
           debitAmount: {
             ...quote.debitAmount,

--- a/packages/backend/src/open_payments/quote/service.test.ts
+++ b/packages/backend/src/open_payments/quote/service.test.ts
@@ -144,7 +144,7 @@ describe('QuoteService', (): void => {
         createQuote(deps, {
           tenantId,
           walletAddressId: sendingWalletAddress.id,
-          receiver: `${receivingWalletAddress.url}/incoming-payments/${uuid()}`,
+          receiver: `${receivingWalletAddress.address}/incoming-payments/${uuid()}`,
           debitAmount: {
             value: BigInt(56),
             assetCode: asset.code,
@@ -446,7 +446,7 @@ describe('QuoteService', (): void => {
         quoteService.create({
           tenantId: unknownTenantId,
           walletAddressId: walletAddress.id,
-          receiver: `${receivingWalletAddress.url}/incoming-payments/${uuid()}`,
+          receiver: `${receivingWalletAddress.address}/incoming-payments/${uuid()}`,
           debitAmount,
           method: 'ilp'
         })
@@ -466,7 +466,7 @@ describe('QuoteService', (): void => {
         quoteService.create({
           tenantId,
           walletAddressId: unknownWalletAddressId,
-          receiver: `${receivingWalletAddress.url}/incoming-payments/${uuid()}`,
+          receiver: `${receivingWalletAddress.address}/incoming-payments/${uuid()}`,
           debitAmount,
           method: 'ilp'
         })
@@ -490,7 +490,7 @@ describe('QuoteService', (): void => {
         quoteService.create({
           tenantId,
           walletAddressId: walletAddress.id,
-          receiver: `${receivingWalletAddress.url}/incoming-payments/${uuid()}`,
+          receiver: `${receivingWalletAddress.address}/incoming-payments/${uuid()}`,
           debitAmount,
           method: 'ilp'
         })
@@ -502,7 +502,7 @@ describe('QuoteService', (): void => {
         quoteService.create({
           tenantId,
           walletAddressId: sendingWalletAddress.id,
-          receiver: `${receivingWalletAddress.url}/incoming-payments/${uuid()}`,
+          receiver: `${receivingWalletAddress.address}/incoming-payments/${uuid()}`,
           debitAmount,
           method: 'ilp'
         })

--- a/packages/backend/src/open_payments/receiver/model.test.ts
+++ b/packages/backend/src/open_payments/receiver/model.test.ts
@@ -65,7 +65,7 @@ describe('Receiver Model', (): void => {
         sharedSecret: expect.any(Buffer),
         incomingPayment: {
           id: incomingPayment.getUrl(walletAddress),
-          walletAddress: walletAddress.url,
+          walletAddress: walletAddress.address,
           updatedAt: incomingPayment.updatedAt,
           createdAt: incomingPayment.createdAt,
           completed: incomingPayment.completed,

--- a/packages/backend/src/open_payments/receiver/service.test.ts
+++ b/packages/backend/src/open_payments/receiver/service.test.ts
@@ -105,7 +105,7 @@ describe('Receiver Service', (): void => {
           sharedSecret: expect.any(Buffer),
           incomingPayment: {
             id: incomingPayment.getUrl(walletAddress),
-            walletAddress: walletAddress.url,
+            walletAddress: walletAddress.address,
             incomingAmount: incomingPayment.incomingAmount,
             receivedAmount: incomingPayment.receivedAmount,
             completed: false,
@@ -315,7 +315,7 @@ describe('Receiver Service', (): void => {
             'create'
           )
           const receiver = await receiverService.create({
-            walletAddressUrl: walletAddress.url,
+            walletAddressUrl: walletAddress.address,
             incomingAmount,
             expiresAt,
             metadata,
@@ -367,7 +367,7 @@ describe('Receiver Service', (): void => {
 
         await expect(
           receiverService.create({
-            walletAddressUrl: walletAddress.url,
+            walletAddressUrl: walletAddress.address,
             tenantId
           })
         ).resolves.toEqual(ReceiverError.InvalidAmount)
@@ -380,7 +380,7 @@ describe('Receiver Service', (): void => {
 
         await expect(
           receiverService.create({
-            walletAddressUrl: walletAddress.url,
+            walletAddressUrl: walletAddress.address,
             tenantId
           })
         ).rejects.toThrow(

--- a/packages/backend/src/open_payments/wallet_address/errors.ts
+++ b/packages/backend/src/open_payments/wallet_address/errors.ts
@@ -4,7 +4,8 @@ export enum WalletAddressError {
   InvalidUrl = 'InvalidUrl',
   UnknownAsset = 'UnknownAsset',
   UnknownWalletAddress = 'UnknownWalletAddress',
-  DuplicateWalletAddress = 'DuplicateWalletAddress'
+  DuplicateWalletAddress = 'DuplicateWalletAddress',
+  WalletAddressSettingNotFound = 'WalletAddressSettingNotFound',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
@@ -17,7 +18,8 @@ export const errorToCode: {
   [WalletAddressError.InvalidUrl]: GraphQLErrorCode.BadUserInput,
   [WalletAddressError.UnknownAsset]: GraphQLErrorCode.BadUserInput,
   [WalletAddressError.UnknownWalletAddress]: GraphQLErrorCode.NotFound,
-  [WalletAddressError.DuplicateWalletAddress]: GraphQLErrorCode.Duplicate
+  [WalletAddressError.DuplicateWalletAddress]: GraphQLErrorCode.Duplicate,
+  [WalletAddressError.WalletAddressSettingNotFound]: GraphQLErrorCode.NotFound
 }
 
 export const errorToMessage: {
@@ -27,5 +29,7 @@ export const errorToMessage: {
   [WalletAddressError.UnknownAsset]: 'unknown asset',
   [WalletAddressError.UnknownWalletAddress]: 'unknown wallet address',
   [WalletAddressError.DuplicateWalletAddress]:
-    'Duplicate wallet address found with the same url'
+    'Duplicate wallet address found with the same url',
+  [WalletAddressError.WalletAddressSettingNotFound]:
+    'Setting for wallet address has not been found.'
 }

--- a/packages/backend/src/open_payments/wallet_address/errors.ts
+++ b/packages/backend/src/open_payments/wallet_address/errors.ts
@@ -5,7 +5,7 @@ export enum WalletAddressError {
   UnknownAsset = 'UnknownAsset',
   UnknownWalletAddress = 'UnknownWalletAddress',
   DuplicateWalletAddress = 'DuplicateWalletAddress',
-  WalletAddressSettingNotFound = 'WalletAddressSettingNotFound',
+  WalletAddressSettingNotFound = 'WalletAddressSettingNotFound'
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types

--- a/packages/backend/src/open_payments/wallet_address/key/routes.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/key/routes.test.ts
@@ -61,7 +61,7 @@ describe('Wallet Address Keys Routes', (): void => {
         headers: { Accept: 'application/json' },
         url: `/jwks.json`
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
 
       await expect(walletAddressKeyRoutes.get(ctx)).resolves.toBeUndefined()
       expect(ctx.response).toSatisfyApiSpec()
@@ -79,7 +79,7 @@ describe('Wallet Address Keys Routes', (): void => {
         headers: { Accept: 'application/json' },
         url: `/jwks.json`
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
 
       await expect(walletAddressKeyRoutes.get(ctx)).resolves.toBeUndefined()
       expect(ctx.body).toEqual({
@@ -134,7 +134,7 @@ describe('Wallet Address Keys Routes', (): void => {
       const ctx = createContext<WalletAddressUrlContext>({
         headers: { Accept: 'application/json' }
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
 
       const getOrPollByUrlSpy = jest.spyOn(
         walletAddressService,

--- a/packages/backend/src/open_payments/wallet_address/middleware.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/middleware.test.ts
@@ -142,7 +142,7 @@ describe('Wallet Address Middleware', (): void => {
       jest.spyOn(incomingPaymentService, 'get').mockResolvedValueOnce({
         id: incomingPaymentId,
         walletAddress: {
-          url: walletAddressUrl
+          address: walletAddressUrl
         }
       } as IncomingPayment)
 
@@ -203,7 +203,7 @@ describe('Wallet Address Middleware', (): void => {
       jest.spyOn(quoteService, 'get').mockResolvedValueOnce({
         id: quoteId,
         walletAddress: {
-          url: walletAddressUrl
+          address: walletAddressUrl
         }
       } as Quote)
 
@@ -319,7 +319,7 @@ describe('Wallet Address Middleware', (): void => {
       jest.spyOn(outgoingPaymentService, 'get').mockResolvedValueOnce({
         id: outgoingPaymentId,
         walletAddress: {
-          url: walletAddressUrl
+          address: walletAddressUrl
         }
       } as OutgoingPayment)
 
@@ -465,7 +465,7 @@ describe('Wallet Address Middleware', (): void => {
       const walletAddress = await createWalletAddress(deps, {
         tenantId: Config.operatorTenantId
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
 
       await walletAddress.$query().patch({ deactivatedAt: new Date() })
 
@@ -484,7 +484,7 @@ describe('Wallet Address Middleware', (): void => {
       const walletAddress = await createWalletAddress(deps, {
         tenantId: Config.operatorTenantId
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
 
       await expect(
         getWalletAddressForSubresource(ctx, next)

--- a/packages/backend/src/open_payments/wallet_address/middleware.ts
+++ b/packages/backend/src/open_payments/wallet_address/middleware.ts
@@ -54,7 +54,7 @@ export async function getWalletAddressUrlFromIncomingPayment(
     })
   }
 
-  ctx.walletAddressUrl = incomingPayment.walletAddress.url
+  ctx.walletAddressUrl = incomingPayment.walletAddress.address
   await next()
 }
 
@@ -77,7 +77,7 @@ export async function getWalletAddressUrlFromOutgoingPayment(
     })
   }
 
-  ctx.walletAddressUrl = outgoingPayment.walletAddress.url
+  ctx.walletAddressUrl = outgoingPayment.walletAddress.address
   await next()
 }
 
@@ -98,7 +98,7 @@ export async function getWalletAddressUrlFromQuote(
     })
   }
 
-  ctx.walletAddressUrl = quote.walletAddress.url
+  ctx.walletAddressUrl = quote.walletAddress.address
   await next()
 }
 

--- a/packages/backend/src/open_payments/wallet_address/model.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/model.test.ts
@@ -58,7 +58,7 @@ export const setup = <
     options.params
   )
   ctx.walletAddress = options.walletAddress
-  ctx.walletAddressUrl = options.walletAddress.url
+  ctx.walletAddressUrl = options.walletAddress.address
   ctx.grant = options.grant
   ctx.client = options.client
   ctx.accessAction = options.accessAction

--- a/packages/backend/src/open_payments/wallet_address/model.ts
+++ b/packages/backend/src/open_payments/wallet_address/model.ts
@@ -56,7 +56,7 @@ export class WalletAddress
   public keys?: WalletAddressKey[]
   public additionalProperties?: WalletAddressAdditionalProperty[]
 
-  public url!: string
+  public address!: string
   public publicName?: string
 
   public readonly assetId!: string
@@ -124,7 +124,7 @@ export class WalletAddress
     resourceServer: string
   }): OpenPaymentsWalletAddress {
     const returnVal: OpenPaymentsWalletAddress = {
-      id: this.url,
+      id: this.address,
       publicName: this.publicName,
       assetCode: this.asset.code,
       assetScale: this.asset.scale,

--- a/packages/backend/src/open_payments/wallet_address/routes.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/routes.test.ts
@@ -71,7 +71,7 @@ describe('Wallet Address Routes', (): void => {
       const ctx = createContext<WalletAddressUrlContext>({
         headers: { Accept: 'application/json' }
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
 
       const getOrPollByUrlSpy = jest.spyOn(
         walletAddressService,
@@ -112,11 +112,11 @@ describe('Wallet Address Routes', (): void => {
         headers: { Accept: 'application/json' },
         url: '/'
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
       await expect(walletAddressRoutes.get(ctx)).resolves.toBeUndefined()
       expect(ctx.response).toSatisfyApiSpec()
       expect(ctx.body).toEqual({
-        id: walletAddress.url,
+        id: walletAddress.address,
         publicName: walletAddress.publicName,
         assetCode: walletAddress.asset.code,
         assetScale: walletAddress.asset.scale,
@@ -156,11 +156,11 @@ describe('Wallet Address Routes', (): void => {
         headers: { Accept: 'application/json' },
         url: '/'
       })
-      ctx.walletAddressUrl = walletAddress.url
+      ctx.walletAddressUrl = walletAddress.address
       await expect(walletAddressRoutes.get(ctx)).resolves.toBeUndefined()
       expect(ctx.response).toSatisfyApiSpec()
       expect(ctx.body).toEqual({
-        id: walletAddress.url,
+        id: walletAddress.address,
         publicName: walletAddress.publicName,
         assetCode: walletAddress.asset.code,
         assetScale: walletAddress.asset.scale,

--- a/packages/backend/src/open_payments/wallet_address/service.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.test.ts
@@ -104,19 +104,22 @@ describe('Open Payments Wallet Address Service', (): void => {
     )
 
     test.each`
-      isOperator            | tenantSettingUrl
-      ${false}              | ${undefined}
-      ${true}               | ${undefined}
-      ${true}               | ${'https://alice.me'}
+      isOperator | tenantSettingUrl
+      ${false}   | ${undefined}
+      ${true}    | ${undefined}
+      ${true}    | ${'https://alice.me'}
     `(
-      'operator - $isOperator with tenantSettingUrl - $tenantSettingUrl', 
-      async({ isOperator, tenantSettingUrl }): Promise<void> => {
-        const config = await deps.use('config')
-        const address = "test"
+      'operator - $isOperator with tenantSettingUrl - $tenantSettingUrl',
+      async ({ isOperator, tenantSettingUrl }): Promise<void> => {
+        const address = 'test'
         const tempTenant = await createTenant(deps)
-        const { id: tempAssetId } = await createAsset(deps, undefined, tempTenant.id)
+        const { id: tempAssetId } = await createAsset(
+          deps,
+          undefined,
+          tempTenant.id
+        )
 
-        let expected: string = WalletAddressError.WalletAddressSettingNotFound;
+        let expected: string = WalletAddressError.WalletAddressSettingNotFound
         if (tenantSettingUrl) {
           await createTenantSettings(deps, {
             tenantId: tempTenant.id,
@@ -153,14 +156,13 @@ describe('Open Payments Wallet Address Service', (): void => {
 
     test('should return error without tenant settings if caller is not an operator', async () => {
       const tempTenant = await createTenant(deps)
-      
+
       expect(
         await walletAddressService.create({
           ...options,
           tenantId: tempTenant.id
         })
       ).toEqual(WalletAddressError.WalletAddressSettingNotFound)
-
     })
 
     test.each`

--- a/packages/backend/src/open_payments/wallet_address/service.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.test.ts
@@ -60,7 +60,7 @@ describe('Open Payments Wallet Address Service', (): void => {
   })
 
   describe('Create or Get Wallet Address3', (): void => {
-    let tenantId: string;
+    let tenantId: string
     let options: CreateOptions
 
     beforeEach(async (): Promise<void> => {
@@ -70,7 +70,10 @@ describe('Open Payments Wallet Address Service', (): void => {
       await createTenantSettings(deps, {
         tenantId: tenantId,
         setting: [
-          { key: TenantSettingKeys.WALLET_ADDRESS_URL.name, value: 'https://alice.me' }
+          {
+            key: TenantSettingKeys.WALLET_ADDRESS_URL.name,
+            value: 'https://alice.me'
+          }
         ]
       })
 
@@ -101,28 +104,31 @@ describe('Open Payments Wallet Address Service', (): void => {
     )
 
     test.each`
-    setting                       | address                           | generated
-    ${'https://alice.me/ilp'}     | ${'https://alice.me/ilp/test'}    | ${'https://alice.me/ilp/test'}
-    ${'https://alice.me/ilp'}     | ${'test'}                         | ${'https://alice.me/ilp/test'}
-    ${'https://alice.me/ilp'}     | ${'/test'}                         | ${'https://alice.me/ilp/test'}
-    ${'https://alice.me/ilp/'}    | ${'test'}                         | ${'https://alice.me/ilp/test'}
-    ${'https://alice.me/ilp/'}    | ${'/test'}                         | ${'https://alice.me/ilp/test'}
-    `('should create address $generated with address $address and setting $setting', async ({ setting, address, generated }): Promise<void> => {
-      await createTenantSettings(deps, {
-        tenantId: tenantId,
-        setting: [
-          { key: TenantSettingKeys.WALLET_ADDRESS_URL.name, value: setting }
-        ]
-      })
+      setting                    | address                        | generated
+      ${'https://alice.me/ilp'}  | ${'https://alice.me/ilp/test'} | ${'https://alice.me/ilp/test'}
+      ${'https://alice.me/ilp'}  | ${'test'}                      | ${'https://alice.me/ilp/test'}
+      ${'https://alice.me/ilp'}  | ${'/test'}                     | ${'https://alice.me/ilp/test'}
+      ${'https://alice.me/ilp/'} | ${'test'}                      | ${'https://alice.me/ilp/test'}
+      ${'https://alice.me/ilp/'} | ${'/test'}                     | ${'https://alice.me/ilp/test'}
+    `(
+      'should create address $generated with address $address and setting $setting',
+      async ({ setting, address, generated }): Promise<void> => {
+        await createTenantSettings(deps, {
+          tenantId: tenantId,
+          setting: [
+            { key: TenantSettingKeys.WALLET_ADDRESS_URL.name, value: setting }
+          ]
+        })
 
-      const walletAddress = await walletAddressService.create({
-        ...options,
-        address
-      })
+        const walletAddress = await walletAddressService.create({
+          ...options,
+          address
+        })
 
-      assert.ok(!isWalletAddressError(walletAddress))
-      expect(walletAddress.address).toEqual(generated)
-    })
+        assert.ok(!isWalletAddressError(walletAddress))
+        expect(walletAddress.address).toEqual(generated)
+      }
+    )
 
     test('Cannot create wallet address with unknown asset', async (): Promise<void> => {
       await expect(

--- a/packages/backend/src/open_payments/wallet_address/service.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.test.ts
@@ -165,6 +165,14 @@ describe('Open Payments Wallet Address Service', (): void => {
       ).toEqual(WalletAddressError.WalletAddressSettingNotFound)
     })
 
+    test('should return InvalidUrl error if wallet address URL does not start with tenant wallet address URL', async (): Promise<void> => {
+      const result = await walletAddressService.create({
+        ...options,
+        address: 'https://bob.me/.well-known/pay'
+      })
+      expect(result).toEqual(WalletAddressError.InvalidUrl)
+    })
+
     test.each`
       setting                    | address                        | generated
       ${'https://alice.me/ilp'}  | ${'https://alice.me/ilp/test'} | ${'https://alice.me/ilp/test'}

--- a/packages/backend/src/open_payments/wallet_address/service.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.test.ts
@@ -139,24 +139,6 @@ describe('Open Payments Wallet Address Service', (): void => {
       ).resolves.toEqual(WalletAddressError.UnknownAsset)
     })
 
-    test.each`
-      url                      | description
-      ${'not a url'}           | ${'without a valid url'}
-      ${'http://alice.me/pay'} | ${'with a non-https url'}
-      ${'https://alice.me'}    | ${'with a url without a path'}
-      ${'https://alice.me/'}   | ${'with a url without a path'}
-    `(
-      'Wallet address cannot be created $description ($url)',
-      async ({ url }): Promise<void> => {
-        await expect(
-          walletAddressService.create({
-            ...options,
-            address: url
-          })
-        ).resolves.toEqual(WalletAddressError.InvalidUrl)
-      }
-    )
-
     test.each(FORBIDDEN_PATHS.map((path) => [path]))(
       'Wallet address cannot be created with forbidden url path (%s)',
       async (path): Promise<void> => {

--- a/packages/backend/src/open_payments/wallet_address/service.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.ts
@@ -40,7 +40,7 @@ export type WalletAddressAdditionalPropertyInput = Pick<
 
 export interface CreateOptions extends Options {
   tenantId: string
-  url: string
+  address: string
   assetId: string
   additionalProperties?: WalletAddressAdditionalPropertyInput[]
 }
@@ -165,7 +165,7 @@ async function createWalletAddress(
   deps: ServiceDependencies,
   options: CreateOptions
 ): Promise<WalletAddress | WalletAddressError> {
-  if (!isValidWalletAddressUrl(options.url)) {
+  if (!isValidWalletAddressUrl(options.address)) {
     return WalletAddressError.InvalidUrl
   }
 
@@ -182,7 +182,7 @@ async function createWalletAddress(
       deps.knex
     ).insertGraphAndFetch({
       tenantId: options.tenantId,
-      url: options.url.toLowerCase(),
+      address: options.address.toLowerCase(),
       publicName: options.publicName,
       assetId: asset.id,
       additionalProperties: additionalProperties
@@ -341,7 +341,7 @@ async function getWalletAddressByUrl(
   if (tenantId) query.andWhere({ tenantId })
 
   const walletAddress = await query.findOne({
-    url: url.toLowerCase()
+    address: url.toLowerCase()
   })
   if (walletAddress) {
     const asset = await deps.assetService.get(walletAddress.assetId)

--- a/packages/backend/src/open_payments/wallet_address/service.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.ts
@@ -28,7 +28,7 @@ import { poll } from '../../shared/utils'
 import { WalletAddressAdditionalProperty } from './additional_property/model'
 import { AssetService } from '../../asset/service'
 import { CacheDataStore } from '../../middleware/cache/data-stores'
-import { TenantSetting, TenantSettingKeys } from '../../tenants/settings/model'
+import { TenantSettingKeys } from '../../tenants/settings/model'
 import { TenantSettingService } from '../../tenants/settings/service'
 
 interface Options {

--- a/packages/backend/src/open_payments/wallet_address/service.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.ts
@@ -236,7 +236,7 @@ async function createWalletAddress(
   const finalWalletAddressUrl = await createWalletAddressUrl(deps, options)
 
   if (isWalletAddressError(finalWalletAddressUrl)) {
-    return finalWalletAddressUrl;
+    return finalWalletAddressUrl
   }
 
   try {

--- a/packages/backend/src/open_payments/wallet_address/service.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.ts
@@ -173,10 +173,10 @@ async function createWalletAddressUrl(
 ): Promise<string | WalletAddressError> {
   let tenantWalletAddressUrl = new URL(deps.config.openPaymentsUrl)
 
-  const found = (await deps.tenantSettingService.get({
+  const found = await deps.tenantSettingService.get({
     tenantId: options.tenantId,
     key: TenantSettingKeys.WALLET_ADDRESS_URL.name
-  })) as TenantSetting[]
+  })
 
   if (!found || found.length === 0) {
     if (!options.isOperator) {

--- a/packages/backend/src/open_payments/wallet_address/service.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.ts
@@ -170,37 +170,38 @@ async function createWalletAddress(
   deps: ServiceDependencies,
   options: CreateOptions
 ): Promise<WalletAddress | WalletAddressError> {
-  const found = await deps.tenantSettingService.get({
+  const found = (await deps.tenantSettingService.get({
     tenantId: options.tenantId,
     key: TenantSettingKeys.WALLET_ADDRESS_URL.name
-  }) as TenantSetting[];
+  })) as TenantSetting[]
 
   if (!found || found.length === 0) {
-    return WalletAddressError.WalletAddressSettingNotFound;
+    return WalletAddressError.WalletAddressSettingNotFound
   }
 
-  const tenantWalletAddressUrl = new URL(found[0].value);
-  
-  let tenantBaseUrl = tenantWalletAddressUrl.toString();
+  const tenantWalletAddressUrl = new URL(found[0].value)
+
+  let tenantBaseUrl = tenantWalletAddressUrl.toString()
   if (!tenantWalletAddressUrl.pathname.endsWith('/')) {
-    tenantBaseUrl = tenantWalletAddressUrl.origin + tenantWalletAddressUrl.pathname + '/'
+    tenantBaseUrl =
+      tenantWalletAddressUrl.origin + tenantWalletAddressUrl.pathname + '/'
   }
 
   const isValidUrl = (str: string): boolean => {
     try {
-      new URL(str);
-      return true;
+      new URL(str)
+      return true
     } catch {
-      return false;
+      return false
     }
-  };
+  }
 
-  let finalWalletAddressUrl: string;
+  let finalWalletAddressUrl: string
   if (isValidUrl(options.address)) {
     // in case that client provided full url, verify that it starts with the tenant's URL
-    const walletAddressUrl = new URL(options.address);
+    const walletAddressUrl = new URL(options.address)
     if (!walletAddressUrl.href.startsWith(tenantWalletAddressUrl.href)) {
-      return WalletAddressError.InvalidUrl;
+      return WalletAddressError.InvalidUrl
     }
     finalWalletAddressUrl = walletAddressUrl.toString()
   } else {
@@ -212,10 +213,10 @@ async function createWalletAddress(
       }
       finalWalletAddressUrl = tenantBaseUrl + relativePath
     } catch (err) {
-      return WalletAddressError.InvalidUrl;
+      return WalletAddressError.InvalidUrl
     }
   }
-  
+
   if (!isValidWalletAddressUrl(finalWalletAddressUrl)) {
     return WalletAddressError.InvalidUrl
   }

--- a/packages/backend/src/shared/pagination.test.ts
+++ b/packages/backend/src/shared/pagination.test.ts
@@ -66,9 +66,9 @@ describe('Pagination', (): void => {
             first,
             last,
             cursor,
-            'wallet-address': walletAddress.url
+            'wallet-address': walletAddress.address
           })
-        ).toEqual({ ...result, walletAddress: walletAddress.url })
+        ).toEqual({ ...result, walletAddress: walletAddress.address })
       }
     )
   })
@@ -144,7 +144,7 @@ describe('Pagination', (): void => {
                   pagination
                 }),
               page,
-              walletAddress: defaultWalletAddress.url
+              walletAddress: defaultWalletAddress.address
             })
             expect(pageInfo).toEqual({
               startCursor: paymentIds[start],
@@ -179,7 +179,7 @@ describe('Pagination', (): void => {
               const payment = await createOutgoingPayment(deps, {
                 tenantId,
                 walletAddressId: defaultWalletAddress.id,
-                receiver: secondaryWalletAddress.url,
+                receiver: secondaryWalletAddress.address,
                 method: 'ilp',
                 debitAmount,
                 validDestination: false
@@ -202,7 +202,7 @@ describe('Pagination', (): void => {
                   pagination
                 }),
               page,
-              walletAddress: defaultWalletAddress.url
+              walletAddress: defaultWalletAddress.address
             })
             expect(pageInfo).toEqual({
               startCursor: paymentIds[start],
@@ -237,7 +237,7 @@ describe('Pagination', (): void => {
               const quote = await createQuote(deps, {
                 tenantId,
                 walletAddressId: defaultWalletAddress.id,
-                receiver: secondaryWalletAddress.url,
+                receiver: secondaryWalletAddress.address,
                 debitAmount,
                 validDestination: false,
                 method: 'ilp'
@@ -260,7 +260,7 @@ describe('Pagination', (): void => {
                   pagination
                 }),
               page,
-              walletAddress: defaultWalletAddress.url
+              walletAddress: defaultWalletAddress.address
             })
             expect(pageInfo).toEqual({
               startCursor: quoteIds[start],

--- a/packages/backend/src/tenants/service.test.ts
+++ b/packages/backend/src/tenants/service.test.ts
@@ -155,7 +155,10 @@ describe('Tenant Service', (): void => {
         idpConsentUrl: faker.internet.url(),
         idpSecret: 'test-idp-secret',
         settings: [
-          { key: TenantSettingKeys.WALLET_ADDRESS_URL.name, value: walletAddressUrl }
+          {
+            key: TenantSettingKeys.WALLET_ADDRESS_URL.name,
+            value: walletAddressUrl
+          }
         ]
       }
 

--- a/packages/backend/src/tenants/service.ts
+++ b/packages/backend/src/tenants/service.ts
@@ -109,6 +109,7 @@ async function createTenant(
       tenantId: tenant.id,
       setting: TenantSetting.default()
     }
+
     if (settings) {
       createInitialTenantSettingsOptions.setting =
         createInitialTenantSettingsOptions.setting.concat(settings)

--- a/packages/backend/src/tenants/service.ts
+++ b/packages/backend/src/tenants/service.ts
@@ -8,6 +8,7 @@ import { TenantSettingService } from './settings/service'
 import { TenantSetting } from './settings/model'
 import type { IAppConfig } from '../config/app'
 import { TenantError } from './errors'
+import { TenantSettingInput } from '../graphql/generated/graphql'
 
 export interface TenantService {
   get: (id: string, includeDeleted?: boolean) => Promise<Tenant | undefined>
@@ -79,6 +80,7 @@ interface CreateTenantOptions {
   idpSecret?: string
   idpConsentUrl?: string
   publicName?: string
+  settings?: TenantSettingInput[]
 }
 
 async function createTenant(
@@ -87,7 +89,7 @@ async function createTenant(
 ): Promise<Tenant> {
   const trx = await deps.knex.transaction()
   try {
-    const { email, apiSecret, publicName, idpSecret, idpConsentUrl } = options
+    const { email, apiSecret, publicName, idpSecret, idpConsentUrl, settings } = options
     const tenant = await Tenant.query(trx).insertAndFetch({
       email,
       publicName,
@@ -102,13 +104,13 @@ async function createTenant(
       idpConsentUrl
     })
 
-    await deps.tenantSettingService.create(
-      {
-        tenantId: tenant.id,
-        setting: TenantSetting.default()
-      },
-      { trx }
-    )
+    const createInitialTenantSettingsOptions = { tenantId: tenant.id, setting: TenantSetting.default() } ;
+    if (settings) {
+      createInitialTenantSettingsOptions.setting = createInitialTenantSettingsOptions.setting.concat(settings)
+    }
+    
+    await deps.tenantSettingService.create(createInitialTenantSettingsOptions, { trx }
+)
 
     await trx.commit()
 

--- a/packages/backend/src/tenants/service.ts
+++ b/packages/backend/src/tenants/service.ts
@@ -89,7 +89,8 @@ async function createTenant(
 ): Promise<Tenant> {
   const trx = await deps.knex.transaction()
   try {
-    const { email, apiSecret, publicName, idpSecret, idpConsentUrl, settings } = options
+    const { email, apiSecret, publicName, idpSecret, idpConsentUrl, settings } =
+      options
     const tenant = await Tenant.query(trx).insertAndFetch({
       email,
       publicName,
@@ -104,13 +105,18 @@ async function createTenant(
       idpConsentUrl
     })
 
-    const createInitialTenantSettingsOptions = { tenantId: tenant.id, setting: TenantSetting.default() } ;
-    if (settings) {
-      createInitialTenantSettingsOptions.setting = createInitialTenantSettingsOptions.setting.concat(settings)
+    const createInitialTenantSettingsOptions = {
+      tenantId: tenant.id,
+      setting: TenantSetting.default()
     }
-    
-    await deps.tenantSettingService.create(createInitialTenantSettingsOptions, { trx }
-)
+    if (settings) {
+      createInitialTenantSettingsOptions.setting =
+        createInitialTenantSettingsOptions.setting.concat(settings)
+    }
+
+    await deps.tenantSettingService.create(createInitialTenantSettingsOptions, {
+      trx
+    })
 
     await trx.commit()
 

--- a/packages/backend/src/tenants/settings/model.ts
+++ b/packages/backend/src/tenants/settings/model.ts
@@ -6,7 +6,8 @@ export const TenantSettingKeys = {
   EXCHANGE_RATES_URL: { name: 'EXCHANGE_RATES_URL' },
   WEBHOOK_URL: { name: 'WEBHOOK_URL' },
   WEBHOOK_TIMEOUT: { name: 'WEBHOOK_TIMEOUT', default: 2000 },
-  WEBHOOK_MAX_RETRY: { name: 'WEBHOOK_MAX_RETRY', default: 10 }
+  WEBHOOK_MAX_RETRY: { name: 'WEBHOOK_MAX_RETRY', default: 10 },
+  WALLET_ADDRESS_URL: { name: 'WALLET_ADDRESS_URL' }
 }
 
 export class TenantSetting extends BaseModel {

--- a/packages/backend/src/tenants/settings/model.ts
+++ b/packages/backend/src/tenants/settings/model.ts
@@ -2,7 +2,12 @@ import { Pojo } from 'objection'
 import { BaseModel } from '../../shared/baseModel'
 import { KeyValuePair } from './service'
 
-export const TenantSettingKeys = {
+interface TenantSettingKeyType {
+  name: string
+  default?: unknown
+}
+
+export const TenantSettingKeys: { [key: string]: TenantSettingKeyType } = {
   EXCHANGE_RATES_URL: { name: 'EXCHANGE_RATES_URL' },
   WEBHOOK_URL: { name: 'WEBHOOK_URL' },
   WEBHOOK_TIMEOUT: { name: 'WEBHOOK_TIMEOUT', default: 2000 },
@@ -30,15 +35,19 @@ export class TenantSetting extends BaseModel {
   }
 
   static default(): KeyValuePair[] {
-    return [
-      {
-        key: TenantSettingKeys.WEBHOOK_TIMEOUT.name,
-        value: TenantSettingKeys.WEBHOOK_TIMEOUT.default.toString()
-      },
-      {
-        key: TenantSettingKeys.WEBHOOK_MAX_RETRY.name,
-        value: TenantSettingKeys.WEBHOOK_MAX_RETRY.default.toString()
+    const settings = []
+    for (const key of Object.keys(TenantSettingKeys)) {
+      const data = TenantSettingKeys[key]
+      if (!data.default) {
+        continue
       }
-    ]
+
+      settings.push({
+        key: data.name,
+        value: String(data.default)
+      })
+    }
+
+    return settings
   }
 }

--- a/packages/backend/src/tenants/settings/service.test.ts
+++ b/packages/backend/src/tenants/settings/service.test.ts
@@ -300,4 +300,75 @@ describe('TenantSetting Service', (): void => {
       expect(dbTenantData.filter((x) => !x.deletedAt)).toHaveLength(0)
     })
   })
+
+  describe('getTenantSettings', () => {
+    let tenantSetting: TenantSetting[]
+
+    beforeEach(async (): Promise<void> => {
+      const createOptions: CreateOptions = {
+        tenantId: tenant.id,
+        setting: [exchangeRatesSetting()]
+      }
+
+      tenantSetting = await tenantSettingService.create(createOptions)
+    })
+
+    afterEach(async (): Promise<void> => {
+      await tenantSettingService.delete({ tenantId: tenant.id })
+    })
+
+    test('should retrieve tenant settings by tenantId', async (): Promise<void> => {
+      const result = await tenantSettingService.get({
+        tenantId: tenant.id
+      })
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            tenantId: tenant.id,
+            key: tenantSetting[0].key,
+            value: tenantSetting[0].value
+          })
+        ])
+      )
+    })
+
+    test('should retrieve tenant settings by tenantId and key', async (): Promise<void> => {
+      const result = await tenantSettingService.get({
+        tenantId: tenant.id,
+        key: tenantSetting[0].key
+      })
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          tenantId: tenant.id,
+          key: tenantSetting[0].key,
+          value: tenantSetting[0].value
+        })
+      ])
+    })
+
+    test('should return an empty array if no settings match', async (): Promise<void> => {
+      const result = await tenantSettingService.get({
+        tenantId: tenant.id,
+        key: 'nonexistent-key'
+      })
+
+      expect(result).toEqual([])
+    })
+
+    test('should not retrieve deleted tenant settings', async (): Promise<void> => {
+      await tenantSettingService.delete({
+        tenantId: tenant.id,
+        key: tenantSetting[0].key
+      })
+
+      const result = await tenantSettingService.get({
+        tenantId: tenant.id,
+        key: tenantSetting[0].key
+      })
+
+      expect(result).toEqual([])
+    })
+  })
 })

--- a/packages/backend/src/tenants/settings/service.test.ts
+++ b/packages/backend/src/tenants/settings/service.test.ts
@@ -91,6 +91,36 @@ describe('TenantSetting Service', (): void => {
 
       expect(tenantSetting).toEqual([])
     })
+
+    test('should update existing tenant settings on conflict - upsert', async (): Promise<void> => {
+      const initialOptions: CreateOptions = {
+        tenantId: tenant.id,
+        setting: [exchangeRatesSetting()]
+      }
+
+      await tenantSettingService.create(initialOptions)
+
+      const newValue = faker.internet.url()
+      const updatedOptions: CreateOptions = {
+        tenantId: tenant.id,
+        setting: [
+          {
+            key: initialOptions.setting[0].key,
+            value: newValue
+          }
+        ]
+      }
+
+      await tenantSettingService.create(updatedOptions)
+      const result = (await tenantSettingService.get({
+        tenantId: tenant.id,
+        key: initialOptions.setting[0].key
+      })) as TenantSetting[]
+
+      expect(result).toHaveLength(1)
+      expect(result[0].key).toEqual(initialOptions.setting[0].key)
+      expect(result[0].value).toEqual(newValue)
+    })
   })
 
   describe('get', () => {

--- a/packages/backend/src/tenants/settings/service.test.ts
+++ b/packages/backend/src/tenants/settings/service.test.ts
@@ -8,13 +8,7 @@ import { truncateTables } from '../../tests/tableManager'
 import { Tenant } from '../model'
 import { TenantService } from '../service'
 import { faker } from '@faker-js/faker'
-import { getPageTests } from '../../shared/baseModel.test'
-import { Pagination, SortOrder } from '../../shared/baseModel'
-import {
-  createTenantSettings,
-  exchangeRatesSetting,
-  randomSetting
-} from '../../tests/tenantSettings'
+import { exchangeRatesSetting, randomSetting } from '../../tests/tenantSettings'
 import { TenantSetting } from './model'
 import {
   CreateOptions,
@@ -274,23 +268,6 @@ describe('TenantSetting Service', (): void => {
       })
 
       expect(dbTenantData.filter((x) => !x.deletedAt)).toHaveLength(0)
-    })
-  })
-
-  describe('pagination', (): void => {
-    beforeEach(async () => {
-      await tenantSettingService.delete({ tenantId: tenant.id })
-    })
-    describe('getPage', (): void => {
-      getPageTests({
-        createModel: () =>
-          createTenantSettings(deps, {
-            tenantId: tenant.id,
-            setting: [exchangeRatesSetting()]
-          }) as Promise<TenantSetting>,
-        getPage: (pagination?: Pagination, sortOrder?: SortOrder) =>
-          tenantSettingService.getPage(tenant.id, pagination, sortOrder)
-      })
     })
   })
 })

--- a/packages/backend/src/tenants/settings/service.ts
+++ b/packages/backend/src/tenants/settings/service.ts
@@ -118,20 +118,23 @@ async function createTenantSetting(
   options: CreateOptions,
   extra?: ExtraOptions
 ) {
-  const dataToInsert = options.setting
+  const dataToUpsert = options.setting
     .filter((setting) => Object.keys(TenantSettingKeys).includes(setting.key))
     .map((s) => ({
       tenantId: options.tenantId,
       ...s
     }))
 
-  if (Object.keys(dataToInsert).length <= 0) {
+  if (Object.keys(dataToUpsert).length <= 0) {
     return []
   }
 
-  return TenantSetting.query(extra?.trx ?? deps.knex).insertAndFetch(
-    dataToInsert
-  )
+  return TenantSetting
+    .query(extra?.trx ?? deps.knex)
+    .insert(dataToUpsert)
+    .onConflict(['tenantId', 'key'])
+    .merge()
+    .returning('*');
 }
 
 async function getTenantSettingPageForTenant(

--- a/packages/backend/src/tenants/settings/service.ts
+++ b/packages/backend/src/tenants/settings/service.ts
@@ -129,12 +129,11 @@ async function createTenantSetting(
     return []
   }
 
-  return TenantSetting
-    .query(extra?.trx ?? deps.knex)
+  return TenantSetting.query(extra?.trx ?? deps.knex)
     .insert(dataToUpsert)
     .onConflict(['tenantId', 'key'])
     .merge()
-    .returning('*');
+    .returning('*')
 }
 
 async function getTenantSettingPageForTenant(

--- a/packages/backend/src/tests/tenantSettings.ts
+++ b/packages/backend/src/tests/tenantSettings.ts
@@ -1,6 +1,6 @@
 import { IocContract } from '@adonisjs/fold'
 import { AppServices } from '../app'
-import { TenantSetting } from '../tenants/settings/model'
+import { TenantSetting, TenantSettingKeys } from '../tenants/settings/model'
 import { CreateOptions, KeyValuePair } from '../tenants/settings/service'
 import { faker } from '@faker-js/faker'
 import { isTenantSettingError } from '../tenants/settings/errors'
@@ -16,7 +16,7 @@ export function randomSetting(): KeyValuePair {
 
 export function exchangeRatesSetting(): KeyValuePair {
   return {
-    key: 'EXCHANGE_RATES_URL',
+    key: TenantSettingKeys.EXCHANGE_RATES_URL.name,
     value: faker.internet.url()
   }
 }

--- a/packages/backend/src/tests/walletAddress.ts
+++ b/packages/backend/src/tests/walletAddress.ts
@@ -36,7 +36,9 @@ export async function createWalletAddress(
     assetId:
       options.assetId || (await createAsset(deps, undefined, tenantIdToUse)).id,
     tenantId: tenantIdToUse,
-    address: options.address || `https://${faker.internet.domainName()}/.well-known/pay`
+    address:
+      options.address ||
+      `https://${faker.internet.domainName()}/.well-known/pay`
   })) as MockWalletAddress
   if (isWalletAddressError(walletAddressOrError)) {
     throw new Error(walletAddressOrError)

--- a/packages/backend/src/tests/walletAddress.ts
+++ b/packages/backend/src/tests/walletAddress.ts
@@ -36,7 +36,7 @@ export async function createWalletAddress(
     assetId:
       options.assetId || (await createAsset(deps, undefined, tenantIdToUse)).id,
     tenantId: tenantIdToUse,
-    url: options.url || `https://${faker.internet.domainName()}/.well-known/pay`
+    address: options.address || `https://${faker.internet.domainName()}/.well-known/pay`
   })) as MockWalletAddress
   if (isWalletAddressError(walletAddressOrError)) {
     throw new Error(walletAddressOrError)
@@ -52,7 +52,7 @@ export async function createWalletAddress(
     )
   }
   if (options.mockServerPort) {
-    const url = new URL(walletAddressOrError.url)
+    const url = new URL(walletAddressOrError.address)
     walletAddressOrError.scope = nock(url.origin)
       .get((uri) => uri.startsWith(url.pathname))
       .matchHeader('Accept', /application\/((ilp-stream|spsp4)\+)?json*./)

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -378,6 +378,8 @@ export type CreateTenantInput = {
   idpSecret?: InputMaybe<Scalars['String']['input']>;
   /** Public name for the tenant. */
   publicName?: InputMaybe<Scalars['String']['input']>;
+  /** Initial settings for tenant. */
+  settings?: InputMaybe<Array<TenantSettingInput>>;
 };
 
 export type CreateTenantSettingsInput = {

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -1490,16 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<TenantSettingsConnection>;
-};
-
-
-export type TenantSettingsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortOrder?: InputMaybe<SortOrder>;
+  settings?: Maybe<Array<TenantSetting>>;
 };
 
 export type TenantEdge = {
@@ -1523,27 +1514,11 @@ export type TenantSetting = {
   value: Scalars['String']['output'];
 };
 
-export type TenantSettingEdge = {
-  __typename?: 'TenantSettingEdge';
-  /** A cursor for paginating through the tenants. */
-  cursor: Scalars['String']['output'];
-  /** A tenant setting node in the list. */
-  node: TenantSetting;
-};
-
 export type TenantSettingInput = {
   /** Key for this setting. */
   key: Scalars['String']['input'];
   /** Value of a setting for this key. */
   value: Scalars['String']['input'];
-};
-
-export type TenantSettingsConnection = {
-  __typename?: 'TenantSettingsConnection';
-  /** A list of edges representing tenant settings and cursors for pagination. */
-  edges: Array<TenantSettingEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
 };
 
 export type TenantsConnection = {
@@ -1917,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
@@ -2034,9 +2009,7 @@ export type ResolversTypes = {
   TenantEdge: ResolverTypeWrapper<Partial<TenantEdge>>;
   TenantMutationResponse: ResolverTypeWrapper<Partial<TenantMutationResponse>>;
   TenantSetting: ResolverTypeWrapper<Partial<TenantSetting>>;
-  TenantSettingEdge: ResolverTypeWrapper<Partial<TenantSettingEdge>>;
   TenantSettingInput: ResolverTypeWrapper<Partial<TenantSettingInput>>;
-  TenantSettingsConnection: ResolverTypeWrapper<Partial<TenantSettingsConnection>>;
   TenantsConnection: ResolverTypeWrapper<Partial<TenantsConnection>>;
   TransferState: ResolverTypeWrapper<Partial<TransferState>>;
   TransferType: ResolverTypeWrapper<Partial<TransferType>>;
@@ -2172,9 +2145,7 @@ export type ResolversParentTypes = {
   TenantEdge: Partial<TenantEdge>;
   TenantMutationResponse: Partial<TenantMutationResponse>;
   TenantSetting: Partial<TenantSetting>;
-  TenantSettingEdge: Partial<TenantSettingEdge>;
   TenantSettingInput: Partial<TenantSettingInput>;
-  TenantSettingsConnection: Partial<TenantSettingsConnection>;
   TenantsConnection: Partial<TenantsConnection>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
@@ -2643,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<ResolversTypes['TenantSettingsConnection']>, ParentType, ContextType, Partial<TenantSettingsArgs>>;
+  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2661,18 +2632,6 @@ export type TenantMutationResponseResolvers<ContextType = any, ParentType extend
 export type TenantSettingResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSetting'] = ResolversParentTypes['TenantSetting']> = {
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingEdge'] = ResolversParentTypes['TenantSettingEdge']> = {
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['TenantSetting'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingsConnection'] = ResolversParentTypes['TenantSettingsConnection']> = {
-  edges?: Resolver<Array<ResolversTypes['TenantSettingEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2851,8 +2810,6 @@ export type Resolvers<ContextType = any> = {
   TenantEdge?: TenantEdgeResolvers<ContextType>;
   TenantMutationResponse?: TenantMutationResponseResolvers<ContextType>;
   TenantSetting?: TenantSettingResolvers<ContextType>;
-  TenantSettingEdge?: TenantSettingEdgeResolvers<ContextType>;
-  TenantSettingsConnection?: TenantSettingsConnectionResolvers<ContextType>;
   TenantsConnection?: TenantsConnectionResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -1892,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -1490,7 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<Array<TenantSetting>>;
+  settings: Array<TenantSetting>;
 };
 
 export type TenantEdge = {
@@ -2614,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
+  settings?: Resolver<Array<ResolversTypes['TenantSetting']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -396,6 +396,8 @@ export type CreateTenantSettingsMutationResponse = {
 export type CreateWalletAddressInput = {
   /** Additional properties associated with the wallet address. */
   additionalProperties?: InputMaybe<Array<AdditionalPropertyInput>>;
+  /** Wallet address. This cannot be changed. */
+  address: Scalars['String']['input'];
   /** Unique identifier of the asset associated with the wallet address. This cannot be changed. */
   assetId: Scalars['String']['input'];
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
@@ -404,8 +406,6 @@ export type CreateWalletAddressInput = {
   publicName?: InputMaybe<Scalars['String']['input']>;
   /** Unique identifier of the tenant associated with the wallet address. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
   tenantId?: InputMaybe<Scalars['ID']['input']>;
-  /** Wallet address URL. This cannot be changed. */
-  url: Scalars['String']['input'];
 };
 
 export type CreateWalletAddressKeyInput = {
@@ -1671,6 +1671,8 @@ export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** Additional properties associated with the wallet address. */
   additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
+  /** Wallet Address. */
+  address: Scalars['String']['output'];
   /** Asset of the wallet address. */
   asset: Asset;
   /** The date and time when the wallet address was created. */
@@ -1691,8 +1693,6 @@ export type WalletAddress = Model & {
   status: WalletAddressStatus;
   /** Tenant ID of the wallet address. */
   tenantId?: Maybe<Scalars['String']['output']>;
-  /** Wallet Address URL. */
-  url: Scalars['String']['output'];
   /** List of keys associated with this wallet address */
   walletAddressKeys?: Maybe<WalletAddressKeyConnection>;
 };
@@ -2707,6 +2707,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
   additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
+  address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2717,7 +2718,6 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;
   status?: Resolver<ResolversTypes['WalletAddressStatus'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   walletAddressKeys?: Resolver<Maybe<ResolversTypes['WalletAddressKeyConnection']>, ParentType, ContextType, Partial<WalletAddressWalletAddressKeysArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -3090,7 +3090,7 @@ export type GetWalletAddressQueryVariables = Exact<{
 }>;
 
 
-export type GetWalletAddressQuery = { __typename?: 'Query', walletAddress?: { __typename?: 'WalletAddress', id: string, url: string, publicName?: string | null, status: WalletAddressStatus, createdAt: string, liquidity?: bigint | null, asset: { __typename?: 'Asset', id: string, code: string, scale: number, withdrawalThreshold?: bigint | null } } | null };
+export type GetWalletAddressQuery = { __typename?: 'Query', walletAddress?: { __typename?: 'WalletAddress', id: string, address: string, publicName?: string | null, status: WalletAddressStatus, createdAt: string, liquidity?: bigint | null, asset: { __typename?: 'Asset', id: string, code: string, scale: number, withdrawalThreshold?: bigint | null } } | null };
 
 export type ListWalletAddresssQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -3100,7 +3100,7 @@ export type ListWalletAddresssQueryVariables = Exact<{
 }>;
 
 
-export type ListWalletAddresssQuery = { __typename?: 'Query', walletAddresses: { __typename?: 'WalletAddressesConnection', edges: Array<{ __typename?: 'WalletAddressEdge', cursor: string, node: { __typename?: 'WalletAddress', id: string, publicName?: string | null, status: WalletAddressStatus, url: string } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
+export type ListWalletAddresssQuery = { __typename?: 'Query', walletAddresses: { __typename?: 'WalletAddressesConnection', edges: Array<{ __typename?: 'WalletAddressEdge', cursor: string, node: { __typename?: 'WalletAddress', id: string, publicName?: string | null, status: WalletAddressStatus, address: string } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean } } };
 
 export type UpdateWalletAddressMutationVariables = Exact<{
   input: UpdateWalletAddressInput;

--- a/packages/frontend/app/lib/api/wallet-address.server.ts
+++ b/packages/frontend/app/lib/api/wallet-address.server.ts
@@ -29,7 +29,7 @@ export const getWalletAddress = async (
       query GetWalletAddressQuery($id: String!) {
         walletAddress(id: $id) {
           id
-          url
+          address
           publicName
           status
           createdAt
@@ -77,7 +77,7 @@ export const listWalletAddresses = async (
               id
               publicName
               status
-              url
+              address
             }
           }
           pageInfo {

--- a/packages/frontend/app/routes/wallet-addresses.$walletAddressId.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.$walletAddressId.tsx
@@ -86,7 +86,7 @@ export default function ViewWalletAddressPage() {
                   />
                   <Input
                     label='URL'
-                    value={walletAddress.url}
+                    value={walletAddress.address}
                     disabled
                     readOnly
                   />

--- a/packages/frontend/app/routes/wallet-addresses._index.tsx
+++ b/packages/frontend/app/routes/wallet-addresses._index.tsx
@@ -69,7 +69,7 @@ export default function WalletAddressesPage() {
                   className='cursor-pointer'
                   onClick={() => navigate(`/wallet-addresses/${pp.node.id}`)}
                 >
-                  <Table.Cell>{pp.node.url}</Table.Cell>
+                  <Table.Cell>{pp.node.address}</Table.Cell>
                   <Table.Cell>
                     <div className='flex flex-col'>
                       {pp.node.publicName ? (

--- a/packages/frontend/app/routes/wallet-addresses.create.tsx
+++ b/packages/frontend/app/routes/wallet-addresses.create.tsx
@@ -162,7 +162,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const path = removeTrailingAndLeadingSlash(result.data.name)
 
   const response = await createWalletAddress(request, {
-    url: `${baseUrl}/${path}`,
+    address: `${baseUrl}/${path}`,
     publicName: result.data.publicName,
     assetId: result.data.asset,
     tenantId: result.data.tenantId,

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -378,6 +378,8 @@ export type CreateTenantInput = {
   idpSecret?: InputMaybe<Scalars['String']['input']>;
   /** Public name for the tenant. */
   publicName?: InputMaybe<Scalars['String']['input']>;
+  /** Initial settings for tenant. */
+  settings?: InputMaybe<Array<TenantSettingInput>>;
 };
 
 export type CreateTenantSettingsInput = {

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -1490,16 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<TenantSettingsConnection>;
-};
-
-
-export type TenantSettingsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortOrder?: InputMaybe<SortOrder>;
+  settings?: Maybe<Array<TenantSetting>>;
 };
 
 export type TenantEdge = {
@@ -1523,27 +1514,11 @@ export type TenantSetting = {
   value: Scalars['String']['output'];
 };
 
-export type TenantSettingEdge = {
-  __typename?: 'TenantSettingEdge';
-  /** A cursor for paginating through the tenants. */
-  cursor: Scalars['String']['output'];
-  /** A tenant setting node in the list. */
-  node: TenantSetting;
-};
-
 export type TenantSettingInput = {
   /** Key for this setting. */
   key: Scalars['String']['input'];
   /** Value of a setting for this key. */
   value: Scalars['String']['input'];
-};
-
-export type TenantSettingsConnection = {
-  __typename?: 'TenantSettingsConnection';
-  /** A list of edges representing tenant settings and cursors for pagination. */
-  edges: Array<TenantSettingEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
 };
 
 export type TenantsConnection = {
@@ -1917,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
@@ -2034,9 +2009,7 @@ export type ResolversTypes = {
   TenantEdge: ResolverTypeWrapper<Partial<TenantEdge>>;
   TenantMutationResponse: ResolverTypeWrapper<Partial<TenantMutationResponse>>;
   TenantSetting: ResolverTypeWrapper<Partial<TenantSetting>>;
-  TenantSettingEdge: ResolverTypeWrapper<Partial<TenantSettingEdge>>;
   TenantSettingInput: ResolverTypeWrapper<Partial<TenantSettingInput>>;
-  TenantSettingsConnection: ResolverTypeWrapper<Partial<TenantSettingsConnection>>;
   TenantsConnection: ResolverTypeWrapper<Partial<TenantsConnection>>;
   TransferState: ResolverTypeWrapper<Partial<TransferState>>;
   TransferType: ResolverTypeWrapper<Partial<TransferType>>;
@@ -2172,9 +2145,7 @@ export type ResolversParentTypes = {
   TenantEdge: Partial<TenantEdge>;
   TenantMutationResponse: Partial<TenantMutationResponse>;
   TenantSetting: Partial<TenantSetting>;
-  TenantSettingEdge: Partial<TenantSettingEdge>;
   TenantSettingInput: Partial<TenantSettingInput>;
-  TenantSettingsConnection: Partial<TenantSettingsConnection>;
   TenantsConnection: Partial<TenantsConnection>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
@@ -2643,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<ResolversTypes['TenantSettingsConnection']>, ParentType, ContextType, Partial<TenantSettingsArgs>>;
+  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2661,18 +2632,6 @@ export type TenantMutationResponseResolvers<ContextType = any, ParentType extend
 export type TenantSettingResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSetting'] = ResolversParentTypes['TenantSetting']> = {
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingEdge'] = ResolversParentTypes['TenantSettingEdge']> = {
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['TenantSetting'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingsConnection'] = ResolversParentTypes['TenantSettingsConnection']> = {
-  edges?: Resolver<Array<ResolversTypes['TenantSettingEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2851,8 +2810,6 @@ export type Resolvers<ContextType = any> = {
   TenantEdge?: TenantEdgeResolvers<ContextType>;
   TenantMutationResponse?: TenantMutationResponseResolvers<ContextType>;
   TenantSetting?: TenantSettingResolvers<ContextType>;
-  TenantSettingEdge?: TenantSettingEdgeResolvers<ContextType>;
-  TenantSettingsConnection?: TenantSettingsConnectionResolvers<ContextType>;
   TenantsConnection?: TenantsConnectionResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -396,6 +396,8 @@ export type CreateTenantSettingsMutationResponse = {
 export type CreateWalletAddressInput = {
   /** Additional properties associated with the wallet address. */
   additionalProperties?: InputMaybe<Array<AdditionalPropertyInput>>;
+  /** Wallet address. This cannot be changed. */
+  address: Scalars['String']['input'];
   /** Unique identifier of the asset associated with the wallet address. This cannot be changed. */
   assetId: Scalars['String']['input'];
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
@@ -404,8 +406,6 @@ export type CreateWalletAddressInput = {
   publicName?: InputMaybe<Scalars['String']['input']>;
   /** Unique identifier of the tenant associated with the wallet address. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
   tenantId?: InputMaybe<Scalars['ID']['input']>;
-  /** Wallet address URL. This cannot be changed. */
-  url: Scalars['String']['input'];
 };
 
 export type CreateWalletAddressKeyInput = {
@@ -1671,6 +1671,8 @@ export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** Additional properties associated with the wallet address. */
   additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
+  /** Wallet Address. */
+  address: Scalars['String']['output'];
   /** Asset of the wallet address. */
   asset: Asset;
   /** The date and time when the wallet address was created. */
@@ -1691,8 +1693,6 @@ export type WalletAddress = Model & {
   status: WalletAddressStatus;
   /** Tenant ID of the wallet address. */
   tenantId?: Maybe<Scalars['String']['output']>;
-  /** Wallet Address URL. */
-  url: Scalars['String']['output'];
   /** List of keys associated with this wallet address */
   walletAddressKeys?: Maybe<WalletAddressKeyConnection>;
 };
@@ -2707,6 +2707,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
   additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
+  address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2717,7 +2718,6 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;
   status?: Resolver<ResolversTypes['WalletAddressStatus'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   walletAddressKeys?: Resolver<Maybe<ResolversTypes['WalletAddressKeyConnection']>, ParentType, ContextType, Partial<WalletAddressWalletAddressKeysArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -1892,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -1490,7 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<Array<TenantSetting>>;
+  settings: Array<TenantSetting>;
 };
 
 export type TenantEdge = {
@@ -2614,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
+  settings?: Resolver<Array<ResolversTypes['TenantSetting']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/packages/mock-account-service-lib/src/requesters.ts
+++ b/packages/mock-account-service-lib/src/requesters.ts
@@ -341,7 +341,7 @@ export async function createWalletAddress(
   `
   const createWalletAddressInput: CreateWalletAddressInput = {
     assetId,
-    url: accountUrl,
+    address: accountUrl,
     publicName: accountName,
     additionalProperties: []
   }

--- a/packages/mock-account-service-lib/src/requesters.ts
+++ b/packages/mock-account-service-lib/src/requesters.ts
@@ -333,12 +333,13 @@ export async function createWalletAddress(
       createWalletAddress(input: $input) {
         walletAddress {
           id
-          url
+          address
           publicName
         }
       }
     }
   `
+
   const createWalletAddressInput: CreateWalletAddressInput = {
     assetId,
     address: accountUrl,
@@ -485,7 +486,7 @@ async function getWalletAddressByURL(
       walletAddressByUrl(url: $url) {
         id
         liquidity
-        url
+        address
         publicName
         asset {
           id

--- a/packages/mock-account-service-lib/src/seed.ts
+++ b/packages/mock-account-service-lib/src/seed.ts
@@ -152,7 +152,7 @@ export async function setupFromSeed(
       await mockAccounts.setWalletAddress(
         account.id,
         walletAddress.id,
-        walletAddress.url
+        walletAddress.address
       )
 
       await createWalletAddressKey({

--- a/test/integration/lib/admin-client.ts
+++ b/test/integration/lib/admin-client.ts
@@ -240,7 +240,7 @@ export class AdminClient {
             createWalletAddress(input: $input) {
               walletAddress {
                 id
-                url
+                address
                 publicName
               }
             }

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -378,6 +378,8 @@ export type CreateTenantInput = {
   idpSecret?: InputMaybe<Scalars['String']['input']>;
   /** Public name for the tenant. */
   publicName?: InputMaybe<Scalars['String']['input']>;
+  /** Initial settings for tenant. */
+  settings?: InputMaybe<Array<TenantSettingInput>>;
 };
 
 export type CreateTenantSettingsInput = {

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -1490,16 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<TenantSettingsConnection>;
-};
-
-
-export type TenantSettingsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortOrder?: InputMaybe<SortOrder>;
+  settings?: Maybe<Array<TenantSetting>>;
 };
 
 export type TenantEdge = {
@@ -1523,27 +1514,11 @@ export type TenantSetting = {
   value: Scalars['String']['output'];
 };
 
-export type TenantSettingEdge = {
-  __typename?: 'TenantSettingEdge';
-  /** A cursor for paginating through the tenants. */
-  cursor: Scalars['String']['output'];
-  /** A tenant setting node in the list. */
-  node: TenantSetting;
-};
-
 export type TenantSettingInput = {
   /** Key for this setting. */
   key: Scalars['String']['input'];
   /** Value of a setting for this key. */
   value: Scalars['String']['input'];
-};
-
-export type TenantSettingsConnection = {
-  __typename?: 'TenantSettingsConnection';
-  /** A list of edges representing tenant settings and cursors for pagination. */
-  edges: Array<TenantSettingEdge>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
 };
 
 export type TenantsConnection = {
@@ -1917,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
@@ -2034,9 +2009,7 @@ export type ResolversTypes = {
   TenantEdge: ResolverTypeWrapper<Partial<TenantEdge>>;
   TenantMutationResponse: ResolverTypeWrapper<Partial<TenantMutationResponse>>;
   TenantSetting: ResolverTypeWrapper<Partial<TenantSetting>>;
-  TenantSettingEdge: ResolverTypeWrapper<Partial<TenantSettingEdge>>;
   TenantSettingInput: ResolverTypeWrapper<Partial<TenantSettingInput>>;
-  TenantSettingsConnection: ResolverTypeWrapper<Partial<TenantSettingsConnection>>;
   TenantsConnection: ResolverTypeWrapper<Partial<TenantsConnection>>;
   TransferState: ResolverTypeWrapper<Partial<TransferState>>;
   TransferType: ResolverTypeWrapper<Partial<TransferType>>;
@@ -2172,9 +2145,7 @@ export type ResolversParentTypes = {
   TenantEdge: Partial<TenantEdge>;
   TenantMutationResponse: Partial<TenantMutationResponse>;
   TenantSetting: Partial<TenantSetting>;
-  TenantSettingEdge: Partial<TenantSettingEdge>;
   TenantSettingInput: Partial<TenantSettingInput>;
-  TenantSettingsConnection: Partial<TenantSettingsConnection>;
   TenantsConnection: Partial<TenantsConnection>;
   TriggerWalletAddressEventsInput: Partial<TriggerWalletAddressEventsInput>;
   TriggerWalletAddressEventsMutationResponse: Partial<TriggerWalletAddressEventsMutationResponse>;
@@ -2643,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<ResolversTypes['TenantSettingsConnection']>, ParentType, ContextType, Partial<TenantSettingsArgs>>;
+  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2661,18 +2632,6 @@ export type TenantMutationResponseResolvers<ContextType = any, ParentType extend
 export type TenantSettingResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSetting'] = ResolversParentTypes['TenantSetting']> = {
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingEdge'] = ResolversParentTypes['TenantSettingEdge']> = {
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['TenantSetting'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type TenantSettingsConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['TenantSettingsConnection'] = ResolversParentTypes['TenantSettingsConnection']> = {
-  edges?: Resolver<Array<ResolversTypes['TenantSettingEdge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2851,8 +2810,6 @@ export type Resolvers<ContextType = any> = {
   TenantEdge?: TenantEdgeResolvers<ContextType>;
   TenantMutationResponse?: TenantMutationResponseResolvers<ContextType>;
   TenantSetting?: TenantSettingResolvers<ContextType>;
-  TenantSettingEdge?: TenantSettingEdgeResolvers<ContextType>;
-  TenantSettingsConnection?: TenantSettingsConnectionResolvers<ContextType>;
   TenantsConnection?: TenantsConnectionResolvers<ContextType>;
   TriggerWalletAddressEventsMutationResponse?: TriggerWalletAddressEventsMutationResponseResolvers<ContextType>;
   UInt8?: GraphQLScalarType;

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -396,6 +396,8 @@ export type CreateTenantSettingsMutationResponse = {
 export type CreateWalletAddressInput = {
   /** Additional properties associated with the wallet address. */
   additionalProperties?: InputMaybe<Array<AdditionalPropertyInput>>;
+  /** Wallet address. This cannot be changed. */
+  address: Scalars['String']['input'];
   /** Unique identifier of the asset associated with the wallet address. This cannot be changed. */
   assetId: Scalars['String']['input'];
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
@@ -404,8 +406,6 @@ export type CreateWalletAddressInput = {
   publicName?: InputMaybe<Scalars['String']['input']>;
   /** Unique identifier of the tenant associated with the wallet address. This cannot be changed. Optional, if not provided, the tenantId will be obtained from the signature. */
   tenantId?: InputMaybe<Scalars['ID']['input']>;
-  /** Wallet address URL. This cannot be changed. */
-  url: Scalars['String']['input'];
 };
 
 export type CreateWalletAddressKeyInput = {
@@ -1671,6 +1671,8 @@ export type WalletAddress = Model & {
   __typename?: 'WalletAddress';
   /** Additional properties associated with the wallet address. */
   additionalProperties?: Maybe<Array<Maybe<AdditionalProperty>>>;
+  /** Wallet Address. */
+  address: Scalars['String']['output'];
   /** Asset of the wallet address. */
   asset: Asset;
   /** The date and time when the wallet address was created. */
@@ -1691,8 +1693,6 @@ export type WalletAddress = Model & {
   status: WalletAddressStatus;
   /** Tenant ID of the wallet address. */
   tenantId?: Maybe<Scalars['String']['output']>;
-  /** Wallet Address URL. */
-  url: Scalars['String']['output'];
   /** List of keys associated with this wallet address */
   walletAddressKeys?: Maybe<WalletAddressKeyConnection>;
 };
@@ -2707,6 +2707,7 @@ export type UpdateWalletAddressMutationResponseResolvers<ContextType = any, Pare
 
 export type WalletAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['WalletAddress'] = ResolversParentTypes['WalletAddress']> = {
   additionalProperties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AdditionalProperty']>>>, ParentType, ContextType>;
+  address?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   asset?: Resolver<ResolversTypes['Asset'], ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -2717,7 +2718,6 @@ export type WalletAddressResolvers<ContextType = any, ParentType extends Resolve
   quotes?: Resolver<Maybe<ResolversTypes['QuoteConnection']>, ParentType, ContextType, Partial<WalletAddressQuotesArgs>>;
   status?: Resolver<ResolversTypes['WalletAddressStatus'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   walletAddressKeys?: Resolver<Maybe<ResolversTypes['WalletAddressKeyConnection']>, ParentType, ContextType, Partial<WalletAddressWalletAddressKeysArgs>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -1892,7 +1892,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
   Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };

--- a/test/integration/lib/generated/graphql.ts
+++ b/test/integration/lib/generated/graphql.ts
@@ -1490,7 +1490,7 @@ export type Tenant = Model & {
   /** Public name for the tenant. */
   publicName?: Maybe<Scalars['String']['output']>;
   /** List of settings for the tenant. */
-  settings?: Maybe<Array<TenantSetting>>;
+  settings: Array<TenantSetting>;
 };
 
 export type TenantEdge = {
@@ -2614,7 +2614,7 @@ export type TenantResolvers<ContextType = any, ParentType extends ResolversParen
   idpConsentUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   idpSecret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   publicName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  settings?: Resolver<Maybe<Array<ResolversTypes['TenantSetting']>>, ParentType, ContextType>;
+  settings?: Resolver<Array<ResolversTypes['TenantSetting']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/test/integration/lib/integration-server.ts
+++ b/test/integration/lib/integration-server.ts
@@ -141,7 +141,7 @@ export class WebhookEventHandler {
     await this.accounts.setWalletAddress(
       account.id,
       walletAddress.id,
-      walletAddress.url
+      walletAddress.address
     )
   }
 

--- a/test/integration/lib/integration-server.ts
+++ b/test/integration/lib/integration-server.ts
@@ -129,7 +129,7 @@ export class WebhookEventHandler {
     const response = await this.adminClient.createWalletAddress({
       assetId,
       publicName,
-      url,
+      address: url,
       additionalProperties: []
     })
     const { walletAddress } = response


### PR DESCRIPTION
- feat(graphql): schema update for specifying settings when creating tenant
- feat(tenant): add possibility to specify initial tenant settings as an operator
- test(tenant): create with settings
- feat(wallet-address): rename url to address
- fix(tenant-settings): duplicate key for tenant
- feat(wallet-address): replace url field with address field
- chore(backend): format

<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- allow operator to specify wallet address range for tenant
- BREAKING CHANGE: replace url field in mutation with address because it will be possible to specify whole url or just a last part of it

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
- fixes #3278

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [x] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
