### PR TITLE
fix(backend): local payments - allow multiple outgoing payments pay into single incoming 

### DIFF
--- a/packages/backend/src/payment-method/local/service.ts
+++ b/packages/backend/src/payment-method/local/service.ts
@@ -226,9 +226,9 @@ async function pay(
       retryable: false
     })
   }
-  if (incomingPayment.state !== IncomingPaymentState.Pending) {
+  if (incomingPayment.isExpiredOrComplete()) {
     throw new PaymentMethodHandlerError('Bad Incoming Payment State', {
-      description: `Incoming Payment state should be ${IncomingPaymentState.Pending}`,
+      description: `Incoming Payment cannot be expired or completed`,
       retryable: false
     })
   }

--- a/packages/backend/src/payment-method/local/service.ts
+++ b/packages/backend/src/payment-method/local/service.ts
@@ -30,7 +30,6 @@ import {
   TransferError
 } from '../../accounting/errors'
 import { IncomingPaymentService } from '../../open_payments/payment/incoming/service'
-import { IncomingPaymentState } from '../../open_payments/payment/incoming/model'
 import { ConvertResults } from '../../rates/util'
 
 export interface LocalPaymentService extends PaymentMethodService {}

--- a/test/integration/integration.test.ts
+++ b/test/integration/integration.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import { MockASE, C9_CONFIG, HLB_CONFIG } from 'test-lib'
-import { Fee, WebhookEventType } from 'mock-account-service-lib'
+import { WebhookEventType } from 'mock-account-service-lib'
 import { poll } from './lib/utils'
 import { TestActions, createTestActions } from './lib/test-actions'
 import { IncomingPaymentState } from 'test-lib/dist/generated/graphql'
@@ -126,7 +126,6 @@ describe('Integration tests', (): void => {
         const outgoingPaymentGrant = await grantRequestOutgoingPayment(
           senderWalletAddress,
           {
-            debitAmount: quote.debitAmount,
             receiveAmount: quote.receiveAmount
           }
         )
@@ -202,10 +201,7 @@ describe('Integration tests', (): void => {
         )
         const outgoingPaymentGrant = await grantRequestOutgoingPayment(
           senderWalletAddress,
-          {
-            debitAmount: quote.debitAmount,
-            receiveAmount: quote.receiveAmount
-          },
+          { receiveAmount: quote.receiveAmount },
           {
             method: 'redirect',
             uri: 'https://example.com',
@@ -238,14 +234,15 @@ describe('Integration tests', (): void => {
 
         await getPublicIncomingPayment(incomingPayment.id, amountValueToSend)
       })
-      test('Open Payments without Quote', async (): Promise<void> => {
+      test('Open Payments Multiple Outgoing Payments into Incoming Payment', async (): Promise<void> => {
         const {
           grantRequestIncomingPayment,
           createIncomingPayment,
           grantRequestOutgoingPayment,
           pollGrantContinue,
           createOutgoingPayment,
-          getOutgoingPayment
+          getOutgoingPayment,
+          getPublicIncomingPayment
         } = testActions.openPayments
         const { consentInteraction } = testActions
 
@@ -264,11 +261,7 @@ describe('Integration tests', (): void => {
         })
         expect(senderWalletAddress.id).toBe(senderWalletAddressUrl)
 
-        const debitAmount = {
-          assetCode: senderWalletAddress.assetCode,
-          assetScale: senderWalletAddress.assetScale,
-          value: '500'
-        }
+        const grantValue = 100n
 
         const incomingPaymentGrant = await grantRequestIncomingPayment(
           receiverWalletAddress
@@ -281,13 +274,23 @@ describe('Integration tests', (): void => {
         const outgoingPaymentGrant = await grantRequestOutgoingPayment(
           senderWalletAddress,
           {
-            debitAmount,
-            receiveAmount: debitAmount
+            debitAmount: {
+              assetCode: senderWalletAddress.assetCode,
+              assetScale: senderWalletAddress.assetScale,
+              value: String(grantValue)
+            }
           }
         )
         await consentInteraction(outgoingPaymentGrant, senderWalletAddress)
         const grantContinue = await pollGrantContinue(outgoingPaymentGrant)
-        const outgoingPayment = await createOutgoingPayment(
+
+        const debitAmount = {
+          assetCode: senderWalletAddress.assetCode,
+          assetScale: senderWalletAddress.assetScale,
+          value: '50'
+        }
+
+        const outgoingPayment1 = await createOutgoingPayment(
           senderWalletAddress,
           grantContinue,
           {
@@ -296,12 +299,32 @@ describe('Integration tests', (): void => {
           }
         )
 
-        const outgoingPayment_ = await getOutgoingPayment(
-          outgoingPayment.id,
-          grantContinue
+        await poll(
+          async () => getOutgoingPayment(outgoingPayment1.id, grantContinue),
+          (responseData) => BigInt(responseData.sentAmount.value) > 0n,
+          5,
+          0.5
         )
 
-        expect(outgoingPayment_.debitAmount).toMatchObject(debitAmount)
+        expect(outgoingPayment1.debitAmount).toMatchObject(debitAmount)
+
+        const outgoingPayment2 = await createOutgoingPayment(
+          senderWalletAddress,
+          grantContinue,
+          {
+            incomingPayment: incomingPayment.id,
+            debitAmount
+          }
+        )
+
+        await poll(
+          async () => getOutgoingPayment(outgoingPayment2.id, grantContinue),
+          (responseData) => BigInt(responseData.sentAmount.value) > 0n,
+          5,
+          0.5
+        )
+
+        await getPublicIncomingPayment(incomingPayment.id, '98') // adjusted for ILP slippage
       })
       test('Peer to Peer', async (): Promise<void> => {
         const {
@@ -399,7 +422,6 @@ describe('Integration tests', (): void => {
         const receiverAssetCode = receiver.incomingAmount.assetCode
         const exchangeRate =
           hlb.config.seed.rates[senderAssetCode][receiverAssetCode]
-        const fee = c9.config.seed.fees.find((fee: Fee) => fee.asset === 'USD')
 
         // Expected amounts depend on the configuration of asset codes, scale, exchange rate, and fees.
         assert(receiverAssetCode === 'EUR')
@@ -409,11 +431,6 @@ describe('Integration tests', (): void => {
         )
         assert(senderWalletAddress.assetScale === 2)
         assert(exchangeRate === 0.91)
-        assert(fee)
-        assert(fee.fixed === 100)
-        assert(fee.basisPoints === 200)
-        assert(fee.asset === 'USD')
-        assert(fee.scale === 2)
         expect(completedOutgoingPayment.receiveAmount).toMatchObject({
           assetCode: 'EUR',
           assetScale: 2,
@@ -422,7 +439,7 @@ describe('Integration tests', (): void => {
         expect(completedOutgoingPayment.debitAmount).toMatchObject({
           assetCode: 'USD',
           assetScale: 2,
-          value: 668n
+          value: 556n // with ILP slippage
         })
         expect(completedOutgoingPayment.sentAmount).toMatchObject({
           assetCode: 'USD',
@@ -604,7 +621,6 @@ describe('Integration tests', (): void => {
         const receiverAssetCode = receiver.incomingAmount.assetCode
         const exchangeRate =
           c9.config.seed.rates[senderAssetCode][receiverAssetCode]
-        const fee = c9.config.seed.fees.find((fee: Fee) => fee.asset === 'USD')
 
         // Expected amounts depend on the configuration of asset codes, scale, exchange rate, and fees.
         assert(receiverAssetCode === 'EUR')
@@ -614,11 +630,6 @@ describe('Integration tests', (): void => {
         )
         assert(senderWalletAddress.assetScale === 2)
         assert(exchangeRate === 0.91)
-        assert(fee)
-        assert(fee.fixed === 100)
-        assert(fee.basisPoints === 200)
-        assert(fee.asset === 'USD')
-        assert(fee.scale === 2)
         expect(completedOutgoingPayment.receiveAmount).toMatchObject({
           assetCode: 'EUR',
           assetScale: 2,
@@ -627,7 +638,7 @@ describe('Integration tests', (): void => {
         expect(completedOutgoingPayment.debitAmount).toMatchObject({
           assetCode: 'USD',
           assetScale: 2,
-          value: 661n
+          value: 550n
         })
         expect(completedOutgoingPayment.sentAmount).toMatchObject({
           assetCode: 'USD',
@@ -643,6 +654,55 @@ describe('Integration tests', (): void => {
           value: 500n
         })
         expect(incomingPayment.state).toBe(IncomingPaymentState.Completed)
+      })
+
+      test('Peer to Peer - Multiple Outgoing Payments into Incoming Payment', async (): Promise<void> => {
+        const {
+          createReceiver,
+          createOutgoingPaymentFromIncomingPayment,
+          getIncomingPayment
+        } = testActions.admin
+
+        const senderWalletAddress = await c9.accounts.getByWalletAddressUrl(
+          'https://cloud-nine-wallet-test-backend:3100/accounts/gfranklin'
+        )
+        assert(senderWalletAddress?.walletAddressID)
+
+        const senderWalletAddressId = senderWalletAddress.walletAddressID
+        const createReceiverInput = {
+          metadata: {
+            description: 'For lunch!'
+          },
+          walletAddressUrl:
+            'https://cloud-nine-wallet-test-backend:3100/accounts/bhamchest'
+        }
+
+        const value = '500'
+        const receiver = await createReceiver(createReceiverInput)
+
+        await createOutgoingPaymentFromIncomingPayment({
+          incomingPayment: receiver.id,
+          walletAddressId: senderWalletAddressId,
+          debitAmount: {
+            assetCode: 'USD',
+            assetScale: 2,
+            value: value as unknown as bigint
+          }
+        })
+        await createOutgoingPaymentFromIncomingPayment({
+          incomingPayment: receiver.id,
+          walletAddressId: senderWalletAddressId,
+          debitAmount: {
+            assetCode: 'USD',
+            assetScale: 2,
+            value: value as unknown as bigint
+          }
+        })
+
+        const incomingPaymentId = receiver.id.split('/').slice(-1)[0]
+        const incomingPayment = await getIncomingPayment(incomingPaymentId)
+        expect(incomingPayment.receivedAmount.value).toBe(BigInt(value) * 2n)
+        expect(incomingPayment.state).toBe(IncomingPaymentState.Processing)
       })
     })
   })

--- a/test/integration/lib/test-actions/index.ts
+++ b/test/integration/lib/test-actions/index.ts
@@ -50,7 +50,6 @@ async function consentInteraction(
   const { interactId, nonce, cookie } = await _startAndAcceptInteraction(
     deps,
     outgoingPaymentGrant,
-    senderWalletAddress,
     idpSecret
   )
 
@@ -77,7 +76,6 @@ async function consentInteractionWithInteractRef(
   const { interactId, nonce, cookie } = await _startAndAcceptInteraction(
     deps,
     outgoingPaymentGrant,
-    senderWalletAddress,
     idpSecret
   )
 
@@ -108,7 +106,6 @@ async function consentInteractionWithInteractRef(
 async function _startAndAcceptInteraction(
   deps: TestActionsDeps,
   outgoingPaymentGrant: PendingGrant,
-  senderWalletAddress: WalletAddress,
   idpSecret: string
 ): Promise<{ nonce: string; interactId: string; cookie: string }> {
   const { redirect: startInteractionUrl } = outgoingPaymentGrant.interact

--- a/test/integration/lib/test-actions/open-payments.ts
+++ b/test/integration/lib/test-actions/open-payments.ts
@@ -224,7 +224,9 @@ async function createQuote(
 
 type InteractFinish = NonNullable<GrantRequest['interact']>['finish']
 type Amount = { value: string; assetCode: string; assetScale: number }
-type GrantRequestPaymentLimits = { debitAmount: Amount; receiveAmount: Amount }
+type GrantRequestPaymentLimits =
+  | { debitAmount: Amount; receiveAmount?: never }
+  | { debitAmount?: never; receiveAmount: Amount }
 
 async function grantRequestOutgoingPayment(
   deps: OpenPaymentsActionsDeps,
@@ -378,7 +380,7 @@ async function getOutgoingPayment(
 async function getPublicIncomingPayment(
   deps: OpenPaymentsActionsDeps,
   url: string,
-  amountValueToSend: string
+  expectedReceiveAmount: string
 ): Promise<PublicIncomingPayment> {
   const { receivingASE } = deps
   const incomingPayment = await receivingASE.opClient.incomingPayment.getPublic(
@@ -386,7 +388,7 @@ async function getPublicIncomingPayment(
   )
 
   assert(incomingPayment.receivedAmount)
-  expect(incomingPayment.receivedAmount.value).toBe(amountValueToSend)
+  expect(incomingPayment.receivedAmount.value).toBe(expectedReceiveAmount)
 
   return incomingPayment
 }

--- a/test/test-lib/src/admin-client.ts
+++ b/test/test-lib/src/admin-client.ts
@@ -1,6 +1,7 @@
 import type { NormalizedCacheObject } from '@apollo/client'
 import { ApolloClient, gql } from '@apollo/client'
 import {
+  CreateOutgoingPaymentFromIncomingPaymentInput,
   CreateOutgoingPaymentInput,
   CreateQuoteInput,
   CreateReceiverInput,
@@ -132,6 +133,51 @@ export class AdminClient {
       })
       .then(({ data }): OutgoingPaymentResponse => {
         return data.createOutgoingPayment
+      })
+  }
+
+  async createOutgoingPaymentFromIncomingPayment(
+    input: CreateOutgoingPaymentFromIncomingPaymentInput
+  ): Promise<OutgoingPaymentResponse> {
+    return await this.apolloClient
+      .mutate({
+        mutation: gql`
+          mutation CreateOutgoingPaymentFromIncomingPayment(
+            $input: CreateOutgoingPaymentFromIncomingPaymentInput!
+          ) {
+            createOutgoingPaymentFromIncomingPayment(input: $input) {
+              payment {
+                createdAt
+                error
+                metadata
+                id
+                walletAddressId
+                receiveAmount {
+                  assetCode
+                  assetScale
+                  value
+                }
+                receiver
+                debitAmount {
+                  assetCode
+                  assetScale
+                  value
+                }
+                sentAmount {
+                  assetCode
+                  assetScale
+                  value
+                }
+                state
+                stateAttempts
+              }
+            }
+          }
+        `,
+        variables: { input }
+      })
+      .then(({ data }): OutgoingPaymentResponse => {
+        return data.createOutgoingPaymentFromIncomingPayment
       })
   }
 

--- a/test/testenv/cloud-nine-wallet/seed.yml
+++ b/test/testenv/cloud-nine-wallet/seed.yml
@@ -64,19 +64,19 @@ rates:
     EUR: 0.006
     MXN: 0.12
 fees:
-  - fixed: 100
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: USD
     scale: 2
-  - fixed: 100
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: EUR
     scale: 2
-  - fixed: 100
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: MXN
     scale: 2
-  - fixed: 1
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: JPY
     scale: 0

--- a/test/testenv/happy-life-bank/seed.yml
+++ b/test/testenv/happy-life-bank/seed.yml
@@ -69,19 +69,20 @@ rates:
     EUR: 0.006
     MXN: 0.12
 fees:
-  - fixed: 100
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: USD
     scale: 2
-  - fixed: 100
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: EUR
     scale: 2
-  - fixed: 100
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: MXN
     scale: 2
-  - fixed: 1
-    basisPoints: 200
+  - fixed: 0
+    basisPoints: 0
     asset: JPY
     scale: 0
+


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
[Slack thread](https://interledgerfoundation.slack.com/archives/C05EMHTG6FM/p1746616946149559)

- During local payments, we should allow paying multiple outgoing payments into a single incoming payment, just like ILP payments.
- Added integration test for this

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

Fixes #3427 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
