### PR TITLE
feat(auth): add event for grant revoked

### DIFF
--- a/packages/auth/jest.env.js
+++ b/packages/auth/jest.env.js
@@ -4,4 +4,5 @@ process.env.IDENTITY_SERVER_SECRET =
   '2pEcn2kkCclbOHQiGNEwhJ0rucATZhrA807HTm2rNXE='
 process.env.AUTH_SERVER_URL = 'http://localhost:3006'
 process.env.IDENTITY_SERVER_URL = 'http://localhost:3030/mock-idp/'
+process.env.WEBHOOK_ENABLED = 'true'
 process.env.WEBHOOK_URL = 'http://127.0.0.1:4001/webhook'

--- a/packages/auth/jest.env.js
+++ b/packages/auth/jest.env.js
@@ -4,3 +4,4 @@ process.env.IDENTITY_SERVER_SECRET =
   '2pEcn2kkCclbOHQiGNEwhJ0rucATZhrA807HTm2rNXE='
 process.env.AUTH_SERVER_URL = 'http://localhost:3006'
 process.env.IDENTITY_SERVER_URL = 'http://localhost:3030/mock-idp/'
+process.env.WEBHOOK_URL = 'http://127.0.0.1:4001/webhook'

--- a/packages/auth/migrations/20250321110501_create_webhook_events_table.js
+++ b/packages/auth/migrations/20250321110501_create_webhook_events_table.js
@@ -1,0 +1,28 @@
+exports.up = function (knex) {
+  return knex.schema.createTable('webhookEvents', function (table) {
+    table.uuid('id').notNullable().primary()
+
+    table.string('type').notNullable()
+    table.json('data').notNullable()
+    table.integer('attempts').notNullable().defaultTo(0)
+    table.integer('statusCode').nullable()
+
+    table
+      .uuid('grantId')
+      .nullable()
+      .references('grants.id')
+      .index()
+      .onDelete('CASCADE')
+
+    table.timestamp('processAt').nullable().defaultTo(knex.fn.now())
+
+    table.timestamp('createdAt').defaultTo(knex.fn.now())
+    table.timestamp('updatedAt').defaultTo(knex.fn.now())
+
+    table.index('processAt')
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('webhookEvents')
+}

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,6 +46,7 @@
     "koa-session": "^6.4.0",
     "objection": "^3.1.5",
     "objection-db-errors": "^1.1.2",
+    "@opentelemetry/api": "^1.8.0",
     "pg": "^8.11.3",
     "pino": "^8.19.0",
     "token-introspection": "workspace:*",

--- a/packages/auth/src/access/service.test.ts
+++ b/packages/auth/src/access/service.test.ts
@@ -19,7 +19,7 @@ describe('Access Service', (): void => {
   let deps: IocContract<AppServices>
   let appContainer: TestContainer
   let accessService: AccessService
-  let trx: Knex.Transaction
+  let knex: Knex
   let grant: Grant
 
   const generateBaseGrant = () => ({
@@ -34,17 +34,18 @@ describe('Access Service', (): void => {
   })
 
   beforeEach(async (): Promise<void> => {
-    grant = await Grant.query(trx).insertAndFetch(generateBaseGrant())
+    grant = await Grant.query(knex).insertAndFetch(generateBaseGrant())
   })
 
   beforeAll(async (): Promise<void> => {
     deps = initIocContainer(Config)
     appContainer = await createTestApp(deps)
     accessService = await deps.use('accessService')
+    knex = appContainer.knex
   })
 
   afterEach(async (): Promise<void> => {
-    await truncateTables(appContainer.knex)
+    await truncateTables(knex)
   })
 
   afterAll(async (): Promise<void> => {
@@ -108,7 +109,7 @@ describe('Access Service', (): void => {
         actions: [AccessAction.Create, AccessAction.Read, AccessAction.List]
       }
 
-      const access = await Access.query(trx).insert([
+      const access = await Access.query(knex).insert([
         {
           grantId: grant.id,
           type: incomingPaymentAccess.type,

--- a/packages/auth/src/access/utils.test.ts
+++ b/packages/auth/src/access/utils.test.ts
@@ -21,7 +21,7 @@ import { compareRequestAndGrantAccessItems } from './utils'
 describe('Access utilities', (): void => {
   let deps: IocContract<AppServices>
   let appContainer: TestContainer
-  let trx: Knex.Transaction
+  let knex: Knex
   let identifier: string
   let grant: Grant
   let grantAccessItem: Access
@@ -32,11 +32,12 @@ describe('Access utilities', (): void => {
   beforeAll(async (): Promise<void> => {
     deps = initIocContainer(Config)
     appContainer = await createTestApp(deps)
+    knex = appContainer.knex
   })
 
   beforeEach(async (): Promise<void> => {
     identifier = `https://example.com/${v4()}`
-    grant = await Grant.query(trx).insertAndFetch({
+    grant = await Grant.query(knex).insertAndFetch({
       state: GrantState.Processing,
       startMethod: [StartMethod.Redirect],
       continueToken: generateToken(),
@@ -47,7 +48,7 @@ describe('Access utilities', (): void => {
       client: faker.internet.url({ appendSlash: false })
     })
 
-    grantAccessItem = await Access.query(trx).insertAndFetch({
+    grantAccessItem = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.OutgoingPayment,
       actions: [AccessAction.Read, AccessAction.Create, AccessAction.List],
@@ -118,7 +119,7 @@ describe('Access utilities', (): void => {
   })
 
   test('Can compare an access item on a grant and an access item from a request with a subaction of the grant', async (): Promise<void> => {
-    const grantAccessItemSuperAction = await Access.query(trx).insertAndFetch({
+    const grantAccessItemSuperAction = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.OutgoingPayment,
       actions: [AccessAction.ReadAll],
@@ -156,7 +157,7 @@ describe('Access utilities', (): void => {
   })
 
   test('Can compare an access item on a grant and an access item from a request with different action ordering', async (): Promise<void> => {
-    const grantAccessItemSuperAction = await Access.query(trx).insertAndFetch({
+    const grantAccessItemSuperAction = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.OutgoingPayment,
       actions: [AccessAction.Create, AccessAction.ReadAll, AccessAction.List],
@@ -194,7 +195,7 @@ describe('Access utilities', (): void => {
   })
 
   test('Can compare an access item on a grant without an identifier with a request with an identifier', async (): Promise<void> => {
-    const grantAccessItemSuperAction = await Access.query(trx).insertAndFetch({
+    const grantAccessItemSuperAction = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.IncomingPayment,
       actions: [AccessAction.ReadAll],
@@ -233,7 +234,7 @@ describe('Access utilities', (): void => {
       }
     }
 
-    const grant = await Grant.query(trx).insertAndFetch({
+    const grant = await Grant.query(knex).insertAndFetch({
       state: GrantState.Processing,
       startMethod: [StartMethod.Redirect],
       continueToken: generateToken(),
@@ -244,7 +245,7 @@ describe('Access utilities', (): void => {
       client: faker.internet.url({ appendSlash: false })
     })
 
-    const grantAccessItem = await Access.query(trx).insertAndFetch({
+    const grantAccessItem = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.OutgoingPayment,
       actions: [AccessAction.Read, AccessAction.Create],
@@ -268,7 +269,7 @@ describe('Access utilities', (): void => {
   })
 
   test('access comparison fails if identifier mismatch', async (): Promise<void> => {
-    const grantAccessItemSuperAction = await Access.query(trx).insertAndFetch({
+    const grantAccessItemSuperAction = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.IncomingPayment,
       actions: [AccessAction.ReadAll],
@@ -290,7 +291,7 @@ describe('Access utilities', (): void => {
   })
 
   test('access comparison fails if type mismatch', async (): Promise<void> => {
-    const grantAccessItemSuperAction = await Access.query(trx).insertAndFetch({
+    const grantAccessItemSuperAction = await Access.query(knex).insertAndFetch({
       grantId: grant.id,
       type: AccessType.Quote,
       actions: [AccessAction.Read]

--- a/packages/auth/src/accessToken/routes.test.ts
+++ b/packages/auth/src/accessToken/routes.test.ts
@@ -28,7 +28,7 @@ import { GNAPErrorCode } from '../shared/gnapErrors'
 describe('Access Token Routes', (): void => {
   let deps: IocContract<AppServices>
   let appContainer: TestContainer
-  let trx: Knex.Transaction
+  let knex: Knex
   let accessTokenRoutes: AccessTokenRoutes
   let accessTokenService: AccessTokenService
   let grantService: GrantService
@@ -36,6 +36,7 @@ describe('Access Token Routes', (): void => {
   beforeAll(async (): Promise<void> => {
     deps = initIocContainer(Config)
     appContainer = await createTestApp(deps)
+    knex = appContainer.knex
     accessTokenRoutes = await deps.use('accessTokenRoutes')
     grantService = await deps.use('grantService')
     accessTokenService = await deps.use('accessTokenService')
@@ -96,12 +97,12 @@ describe('Access Token Routes', (): void => {
     const method = 'POST'
 
     beforeEach(async (): Promise<void> => {
-      grant = await Grant.query(trx).insertAndFetch(BASE_GRANT)
-      access = await Access.query(trx).insertAndFetch({
+      grant = await Grant.query(knex).insertAndFetch(BASE_GRANT)
+      access = await Access.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_ACCESS
       })
-      token = await AccessToken.query(trx).insertAndFetch({
+      token = await AccessToken.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_TOKEN
       })
@@ -285,7 +286,7 @@ describe('Access Token Routes', (): void => {
         type: 'quote',
         actions: ['create', 'read']
       }
-      await Access.query(trx).insertAndFetch({
+      await Access.query(knex).insertAndFetch({
         grantId: grant.id,
         ...secondAccess
       })
@@ -370,8 +371,8 @@ describe('Access Token Routes', (): void => {
     let token: AccessToken
 
     beforeEach(async (): Promise<void> => {
-      grant = await Grant.query(trx).insertAndFetch(BASE_GRANT)
-      token = await AccessToken.query(trx).insertAndFetch({
+      grant = await Grant.query(knex).insertAndFetch(BASE_GRANT)
+      token = await AccessToken.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_TOKEN
       })
@@ -380,7 +381,7 @@ describe('Access Token Routes', (): void => {
     test('Returns status 204 even if token does not exist', async (): Promise<void> => {
       const ctx = createTokenHttpSigContext(token, grant)
 
-      await token.$query(trx).delete()
+      await token.$query(knex).delete()
 
       await accessTokenRoutes.revoke(ctx)
       expect(ctx.response.status).toBe(204)
@@ -389,7 +390,7 @@ describe('Access Token Routes', (): void => {
     test('Returns status 204 if token has not expired', async (): Promise<void> => {
       const ctx = createTokenHttpSigContext(token, grant)
 
-      await token.$query(trx).patch({ expiresIn: 10000 })
+      await token.$query(knex).patch({ expiresIn: 10000 })
       await accessTokenRoutes.revoke(ctx)
       expect(ctx.response.status).toBe(204)
     })
@@ -397,7 +398,7 @@ describe('Access Token Routes', (): void => {
     test('Returns status 204 if token has expired', async (): Promise<void> => {
       const ctx = createTokenHttpSigContext(token, grant)
 
-      await token.$query(trx).patch({ expiresIn: -1 })
+      await token.$query(knex).patch({ expiresIn: -1 })
       await accessTokenRoutes.revoke(ctx)
       expect(ctx.response.status).toBe(204)
     })
@@ -409,12 +410,12 @@ describe('Access Token Routes', (): void => {
     let token: AccessToken
 
     beforeEach(async (): Promise<void> => {
-      grant = await Grant.query(trx).insertAndFetch(BASE_GRANT)
-      access = await Access.query(trx).insertAndFetch({
+      grant = await Grant.query(knex).insertAndFetch(BASE_GRANT)
+      access = await Access.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_ACCESS
       })
-      token = await AccessToken.query(trx).insertAndFetch({
+      token = await AccessToken.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_TOKEN
       })
@@ -450,7 +451,7 @@ describe('Access Token Routes', (): void => {
     test('Can rotate an expired token', async (): Promise<void> => {
       const ctx = createTokenHttpSigContext(token, grant)
 
-      await token.$query(trx).patch({ expiresIn: -1 })
+      await token.$query(knex).patch({ expiresIn: -1 })
       await accessTokenRoutes.rotate(ctx)
       expect(ctx.response.status).toBe(200)
       expect(ctx.response.get('Content-Type')).toBe(

--- a/packages/auth/src/accessToken/service.test.ts
+++ b/packages/auth/src/accessToken/service.test.ts
@@ -24,12 +24,13 @@ import { generateBaseGrant } from '../tests/grant'
 describe('Access Token Service', (): void => {
   let deps: IocContract<AppServices>
   let appContainer: TestContainer
-  let trx: Knex.Transaction
+  let knex: Knex
   let accessTokenService: AccessTokenService
 
   beforeAll(async (): Promise<void> => {
     deps = initIocContainer(Config)
     appContainer = await createTestApp(deps)
+    knex = appContainer.knex
     accessTokenService = await deps.use('accessTokenService')
   })
 
@@ -63,11 +64,11 @@ describe('Access Token Service', (): void => {
 
   let grant: Grant
   beforeEach(async (): Promise<void> => {
-    grant = await Grant.query(trx).insertAndFetch(
+    grant = await Grant.query(knex).insertAndFetch(
       generateBaseGrant({ state: GrantState.Approved })
     )
     grant.access = [
-      await Access.query(trx).insertAndFetch({
+      await Access.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_ACCESS
       })
@@ -88,7 +89,7 @@ describe('Access Token Service', (): void => {
   describe('getByManagementId', (): void => {
     let accessToken: AccessToken
     beforeEach(async (): Promise<void> => {
-      accessToken = await AccessToken.query(trx).insert({
+      accessToken = await AccessToken.query(knex).insert({
         value: 'test-access-token',
         managementId: v4(),
         grantId: grant.id,
@@ -97,7 +98,7 @@ describe('Access Token Service', (): void => {
     })
 
     test('Can get an access token by its managementId', async (): Promise<void> => {
-      const retrievedGrant = await Grant.query(trx).findById(grant.id)
+      const retrievedGrant = await Grant.query(knex).findById(grant.id)
       await expect(
         accessTokenService.getByManagementId(accessToken.managementId)
       ).resolves.toMatchObject({
@@ -132,7 +133,7 @@ describe('Access Token Service', (): void => {
     }
 
     beforeEach(async (): Promise<void> => {
-      accessToken = await AccessToken.query(trx).insert({
+      accessToken = await AccessToken.query(knex).insert({
         value: 'test-access-token',
         managementId: v4(),
         grantId: grant.id,
@@ -158,7 +159,7 @@ describe('Access Token Service', (): void => {
     })
 
     test('Can introspect active token for revoked grant', async (): Promise<void> => {
-      await grant.$query(trx).patch({
+      await grant.$query(knex).patch({
         state: GrantState.Finalized,
         finalizationReason: GrantFinalization.Revoked
       })
@@ -186,11 +187,11 @@ describe('Access Token Service', (): void => {
     })
 
     test('Introspection only returns requested access', async (): Promise<void> => {
-      const grantWithTwoAccesses = await Grant.query(trx).insertAndFetch(
+      const grantWithTwoAccesses = await Grant.query(knex).insertAndFetch(
         generateBaseGrant({ state: GrantState.Approved })
       )
       grantWithTwoAccesses.access = [
-        await Access.query(trx).insertAndFetch({
+        await Access.query(knex).insertAndFetch({
           grantId: grantWithTwoAccesses.id,
           ...BASE_ACCESS
         })
@@ -199,19 +200,21 @@ describe('Access Token Service', (): void => {
         type: 'quote',
         actions: ['create', 'read']
       }
-      const dbSecondAccess = await Access.query(trx).insertAndFetch({
+      const dbSecondAccess = await Access.query(knex).insertAndFetch({
         grantId: grantWithTwoAccesses.id,
         ...secondAccessItem
       })
 
       grantWithTwoAccesses.access.push(dbSecondAccess)
 
-      const accessTokenForTwoAccessGrant = await AccessToken.query(trx).insert({
-        value: 'test-access-token-two-access',
-        managementId: v4(),
-        grantId: grantWithTwoAccesses.id,
-        expiresIn: 1234
-      })
+      const accessTokenForTwoAccessGrant = await AccessToken.query(knex).insert(
+        {
+          value: 'test-access-token-two-access',
+          managementId: v4(),
+          grantId: grantWithTwoAccesses.id,
+          expiresIn: 1234
+        }
+      )
 
       await expect(
         accessTokenService.introspect(accessTokenForTwoAccessGrant.value, [
@@ -250,14 +253,14 @@ describe('Access Token Service', (): void => {
     let grant: Grant
     let token: AccessToken
     beforeEach(async (): Promise<void> => {
-      grant = await Grant.query(trx).insertAndFetch(
+      grant = await Grant.query(knex).insertAndFetch(
         generateBaseGrant({
           state: GrantState.Finalized,
           finalizationReason: GrantFinalization.Issued
         })
       )
 
-      token = await AccessToken.query(trx).insertAndFetch({
+      token = await AccessToken.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_TOKEN,
         value: generateToken(),
@@ -267,7 +270,7 @@ describe('Access Token Service', (): void => {
 
     describe('Revoke by token id', (): void => {
       test('Can revoke un-expired token', async (): Promise<void> => {
-        await token.$query(trx).patch({ expiresIn: 1000000 })
+        await token.$query(knex).patch({ expiresIn: 1000000 })
         await expect(accessTokenService.revoke(token.id)).resolves.toEqual({
           ...token,
           revokedAt: expect.any(Date),
@@ -275,7 +278,7 @@ describe('Access Token Service', (): void => {
         })
       })
       test('Can revoke even if token has already expired', async (): Promise<void> => {
-        await token.$query(trx).patch({ expiresIn: -1 })
+        await token.$query(knex).patch({ expiresIn: -1 })
         await expect(accessTokenService.revoke(token.id)).resolves.toEqual({
           ...token,
           revokedAt: expect.any(Date),
@@ -283,12 +286,12 @@ describe('Access Token Service', (): void => {
         })
       })
       test('Can revoke even if token has already been revoked', async (): Promise<void> => {
-        await token.$query(trx).delete()
+        await token.$query(knex).delete()
         await expect(
           accessTokenService.revoke(token.id)
         ).resolves.toBeUndefined()
         await expect(
-          AccessToken.query(trx).findById(token.id)
+          AccessToken.query(knex).findById(token.id)
         ).resolves.toBeUndefined()
       })
 
@@ -302,12 +305,12 @@ describe('Access Token Service', (): void => {
     })
     describe('Revoke by grant id', (): void => {
       test('Can revoke un-expired token', async (): Promise<void> => {
-        await token.$query(trx).patch({ expiresIn: 1000000 })
+        await token.$query(knex).patch({ expiresIn: 1000000 })
         await expect(
           accessTokenService.revokeByGrantId(grant.id)
         ).resolves.toEqual(1)
         await expect(
-          AccessToken.query(trx).findById(token.id)
+          AccessToken.query(knex).findById(token.id)
         ).resolves.toEqual({
           ...token,
           revokedAt: expect.any(Date),
@@ -315,12 +318,12 @@ describe('Access Token Service', (): void => {
         })
       })
       test('Can revoke even if token has already expired', async (): Promise<void> => {
-        await token.$query(trx).patch({ expiresIn: -1 })
+        await token.$query(knex).patch({ expiresIn: -1 })
         await expect(
           accessTokenService.revokeByGrantId(grant.id)
         ).resolves.toEqual(1)
         await expect(
-          AccessToken.query(trx).findById(token.id)
+          AccessToken.query(knex).findById(token.id)
         ).resolves.toEqual({
           ...token,
           revokedAt: expect.any(Date),
@@ -328,12 +331,12 @@ describe('Access Token Service', (): void => {
         })
       })
       test('Can revoke even if token has already been revoked', async (): Promise<void> => {
-        await token.$query(trx).delete()
+        await token.$query(knex).delete()
         await expect(
           accessTokenService.revokeByGrantId(grant.id)
         ).resolves.toEqual(0)
         await expect(
-          AccessToken.query(trx).findById(token.id)
+          AccessToken.query(knex).findById(token.id)
         ).resolves.toBeUndefined()
       })
 
@@ -352,17 +355,17 @@ describe('Access Token Service', (): void => {
     let token: AccessToken
     let originalTokenValue: string
     beforeEach(async (): Promise<void> => {
-      grant = await Grant.query(trx).insertAndFetch(
+      grant = await Grant.query(knex).insertAndFetch(
         generateBaseGrant({
           state: GrantState.Finalized,
           finalizationReason: GrantFinalization.Issued
         })
       )
-      await Access.query(trx).insertAndFetch({
+      await Access.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_ACCESS
       })
-      token = await AccessToken.query(trx).insertAndFetch({
+      token = await AccessToken.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_TOKEN,
         value: generateToken(),
@@ -372,16 +375,16 @@ describe('Access Token Service', (): void => {
     })
 
     test('Can rotate un-expired token', async (): Promise<void> => {
-      await token.$query(trx).patch({ expiresIn: 1000000 })
+      await token.$query(knex).patch({ expiresIn: 1000000 })
       const result = await accessTokenService.rotate(token.id)
       assert.ok(result)
       expect(result.value).not.toBe(originalTokenValue)
     })
     test('Can rotate expired token', async (): Promise<void> => {
-      await token.$query(trx).patch({ expiresIn: -1 })
+      await token.$query(knex).patch({ expiresIn: -1 })
       const result = await accessTokenService.rotate(token.id)
       assert.ok(result)
-      const rotatedToken = await AccessToken.query(trx).findOne({
+      const rotatedToken = await AccessToken.query(knex).findOne({
         managementId: result.managementId
       })
       assert.ok(rotatedToken)

--- a/packages/auth/src/accessToken/service.ts
+++ b/packages/auth/src/accessToken/service.ts
@@ -18,7 +18,7 @@ export interface AccessTokenService {
   ): Promise<{ grant: Grant; access: Access[] } | undefined>
   create(grantId: string, trx?: TransactionOrKnex): Promise<AccessToken>
   revoke(id: string, trx?: TransactionOrKnex): Promise<AccessToken | undefined>
-  revokeByGrantId(grantId: string, trx?: TransactionOrKnex): Promise<number>
+  revokeByGrantId(grantId: string, trx?: TransactionOrKnex): Promise<Date>
   rotate(id: string, trx?: TransactionOrKnex): Promise<AccessToken | undefined>
 }
 
@@ -126,12 +126,15 @@ async function revokeByGrantId(
   deps: ServiceDependencies,
   grantId: string,
   trx?: TransactionOrKnex
-): Promise<number> {
-  return await AccessToken.query(trx || deps.knex)
+): Promise<Date> {
+  const revokedAt = new Date()
+  await AccessToken.query(trx || deps.knex)
     .patch({
       revokedAt: new Date()
     })
     .where('grantId', grantId)
+
+  return revokedAt
 }
 async function createAccessToken(
   deps: ServiceDependencies,

--- a/packages/auth/src/accessToken/service.ts
+++ b/packages/auth/src/accessToken/service.ts
@@ -130,7 +130,7 @@ async function revokeByGrantId(
   const revokedAt = new Date()
   await AccessToken.query(trx || deps.knex)
     .patch({
-      revokedAt: new Date()
+      revokedAt
     })
     .where('grantId', grantId)
 

--- a/packages/auth/src/app.ts
+++ b/packages/auth/src/app.ts
@@ -146,7 +146,7 @@ export class App {
       }
 
       // if webhookUrl is not set, webhook events are not saved or processed
-      if (this.config.webhookUrl) {
+      if (this.config.webhookEnabled) {
         for (let i = 0; i < this.config.webhookWorkers; i++) {
           process.nextTick(() => this.processWebhook())
         }

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -83,7 +83,11 @@ export const Config = {
   signatureSecret: process.env.SIGNATURE_SECRET, // optional
   signatureVersion: envInt('SIGNATURE_VERSION', 1),
 
-  webhookUrl: process.env.WEBHOOK_URL, // optional
+  webhookEnabled: envBool('WEBHOOK_ENABLED', false),
+  webhookUrl:
+    process.env.WEBHOOK_ENABLED === 'true'
+      ? envString('WEBHOOK_URL')
+      : undefined, //  required only when WEBHOOK_ENABLED is true
   webhookWorkers: envInt('WEBHOOK_WORKERS', 1),
   webhookWorkerIdle: envInt('WEBHOOK_WORKER_IDLE', 200), // milliseconds
   webhookTimeout: envInt('WEBHOOK_TIMEOUT', 2000), // milliseconds

--- a/packages/auth/src/config/app.ts
+++ b/packages/auth/src/config/app.ts
@@ -78,7 +78,16 @@ export const Config = {
     process.env.REDIS_TLS_CA_FILE_PATH,
     process.env.REDIS_TLS_KEY_FILE_PATH,
     process.env.REDIS_TLS_CERT_FILE_PATH
-  )
+  ),
+
+  signatureSecret: process.env.SIGNATURE_SECRET, // optional
+  signatureVersion: envInt('SIGNATURE_VERSION', 1),
+
+  webhookUrl: process.env.WEBHOOK_URL, // optional
+  webhookWorkers: envInt('WEBHOOK_WORKERS', 1),
+  webhookWorkerIdle: envInt('WEBHOOK_WORKER_IDLE', 200), // milliseconds
+  webhookTimeout: envInt('WEBHOOK_TIMEOUT', 2000), // milliseconds
+  webhookMaxRetry: envInt('WEBHOOK_MAX_RETRY', 10)
 }
 
 function parseRedisTlsConfig(

--- a/packages/auth/src/grant/event.model.ts
+++ b/packages/auth/src/grant/event.model.ts
@@ -1,0 +1,29 @@
+import { WebhookEvent } from '../webhook/model'
+import { QueryContext } from 'objection'
+
+export enum GrantEventType {
+  GrantRevoked = 'grant.revoked'
+}
+
+export enum GrantEventError {
+  GrantIdRequired = 'Grant ID is required for grant events'
+}
+
+export interface GrantResponse {
+  id: string
+  revokedAt: string
+}
+
+export type GrantData = GrantResponse & WebhookEvent['data']
+export class GrantEvent extends WebhookEvent {
+  public type!: GrantEventType
+  public data!: GrantData
+
+  public $beforeInsert(context: QueryContext): void {
+    super.$beforeInsert(context)
+
+    if (!this.grantId) {
+      throw new Error(GrantEventError.GrantIdRequired)
+    }
+  }
+}

--- a/packages/auth/src/grant/model.ts
+++ b/packages/auth/src/grant/model.ts
@@ -9,7 +9,6 @@ import {
 } from '@interledger/open-payments'
 import { AccessToken, toOpenPaymentsAccessToken } from '../accessToken/model'
 import { Interaction } from '../interaction/model'
-import { WebhookEvent } from '../webhook/model'
 
 export enum StartMethod {
   Redirect = 'redirect'
@@ -42,6 +41,7 @@ export class Grant extends BaseModel {
     accessTokens: {
       relation: Model.HasManyRelation,
       modelClass: join(__dirname, '../accessToken/model'),
+      modelPaths: '',
       join: {
         from: 'grants.id',
         to: 'accessTokens.grantId'
@@ -192,31 +192,4 @@ export function isRevokedGrant(grant: Grant): boolean {
     grant.state === GrantState.Finalized &&
     grant.finalizationReason === GrantFinalization.Revoked
   )
-}
-
-export enum GrantEventType {
-  GrantRevoked = 'grant.revoked'
-}
-
-export enum GrantEventError {
-  GrantIdRequired = 'Grant ID is required for grant events'
-}
-
-export interface GrantResponse {
-  id: string
-  revokedAt: string
-}
-
-export type GrantData = GrantResponse & WebhookEvent['data']
-export class GrantEvent extends WebhookEvent {
-  public type!: GrantEventType
-  public data!: GrantData
-
-  public $beforeInsert(context: QueryContext): void {
-    super.$beforeInsert(context)
-
-    if (!this.grantId) {
-      throw new Error(GrantEventError.GrantIdRequired)
-    }
-  }
 }

--- a/packages/auth/src/grant/model.ts
+++ b/packages/auth/src/grant/model.ts
@@ -9,6 +9,7 @@ import {
 } from '@interledger/open-payments'
 import { AccessToken, toOpenPaymentsAccessToken } from '../accessToken/model'
 import { Interaction } from '../interaction/model'
+import { WebhookEvent } from '../webhook/model'
 
 export enum StartMethod {
   Redirect = 'redirect'
@@ -191,4 +192,31 @@ export function isRevokedGrant(grant: Grant): boolean {
     grant.state === GrantState.Finalized &&
     grant.finalizationReason === GrantFinalization.Revoked
   )
+}
+
+export enum GrantEventType {
+  GrantRevoked = 'grant.revoked'
+}
+
+export enum GrantEventError {
+  GrantIdRequired = 'Grant ID is required for grant events'
+}
+
+export interface GrantResponse {
+  id: string
+  revokedAt: string
+}
+
+export type GrantData = GrantResponse & WebhookEvent['data']
+export class GrantEvent extends WebhookEvent {
+  public type!: GrantEventType
+  public data!: GrantData
+
+  public $beforeInsert(context: QueryContext): void {
+    super.$beforeInsert(context)
+
+    if (!this.grantId) {
+      throw new Error(GrantEventError.GrantIdRequired)
+    }
+  }
 }

--- a/packages/auth/src/grant/service.ts
+++ b/packages/auth/src/grant/service.ts
@@ -8,9 +8,7 @@ import {
   GrantState,
   GrantFinalization,
   StartMethod,
-  FinishMethod,
-  GrantEvent,
-  GrantEventType
+  FinishMethod
 } from './model'
 import { AccessRequest } from '../access/types'
 import { AccessService } from '../access/service'
@@ -19,6 +17,7 @@ import { FilterString } from '../shared/filters'
 import { AccessTokenService } from '../accessToken/service'
 import { canSkipInteraction } from './utils'
 import { IAppConfig } from '../config/app'
+import { GrantEvent, GrantEventType } from './event.model'
 
 interface GrantFilter {
   identifier?: FilterString

--- a/packages/auth/src/grant/service.ts
+++ b/packages/auth/src/grant/service.ts
@@ -201,7 +201,7 @@ async function revokeGrant(
 
     const revokedAt = await accessTokenService.revokeByGrantId(grant.id, trx)
 
-    if (deps.config.webhookUrl) {
+    if (deps.config.webhookEnabled) {
       await GrantEvent.query(trx).insert({
         type: GrantEventType.GrantRevoked,
         grantId: grant.id,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -21,6 +21,7 @@ import {
 import { createInteractionService } from './interaction/service'
 import { getTokenIntrospectionOpenAPI } from 'token-introspection'
 import { Redis } from 'ioredis'
+import { createWebhookService } from './webhook/service'
 
 const container = initIocContainer(Config)
 const app = new App(container)
@@ -207,6 +208,14 @@ export function initIocContainer(
   container.singleton('redis', async (deps): Promise<Redis> => {
     const config = await deps.use('config')
     return new Redis(config.redisUrl, { tls: config.redisTls })
+  })
+
+  container.singleton('webhookService', async (deps) => {
+    return createWebhookService({
+      config: await deps.use('config'),
+      knex: await deps.use('knex'),
+      logger: await deps.use('logger')
+    })
   })
 
   return container

--- a/packages/auth/src/openapi/specs/webhooks.yaml
+++ b/packages/auth/src/openapi/specs/webhooks.yaml
@@ -1,0 +1,50 @@
+openapi: 3.1.0
+info:
+  title: Rafiki Auth Webhooks
+  version: 1.1.0
+  description: 'Webhook events fired by Rafiki Auth'
+  contact:
+    email: tech@interledger.org
+servers:
+  - url: 'https://account-servicing-entity.com/webhooks'
+webhooks:
+  grantRevoked:
+    post:
+      requestBody:
+        description: Notifies the account servicing entity that a grant was revoked.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/grantEvent'
+      responses:
+        '200':
+          description: Data received successfully
+
+components:
+  schemas:
+    grantEvent:
+      required:
+        - id
+        - type
+        - data
+      properties:
+        id:
+          type: string
+          format: uuid
+        type:
+          type: string
+          enum:
+            - grant.revoked
+        data:
+          type: object
+          required:
+            - id
+            - revokedAt
+          properties:
+            id:
+              type: string
+              format: uuid
+            revokedAt:
+              type: string
+              format: date-time
+      additionalProperties: false

--- a/packages/auth/src/signature/middleware.test.ts
+++ b/packages/auth/src/signature/middleware.test.ts
@@ -43,10 +43,12 @@ describe('Signature Service', (): void => {
   const CLIENT = faker.internet.url({ appendSlash: false })
   let testKeys: TestKeys
   let testClientKey: JWK
+  let knex: Knex
 
   beforeAll(async (): Promise<void> => {
     deps = initIocContainer(Config)
     appContainer = await createTestApp(deps)
+    knex = appContainer.knex
     testKeys = generateTestKeys()
     testClientKey = testKeys.publicKey
   })
@@ -60,7 +62,6 @@ describe('Signature Service', (): void => {
     let grant: Grant
     let interaction: Interaction
     let token: AccessToken
-    let trx: Knex.Transaction
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let next: () => Promise<any>
     let managementId: string
@@ -112,15 +113,15 @@ describe('Signature Service', (): void => {
     })
 
     beforeEach(async (): Promise<void> => {
-      grant = await Grant.query(trx).insertAndFetch(generateBaseGrant())
-      await Access.query(trx).insertAndFetch({
+      grant = await Grant.query(knex).insertAndFetch(generateBaseGrant())
+      await Access.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_ACCESS
       })
-      interaction = await Interaction.query(trx).insertAndFetch(
+      interaction = await Interaction.query(knex).insertAndFetch(
         generateBaseInteraction(grant)
       )
-      token = await AccessToken.query(trx).insertAndFetch({
+      token = await AccessToken.query(knex).insertAndFetch({
         grantId: grant.id,
         ...BASE_TOKEN
       })

--- a/packages/auth/src/tests/webhook.ts
+++ b/packages/auth/src/tests/webhook.ts
@@ -1,0 +1,24 @@
+import { v4 as uuid } from 'uuid'
+import { IocContract } from '@adonisjs/fold'
+import { AppServices } from '../app'
+import { WebhookEvent } from '../webhook/model'
+import { EventPayload } from '../webhook/service'
+import { createGrant } from './grant'
+
+type WebhookEventPayload = EventPayload & { grantId: string }
+
+export async function createWebhookEvent(
+  deps: IocContract<AppServices>,
+  overrides?: Partial<WebhookEventPayload>
+): Promise<WebhookEvent> {
+  const knex = await deps.use('knex')
+  const grant = await createGrant(deps)
+  const newEvent = {
+    id: uuid(),
+    grantId: grant.id,
+    type: 'grant.revoked',
+    data: { id: grant.id, revokedAt: new Date().toISOString() },
+    ...overrides
+  }
+  return await WebhookEvent.query(knex).insertAndFetch(newEvent)
+}

--- a/packages/auth/src/webhook/model.ts
+++ b/packages/auth/src/webhook/model.ts
@@ -1,0 +1,30 @@
+import { BaseModel } from '../shared/baseModel'
+import { join } from 'path'
+import { Grant } from '../grant/model'
+
+export class WebhookEvent extends BaseModel {
+  public static get tableName(): string {
+    return 'webhookEvents'
+  }
+
+  static relationMappings = () => ({
+    grant: {
+      relation: BaseModel.BelongsToOneRelation,
+      modelClass: join(__dirname, '../grant/model'),
+      join: {
+        from: 'webhookEvents.grantId',
+        to: 'grants.id'
+      }
+    }
+  })
+
+  public type!: string
+  public data!: Record<string, unknown>
+  public attempts!: number
+  public statusCode?: number
+  public processAt!: Date | null
+
+  public readonly grantId?: string
+
+  public grant?: Grant
+}

--- a/packages/auth/src/webhook/service.test.ts
+++ b/packages/auth/src/webhook/service.test.ts
@@ -1,0 +1,318 @@
+import assert from 'assert'
+import { Definition, ReplyHeaderValue, Scope } from 'nock'
+import nock from 'nock'
+import { URL } from 'url'
+import { Knex } from 'knex'
+import { v4 as uuid } from 'uuid'
+
+import { WebhookEvent } from './model'
+import {
+  WebhookService,
+  generateWebhookSignature,
+  RETRY_BACKOFF_MS
+} from './service'
+import { createTestApp, TestContainer } from '../tests/app'
+import { truncateTables } from '../tests/tableManager'
+import { Config } from '../config/app'
+import { IocContract } from '@adonisjs/fold'
+import { initIocContainer } from '../'
+import { AppServices } from '../app'
+import { getPageTests } from '../shared/baseModel.test'
+import { Pagination, SortOrder } from '../shared/baseModel'
+import { createWebhookEvent } from '../tests/webhook'
+import { GrantEventType } from '../grant/model'
+
+describe('Webhook Service', (): void => {
+  let deps: IocContract<AppServices>
+  let appContainer: TestContainer
+  let webhookService: WebhookService
+  let knex: Knex
+  let webhookUrl: URL
+  let event: WebhookEvent
+  const WEBHOOK_SECRET = 'test secret'
+
+  beforeAll(async (): Promise<void> => {
+    Config.signatureSecret = WEBHOOK_SECRET
+    Config.webhookMaxRetry = 10
+    deps = await initIocContainer(Config)
+    appContainer = await createTestApp(deps)
+    knex = appContainer.knex
+    webhookService = await deps.use('webhookService')
+    webhookUrl = new URL(Config.webhookUrl!)
+  })
+
+  afterEach(async (): Promise<void> => {
+    jest.useRealTimers()
+    await truncateTables(knex)
+  })
+
+  afterAll(async (): Promise<void> => {
+    await appContainer.shutdown()
+  })
+
+  describe('Get Webhook Event', (): void => {
+    beforeEach(async (): Promise<void> => {
+      event = await createWebhookEvent(deps)
+    })
+
+    test('A webhook event can be fetched', async (): Promise<void> => {
+      await expect(webhookService.getEvent(event.id)).resolves.toEqual(event)
+    })
+
+    test('Cannot fetch a bogus webhook event', async (): Promise<void> => {
+      await expect(webhookService.getEvent(uuid())).resolves.toBeUndefined()
+    })
+  })
+
+  describe('Get Webhook Events', (): void => {
+    let events: WebhookEvent[] = []
+
+    beforeEach(async (): Promise<void> => {
+      events = [
+        await createWebhookEvent(deps),
+        await createWebhookEvent(deps),
+        await createWebhookEvent(deps),
+        await createWebhookEvent(deps)
+      ]
+    })
+
+    test('Gets latest of any type when type not provided', async (): Promise<void> => {
+      const newLatestEvent = await createWebhookEvent(deps)
+      await expect(
+        webhookService.getLatestByResourceId({
+          grantId: newLatestEvent.grantId!
+        })
+      ).resolves.toEqual(newLatestEvent)
+    })
+
+    describe('Returns undefined if no match', (): void => {
+      test('Good grant id, bad event type', async (): Promise<void> => {
+        await expect(
+          webhookService.getLatestByResourceId({
+            grantId: events[0].grantId!,
+            types: ['nonexistant.event']
+          })
+        ).resolves.toBeUndefined()
+      })
+      test('Bad grant id, good event type', async (): Promise<void> => {
+        await expect(
+          webhookService.getLatestByResourceId({
+            grantId: uuid(),
+            types: [GrantEventType.GrantRevoked]
+          })
+        ).resolves.toBeUndefined()
+      })
+    })
+  })
+
+  describe('getPage', (): void => {
+    getPageTests({
+      createModel: () => createWebhookEvent(deps),
+      getPage: (pagination?: Pagination, sortOrder?: SortOrder) =>
+        webhookService.getPage({ pagination, sortOrder })
+    })
+  })
+
+  describe('getWebhookEventsPage', (): void => {
+    const eventOverrides = [
+      { type: 'fake_type' },
+      { type: 'fake_type' },
+      { type: 'fake_type_2' },
+      { type: 'fake_type_2' },
+      { type: 'fake_type_2' },
+      { type: 'fake_type' }
+    ]
+    let webhookEvents: WebhookEvent[] = []
+
+    beforeEach(async (): Promise<void> => {
+      for (const eventOverride of eventOverrides) {
+        webhookEvents.push(await createWebhookEvent(deps, eventOverride))
+      }
+    })
+    afterEach(async (): Promise<void> => {
+      webhookEvents = []
+    })
+
+    test('No filter gets all', async (): Promise<void> => {
+      const webhookEvents = await webhookService.getPage()
+      const allWebhookEvents = await WebhookEvent.query(knex)
+      expect(webhookEvents.length).toBe(allWebhookEvents.length)
+    })
+
+    const uniqueTypes = Array.from(
+      new Set(eventOverrides.map((event) => event.type))
+    )
+    test.each(uniqueTypes)('Filter by type: %s', async (type) => {
+      const webhookEvents = await webhookService.getPage({
+        filter: {
+          type: {
+            in: [type]
+          }
+        }
+      })
+      const expectedLength = webhookEvents.filter(
+        (event) => event.type === type
+      ).length
+      expect(webhookEvents.length).toBe(expectedLength)
+    })
+
+    test('Can paginate and filter', async (): Promise<void> => {
+      const type = 'fake_type'
+      const filter = { type: { in: [type] } }
+      const idsOfTypeY = webhookEvents
+        .filter((event) => event.type === type)
+        .map((event) => event.id)
+      idsOfTypeY.reverse() // default is descending
+      const page = await webhookService.getPage({
+        pagination: { first: 10, after: idsOfTypeY[0] },
+        filter
+      })
+      expect(page[0].id).toBe(idsOfTypeY[1])
+      expect(page.filter((event) => event.type === type).length).toBe(
+        page.length
+      )
+    })
+  })
+
+  describe('processNext', (): void => {
+    beforeEach(async (): Promise<void> => {
+      event = await createWebhookEvent(deps)
+    })
+
+    function mockWebhookServer(
+      status = 200,
+      expectedEvent: WebhookEvent = event
+    ): Scope {
+      return nock(webhookUrl.origin)
+        .post(webhookUrl.pathname, function (this: Definition, body) {
+          expect(body).toMatchObject({
+            id: expectedEvent.id,
+            type: expectedEvent.type,
+            data: expectedEvent.data
+          })
+          return true
+        })
+        .reply(status)
+    }
+
+    test('Does not process events not scheduled to be sent', async (): Promise<void> => {
+      await event.$query(knex).patch({
+        processAt: new Date(Date.now() + 30_000)
+      })
+      await expect(webhookService.getEvent(event.id)).resolves.toEqual(event)
+      await expect(webhookService.processNext()).resolves.toBeUndefined()
+    })
+
+    test('Sends webhook event', async (): Promise<void> => {
+      const scope = mockWebhookServer()
+      await expect(webhookService.processNext()).resolves.toEqual(event.id)
+      scope.done()
+      await expect(webhookService.getEvent(event.id)).resolves.toMatchObject({
+        attempts: 1,
+        statusCode: 200,
+        processAt: null
+      })
+    })
+
+    test('Signs webhook event', async (): Promise<void> => {
+      jest.useFakeTimers({
+        now: Date.now(),
+        advanceTimers: true // needed for nock when using fake timers
+      })
+
+      const scope = nock(webhookUrl.origin)
+        .post(webhookUrl.pathname, function (this: Definition, body) {
+          assert.ok(this.headers)
+          const headers = this.headers as Record<string, ReplyHeaderValue>
+          const signature = headers['rafiki-signature']
+          expect(
+            generateWebhookSignature(
+              body,
+              WEBHOOK_SECRET,
+              Config.signatureVersion
+            )
+          ).toEqual(signature)
+          return true
+        })
+        .reply(200)
+
+      await expect(webhookService.processNext()).resolves.toEqual(event.id)
+      scope.done()
+    })
+
+    test.each([[201], [400], [504]])(
+      'Schedules retry if request fails (%i)',
+      async (status): Promise<void> => {
+        const scope = mockWebhookServer(status)
+        await expect(webhookService.processNext()).resolves.toEqual(event.id)
+        scope.done()
+        const updatedEvent = await webhookService.getEvent(event.id)
+        assert.ok(updatedEvent?.processAt)
+        expect(updatedEvent).toMatchObject({
+          attempts: 1,
+          statusCode: status
+        })
+        expect(updatedEvent.processAt.getTime()).toBeGreaterThanOrEqual(
+          event.createdAt.getTime() + RETRY_BACKOFF_MS
+        )
+      }
+    )
+
+    test('Schedules retry if request times out', async (): Promise<void> => {
+      const scope = nock(webhookUrl.origin)
+        .post(webhookUrl.pathname)
+        .delayConnection(Config.webhookTimeout + 1)
+        .reply(200)
+      await expect(webhookService.processNext()).resolves.toEqual(event.id)
+      scope.done()
+      const updatedEvent = await webhookService.getEvent(event.id)
+      assert.ok(updatedEvent?.processAt)
+      expect(updatedEvent).toMatchObject({
+        attempts: 1,
+        statusCode: null
+      })
+      expect(updatedEvent.processAt.getTime()).toBeGreaterThanOrEqual(
+        event.createdAt.getTime() + RETRY_BACKOFF_MS
+      )
+    })
+
+    test('Does not send event if webhookMaxAttempts is reached', async (): Promise<void> => {
+      let requests = 0
+      nock(webhookUrl.origin)
+        .post('/')
+        .reply(200, () => {
+          requests++
+        })
+      await event.$query(knex).patch({
+        attempts: Config.webhookMaxRetry
+      })
+      await expect(webhookService.getEvent(event.id)).resolves.toEqual(event)
+      await expect(webhookService.processNext()).resolves.toBeUndefined()
+      expect(requests).toBe(0)
+    })
+
+    test('Skips the event if webhookMaxAttempts is reached (processes the next one)', async (): Promise<void> => {
+      await event.$query(knex).patch({
+        attempts: Config.webhookMaxRetry
+      })
+
+      const nextEvent = await createWebhookEvent(deps)
+      const scope = mockWebhookServer(200, nextEvent)
+
+      await expect(webhookService.getEvent(event.id)).resolves.toEqual(event)
+      await expect(webhookService.getEvent(nextEvent.id)).resolves.toEqual(
+        nextEvent
+      )
+
+      await expect(webhookService.processNext()).resolves.toBe(nextEvent.id)
+      scope.done()
+      await expect(
+        webhookService.getEvent(nextEvent.id)
+      ).resolves.toMatchObject({
+        attempts: 1,
+        statusCode: 200,
+        processAt: null
+      })
+    })
+  })
+})

--- a/packages/auth/src/webhook/service.test.ts
+++ b/packages/auth/src/webhook/service.test.ts
@@ -20,7 +20,7 @@ import { AppServices } from '../app'
 import { getPageTests } from '../shared/baseModel.test'
 import { Pagination, SortOrder } from '../shared/baseModel'
 import { createWebhookEvent } from '../tests/webhook'
-import { GrantEventType } from '../grant/model'
+import { GrantEventType } from '../grant/event.model'
 
 describe('Webhook Service', (): void => {
   let deps: IocContract<AppServices>

--- a/packages/auth/src/webhook/service.ts
+++ b/packages/auth/src/webhook/service.ts
@@ -1,0 +1,237 @@
+import axios, { isAxiosError } from 'axios'
+import { createHmac } from 'crypto'
+import { canonicalize } from 'json-canonicalize'
+
+import { WebhookEvent } from './model'
+import { IAppConfig } from '../config/app'
+import { BaseService } from '../shared/baseService'
+import { Pagination, SortOrder } from '../shared/baseModel'
+import { FilterString } from '../shared/filters'
+import { trace, Span } from '@opentelemetry/api'
+
+// First retry waits 10 seconds
+// Second retry waits 20 (more) seconds
+// Third retry waits 30 (more) seconds, etc. up to 60 seconds
+export const RETRY_BACKOFF_MS = 10_000
+
+interface WebhookEventFilter {
+  type?: FilterString
+}
+
+interface GetPageOptions {
+  pagination?: Pagination
+  filter?: WebhookEventFilter
+  sortOrder?: SortOrder
+}
+
+export interface WebhookService {
+  getEvent(id: string): Promise<WebhookEvent | undefined>
+  getLatestByResourceId(
+    options: WebhookByResourceIdOptions
+  ): Promise<WebhookEvent | undefined>
+  processNext(): Promise<string | undefined>
+  getPage(options?: GetPageOptions): Promise<WebhookEvent[]>
+}
+
+interface ServiceDependencies extends BaseService {
+  config: IAppConfig
+}
+
+export async function createWebhookService(
+  deps_: ServiceDependencies
+): Promise<WebhookService> {
+  const logger = deps_.logger.child({
+    service: 'WebhookService'
+  })
+  const deps = { ...deps_, logger }
+  return {
+    getEvent: (id) => getWebhookEvent(deps, id),
+    getLatestByResourceId: (options) =>
+      getLatestWebhookEventByResourceId(deps, options),
+    processNext: () => processNextWebhookEvent(deps),
+    getPage: (options) => getWebhookEventsPage(deps, options)
+  }
+}
+
+async function getWebhookEvent(
+  deps: ServiceDependencies,
+  id: string
+): Promise<WebhookEvent | undefined> {
+  return WebhookEvent.query(deps.knex).findById(id)
+}
+
+interface WebhookEventOptions {
+  types?: string[]
+}
+interface GrantOptions extends WebhookEventOptions {
+  grantId: string
+}
+type WebhookByResourceIdOptions = GrantOptions
+
+async function getLatestWebhookEventByResourceId(
+  deps: ServiceDependencies,
+  options: WebhookByResourceIdOptions
+): Promise<WebhookEvent | undefined> {
+  const { types } = options
+
+  const query = WebhookEvent.query(deps.knex)
+    .orderBy('createdAt', 'DESC')
+    .limit(1)
+
+  if (types && types.length) {
+    query.whereIn('type', types)
+  }
+
+  query.where({ grantId: options.grantId })
+
+  return await query.first()
+}
+
+// Fetch (and lock) a webhook event for work.
+// Returns the id of the processed event (if any).
+async function processNextWebhookEvent(
+  deps_: ServiceDependencies
+): Promise<string | undefined> {
+  if (!deps_.knex) {
+    throw new Error('Knex undefined')
+  }
+
+  const tracer = trace.getTracer('webhook_worker')
+
+  return tracer.startActiveSpan(
+    'processNextWebhookEvent',
+    async (span: Span) => {
+      return deps_.knex!.transaction(async (trx) => {
+        const now = Date.now()
+        const events = await WebhookEvent.query(trx)
+          .limit(1)
+          // Ensure the webhook event cannot be processed concurrently by multiple workers.
+          .forUpdate()
+          // If a webhook event is locked, don't wait — just come back for it later.
+          .skipLocked()
+          .where('attempts', '<', deps_.config.webhookMaxRetry)
+          .where('processAt', '<=', new Date(now).toISOString())
+
+        const event = events[0]
+        if (!event) return
+
+        const deps = {
+          ...deps_,
+          knex: trx,
+          logger: deps_.logger.child({
+            event: event.id
+          })
+        }
+
+        await sendWebhookEvent(deps, event)
+        span.end()
+        return event.id
+      })
+    }
+  )
+}
+
+type WebhookHeaders = {
+  'Content-Type': string
+  'Rafiki-Signature'?: string
+}
+
+async function sendWebhookEvent(
+  deps: ServiceDependencies,
+  event: WebhookEvent
+): Promise<void> {
+  if (!deps.config.webhookUrl) {
+    return
+  }
+
+  try {
+    const requestHeaders: WebhookHeaders = {
+      'Content-Type': 'application/json'
+    }
+
+    const body = {
+      id: event.id,
+      type: event.type,
+      data: event.data
+    }
+
+    if (deps.config.signatureSecret) {
+      requestHeaders['Rafiki-Signature'] = generateWebhookSignature(
+        body,
+        deps.config.signatureSecret,
+        deps.config.signatureVersion
+      )
+    }
+
+    await axios.post(deps.config.webhookUrl, body, {
+      timeout: deps.config.webhookTimeout,
+      headers: requestHeaders,
+      validateStatus: (status) => status === 200
+    })
+
+    await event.$query(deps.knex).patch({
+      attempts: event.attempts + 1,
+      statusCode: 200,
+      processAt: null
+    })
+  } catch (err) {
+    if (isAxiosError(err)) {
+      const attempts = event.attempts + 1
+      const errorMessage = err.message
+      deps.logger.warn(
+        {
+          attempts,
+          error: errorMessage
+        },
+        'webhook request failed'
+      )
+
+      await event.$query(deps.knex).patch({
+        attempts,
+        statusCode: err.response ? err.response.status : undefined,
+        processAt: new Date(
+          Date.now() + Math.min(attempts, 6) * RETRY_BACKOFF_MS
+        )
+      })
+    } else {
+      deps.logger.warn({ error: err }, 'error not type AxiosError')
+      throw err
+    }
+  }
+}
+
+export type EventPayload = Pick<WebhookEvent, 'id' | 'type' | 'data'>
+
+export function generateWebhookSignature(
+  event: EventPayload,
+  secret: string,
+  version: number
+): string {
+  const timestamp = Date.now()
+
+  const payload = `${timestamp}.${canonicalize({
+    id: event.id,
+    type: event.type,
+    data: event.data
+  })}`
+  const hmac = createHmac('sha256', secret)
+  hmac.update(payload)
+  const digest = hmac.digest('hex')
+
+  return `t=${timestamp}, v${version}=${digest}`
+}
+
+async function getWebhookEventsPage(
+  deps: ServiceDependencies,
+  options?: GetPageOptions
+): Promise<WebhookEvent[]> {
+  const { filter, pagination, sortOrder } = options ?? {}
+
+  const query = WebhookEvent.query(deps.knex)
+
+  if (filter?.type?.in && filter.type.in.length > 0) {
+    query.whereIn('type', filter.type.in)
+  }
+
+  return await query.getPage(pagination, sortOrder)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@koa/router':
         specifier: ^12.0.2
         version: 12.0.2
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.8.0
       ajv:
         specifier: ^8.12.0
         version: 8.12.0


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds webhook workers in Auth service. The webhook url is optional as not all ASE will need to process these events (at least for now). If webhook url is not provided the workers are not started and the events are not saved in db.
- Implements `grant.revoked` event.
- Replaces `trx` with `knex` in some tests where trx was not defined before being used.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
fixes #2898

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [x] OpenAPI specs updated (if necessary)
