### PR TITLE
feat(backend): rework fixed send fee calculation

### DIFF
--- a/packages/backend/src/open_payments/quote/service.test.ts
+++ b/packages/backend/src/open_payments/quote/service.test.ts
@@ -652,8 +652,8 @@ describe('QuoteService', (): void => {
         ${200n}          | ${0}     | ${0}          | ${1.0}       | ${200n}                    | ${'no fees, equal exchange rate'}
         ${200n}          | ${20}    | ${0}          | ${0.5}       | ${90n}                     | ${'fixed fee'}
         ${200n}          | ${101n}  | ${0}          | ${1.0}       | ${99n}                     | ${'fixed fee larger than receiveAmount, equal exchange rate'}
-        ${200n}          | ${0}     | ${200}        | ${0.5}       | ${99n}                     | ${'basis point fee'}
-        ${200n}          | ${20}    | ${200}        | ${0.5}       | ${89n}                     | ${'fixed and basis point fee'}
+        ${200n}          | ${0}     | ${200}        | ${0.5}       | ${98n}                     | ${'basis point fee'}
+        ${200n}          | ${20}    | ${200}        | ${0.5}       | ${88n}                     | ${'fixed and basis point fee'}
         ${200n}          | ${20}    | ${200}        | ${0.455}     | ${80n}                     | ${'fixed and basis point fee with floating exchange rate'}
       `(
         '$description',
@@ -666,7 +666,7 @@ describe('QuoteService', (): void => {
         }): Promise<void> => {
           const receiver = await createReceiver(deps, receivingWalletAddress)
 
-          await Fee.query().insertAndFetch({
+          const sendingFee = await Fee.query().insertAndFetch({
             assetId: sendAsset.id,
             type: FeeType.Sending,
             fixedFee,
@@ -676,7 +676,8 @@ describe('QuoteService', (): void => {
           const mockedQuote = mockQuote({
             receiver,
             walletAddress: sendingWalletAddress,
-            debitAmountValue,
+            debitAmountValue:
+              debitAmountValue - sendingFee.calculate(debitAmountValue),
             exchangeRate
           })
 
@@ -708,7 +709,7 @@ describe('QuoteService', (): void => {
         const receiver = await createReceiver(deps, receivingWalletAddress)
         const debitAmountValue = 100n
 
-        await Fee.query().insertAndFetch({
+        const fee = await Fee.query().insertAndFetch({
           assetId: sendAsset.id,
           type: FeeType.Sending,
           fixedFee: debitAmountValue + 1n,
@@ -718,7 +719,7 @@ describe('QuoteService', (): void => {
         const mockedQuote = mockQuote({
           receiver,
           walletAddress: sendingWalletAddress,
-          debitAmountValue: debitAmountValue,
+          debitAmountValue: debitAmountValue - fee.calculate(debitAmountValue),
           exchangeRate: 1.0
         })
 

--- a/packages/backend/src/tests/quote.ts
+++ b/packages/backend/src/tests/quote.ts
@@ -47,7 +47,7 @@ export function mockQuote(
       value:
         'receiveAmountValue' in args
           ? args.receiveAmountValue
-          : BigInt(Math.ceil(Number(args.debitAmountValue) * exchangeRate))
+          : BigInt(Math.floor(Number(args.debitAmountValue) * exchangeRate))
     },
     estimatedExchangeRate: exchangeRate,
     ...overrides


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
For fixed debit amounts:
- moved fee calculation before payment quote retrieval (using options.debitAmount)
- subtracted receive amount value from payment quote retrieval
- fee is calculated with the options.debitAmount.value as principal
- added fee back to the final quote to insert in db

For fixed receive amounts:
- moved fee calculation after payment quote retrieval for fixed debit amounts (as quote.debitAmount is needed, rather than the options.debitAmount). This cannot be done before retrieving the payment quote because we don't know the peer's exchange rate in advance.
- fee is calculated with quote.debitAmount.value as principal
- added to the final quote to insert in db

Changed `mockQuote`'s receiveAmount logic a bit because one of the tests were failing:
debitAmountValue | fixedFee | basisPointFee | exchangeRate | expectedReceiveAmountValue
${200n}          | ${20}    | ${200}        | ${0.455}     | ${80n}

Fees: (200 * (200 * 0.0001)) - 20 = 24
Debit - fees: 200 - 24 = 176
Receive: 176 USD * 0.455 = 80.08 XRP (this returned 81 instead of 80 and it should be `Math.floor`'d instead of `Math.ceil`'d because the peer will deliver 80 XRP for 175.82417582 USD)


## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
fixes #3055 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Make sure that all checks pass
- [x] Bruno collection updated (if necessary)
- [x] Documentation issue created with `user-docs` label (if necessary)
- [x] OpenAPI specs updated (if necessary)
