### PR TITLE
docs: github link in top nav

### DIFF
--- a/packages/documentation/astro.config.mjs
+++ b/packages/documentation/astro.config.mjs
@@ -67,8 +67,7 @@ export default defineConfig({
         src: './public/img/icon.svg'
       },
       social: {
-        github:
-          'https://github.com/interledger/rafiki/tree/main/packages/documentation'
+        github: 'https://github.com/interledger/rafiki/tree/main'
       },
       sidebar: [
         {


### PR DESCRIPTION
The github link in the top nav of the docs points to rafiki/packages/documentation when it should really just point to rafiki
