### PR TITLE
feat(auth): handle expired interactions gracefully during finish

### DIFF
--- a/packages/auth/src/interaction/routes.test.ts
+++ b/packages/auth/src/interaction/routes.test.ts
@@ -65,6 +65,7 @@ describe('Interaction Routes', (): void => {
   })
 
   afterEach(async (): Promise<void> => {
+    jest.restoreAllMocks()
     jest.useRealTimers()
     await truncateTables(appContainer.knex)
   })
@@ -98,34 +99,119 @@ describe('Interaction Routes', (): void => {
         })
       })
 
-      test('Interaction start fails if grant is revoked', async (): Promise<void> => {
-        const grant = await Grant.query().insert(
-          generateBaseGrant({
-            state: GrantState.Finalized,
-            finalizationReason: GrantFinalization.Revoked
-          })
-        )
+      test.each`
+        isFinishableGrant | description
+        ${true}           | ${'finishable'}
+        ${false}          | ${'unfinishable'}
+      `(
+        'Interaction start fails if $description grant is revoked',
+        async ({ isFinishableGrant }): Promise<void> => {
+          const grant = await Grant.query().insert(
+            generateBaseGrant({
+              noFinishMethod: !isFinishableGrant,
+              state: GrantState.Finalized,
+              finalizationReason: GrantFinalization.Revoked
+            })
+          )
 
-        const interaction = await Interaction.query().insert(
-          generateBaseInteraction(grant)
-        )
+          const interaction = await Interaction.query().insert(
+            generateBaseInteraction(grant)
+          )
 
-        const ctx = createContext<StartContext>(
-          {
-            headers: {
-              Accept: 'application/json',
-              'Content-Type': 'application/json'
-            }
-          },
-          { id: interaction.id, nonce: interaction.nonce }
-        )
+          const ctx = createContext<StartContext>(
+            {
+              headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+              },
+              url: `/interact/${interaction.id}/${interaction.nonce}`
+            },
+            { id: interaction.id, nonce: interaction.nonce }
+          )
 
-        await expect(interactionRoutes.start(ctx)).rejects.toMatchObject({
-          status: 403,
-          code: GNAPErrorCode.InvalidInteraction,
-          message: 'invalid interaction'
-        })
-      })
+          if (isFinishableGrant) {
+            const redirectSpy = jest.spyOn(ctx, 'redirect')
+            await expect(interactionRoutes.start(ctx)).resolves.toBeUndefined()
+            expect(ctx.status).toBe(302)
+            expect(ctx.response).toSatisfyApiSpec()
+
+            assert.ok(grant.finishUri)
+            const redirectUrl = new URL(grant.finishUri)
+            redirectUrl.searchParams.set(
+              'result',
+              GNAPErrorCode.InvalidInteraction
+            )
+            redirectUrl.searchParams.set('message', 'invalid interaction')
+            expect(redirectSpy).toHaveBeenCalledWith(redirectUrl.toString())
+          } else {
+            await expect(interactionRoutes.start(ctx)).rejects.toMatchObject({
+              status: 403,
+              code: GNAPErrorCode.InvalidInteraction,
+              message: 'invalid interaction'
+            })
+          }
+        }
+      )
+
+      test.each`
+        isFinishableGrant | description
+        ${true}           | ${'finishable'}
+        ${false}          | ${'unfinishable'}
+      `(
+        'handles unexpected error for $description grant',
+        async ({ isFinishableGrant }): Promise<void> => {
+          const grant = await Grant.query().insertAndFetch(
+            generateBaseGrant({
+              noFinishMethod: !isFinishableGrant
+            })
+          )
+
+          const interaction = await Interaction.query()
+            .insertAndFetch(generateBaseInteraction(grant))
+            .withGraphFetched('grant')
+
+          const ctx = createContext<StartContext>(
+            {
+              headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json'
+              },
+              query: {
+                clientName: 'Test Client',
+                clientUri: 'https://example.com'
+              },
+              url: `/interact/${interaction.id}/${interaction.nonce}`
+            },
+            { id: interaction.id, nonce: interaction.nonce }
+          )
+
+          const grantService = await deps.use('grantService')
+          const markPendingSpy = jest
+            .spyOn(grantService, 'markPending')
+            .mockRejectedValueOnce(new Error('unexpected'))
+
+          if (isFinishableGrant) {
+            const redirectSpy = jest.spyOn(ctx, 'redirect')
+            await expect(interactionRoutes.start(ctx)).resolves.toBeUndefined()
+            expect(ctx.status).toBe(302)
+            expect(ctx.response).toSatisfyApiSpec()
+
+            assert.ok(interaction.grant?.finishUri)
+            const redirectUrl = new URL(interaction.grant.finishUri)
+            redirectUrl.searchParams.set('result', GNAPErrorCode.RequestDenied)
+            redirectUrl.searchParams.set('message', 'internal server error')
+            expect(redirectSpy).toHaveBeenCalledWith(redirectUrl.toString())
+          } else {
+            await expect(interactionRoutes.start(ctx)).rejects.toMatchObject({
+              status: 500,
+              code: GNAPErrorCode.RequestDenied,
+              message: 'internal server error'
+            })
+          }
+
+          expect(markPendingSpy).toHaveBeenCalled()
+        }
+      )
 
       test('Can start an interaction', async (): Promise<void> => {
         const ctx = createContext<StartContext>(
@@ -390,6 +476,7 @@ describe('Interaction Routes', (): void => {
             'result',
             GNAPErrorCode.UnknownInteraction
           )
+          clientRedirectUri.searchParams.set('message', 'unknown interaction')
 
           const interaction = await Interaction.query().insert(
             generateBaseInteraction(grant)
@@ -422,6 +509,7 @@ describe('Interaction Routes', (): void => {
             'result',
             GNAPErrorCode.InvalidInteraction
           )
+          clientRedirectUri.searchParams.set('message', 'interaction expired')
           const interactionCreatedDate = new Date(interaction.createdAt)
           const now = new Date(
             interactionCreatedDate.getTime() +

--- a/packages/auth/src/interaction/routes.ts
+++ b/packages/auth/src/interaction/routes.ts
@@ -176,16 +176,16 @@ async function startInteraction(
     )
   }
 
-  const isInvalidInteraction =
-    interaction.state !== InteractionState.Pending ||
-    isRevokedGrant(interaction.grant)
-  if (isInvalidInteraction && !isFinishableGrant(interaction.grant)) {
+  const isValidInteraction =
+    interaction.state === InteractionState.Pending &&
+    !isRevokedGrant(interaction.grant)
+  if (!isValidInteraction && !isFinishableGrant(interaction.grant)) {
     throw new GNAPServerRouteError(
       403,
       GNAPErrorCode.InvalidInteraction,
       'invalid interaction'
     )
-  } else if (isInvalidInteraction && isFinishableGrant(interaction.grant)) {
+  } else if (!isValidInteraction && isFinishableGrant(interaction.grant)) {
     const clientRedirectUri = new URL(interaction.grant.finishUri)
     clientRedirectUri.searchParams.set(
       'result',


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds interaction expiry check to interaction finish endpoint, before the session check.
- Throws an error or redirects to client on interaction start and finish endpoints, depending on if the associated grant has a finish URI or not.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3318.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
