### PR TITLE
feat(backend): required tenantId when fetching peer by destination address

### DIFF
--- a/packages/backend/src/graphql/resolvers/peer.ts
+++ b/packages/backend/src/graphql/resolvers/peer.ts
@@ -70,7 +70,7 @@ export const getPeerByAddressAndAsset: QueryResolvers<TenantedApolloContext>['pe
     const peerService = await ctx.container.use('peerService')
     const peer = await peerService.getByDestinationAddress(
       args.staticIlpAddress,
-      ctx.isOperator ? undefined : ctx.tenant.id,
+      ctx.tenant.id,
       args.assetId
     )
     return peer ? peerToGraphql(peer) : null

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -350,7 +350,8 @@ async function createOutgoingPayment(
           }
         )
         const peer = await deps.peerService.getByDestinationAddress(
-          receiver.ilpAddress
+          receiver.ilpAddress,
+          tenantId
         )
         stopTimerPeer()
 

--- a/packages/backend/src/payment-method/ilp/connector/core/middleware/account.ts
+++ b/packages/backend/src/payment-method/ilp/connector/core/middleware/account.ts
@@ -104,7 +104,10 @@ export function createAccountMiddleware(serverAddress: string): ILPMiddleware {
         }
       }
       const address = ctx.request.prepare.destination
-      const peer = await peers.getByDestinationAddress(address)
+      const peer = await peers.getByDestinationAddress(
+        address,
+        incomingAccount.tenantId
+      )
       if (peer) {
         return peer
       }

--- a/packages/backend/src/payment-method/ilp/peer/service.ts
+++ b/packages/backend/src/payment-method/ilp/peer/service.ts
@@ -65,7 +65,7 @@ export interface PeerService {
   update(options: UpdateOptions): Promise<Peer | PeerError>
   getByDestinationAddress(
     address: string,
-    tenantId?: string,
+    tenantId: string,
     assetId?: string
   ): Promise<Peer | undefined>
   getByIncomingToken(token: string): Promise<Peer | undefined>


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Make tenantId required in `peerService.getByDestinationAddress`

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Whenever we are lookup a peer by destination address (particularly during payment processing in the connector), a situation may arise where multiple tenants have the configured the same peer, with the same destination (ILP) address. In order to avoid confusion, `peerService.getByDestinationAddress` now requires `tenantId`. This ensures that whenever outgoing payments are made to a peer Rafiki across ILP, the peer must be for the same tenant as the outgoing payment.

Follow up to #3129 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
