### PR TITLE
feat(backend): try to match 'wallet address not found' webhook to tenant by prefix

### DIFF
--- a/packages/backend/src/tenants/settings/service.ts
+++ b/packages/backend/src/tenants/settings/service.ts
@@ -43,6 +43,7 @@ export interface TenantSettingService {
     pagination?: Pagination,
     sortOrder?: SortOrder
   ) => Promise<TenantSetting[]>
+  getSettingsByPrefix: (prefix: string) => Promise<TenantSetting[]>
 }
 
 export interface ServiceDependencies extends BaseService {
@@ -68,7 +69,9 @@ export async function createTenantSettingService(
       tenantId: string,
       pagination?: Pagination,
       sortOrder?: SortOrder
-    ) => getTenantSettingPageForTenant(deps, tenantId, pagination, sortOrder)
+    ) => getTenantSettingPageForTenant(deps, tenantId, pagination, sortOrder),
+    getSettingsByPrefix: (prefix: string) =>
+      getWalletAddressSettingsByPrefix(deps, prefix)
   }
 }
 
@@ -146,4 +149,15 @@ async function getTenantSettingPageForTenant(
     .whereNull('deletedAt')
     .andWhere('tenantId', tenantId)
     .getPage(pagination, sortOrder)
+}
+
+async function getWalletAddressSettingsByPrefix(
+  deps: ServiceDependencies,
+  prefix: string
+): Promise<TenantSetting[]> {
+  return await TenantSetting.query(deps.knex)
+    .whereILike('value', `${prefix}%`)
+    .andWhere({
+      key: TenantSettingKeys.WALLET_ADDRESS_URL.name
+    })
 }


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- On "webhook not found" errors, try to find any tenants whose wallet address prefix matches with the attempted wallet address, then send webhooks to those tenants.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3414.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
