### PR TITLE
feat(backend): allow tenant id to be specified during tenant creation

### DIFF
--- a/localenv/cloud-ten-wallet/seed.yml
+++ b/localenv/cloud-ten-wallet/seed.yml
@@ -97,3 +97,4 @@ tenants:
     idpSecret: 'ue3ixgIiWLIlWOd4w5KO78scYpFH+vHuCJ33lnjgzEg='
     walletAddressPrefix: 'https://cloud-nine-wallet-backend/cloud-ten'
     webhookUrl: 'http://cloud-ten-wallet/webhooks'
+    id: 'bc293b79-8609-47bd-b914-6438b470aff8'

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -372,6 +372,8 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
+  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;
   /** Secret used to secure requests from the tenant's identity provider. */

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -372,7 +372,7 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
-  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  /** Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided. */
   id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -2205,7 +2205,7 @@
           },
           {
             "name": "id",
-            "description": "Unique identifier of the tenant. Will be generated automatically if not provided.",
+            "description": "Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided.",
             "type": {
               "kind": "SCALAR",
               "name": "ID",

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -2204,6 +2204,18 @@
             "deprecationReason": null
           },
           {
+            "name": "id",
+            "description": "Unique identifier of the tenant. Will be generated automatically if not provided.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "idpConsentUrl",
             "description": "URL of the tenant's identity provider's consent screen.",
             "type": {

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -372,6 +372,8 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
+  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;
   /** Secret used to secure requests from the tenant's identity provider. */

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -372,7 +372,7 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
-  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  /** Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided. */
   id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;

--- a/packages/backend/src/graphql/resolvers/tenant.test.ts
+++ b/packages/backend/src/graphql/resolvers/tenant.test.ts
@@ -21,6 +21,7 @@ import { truncateTables } from '../../tests/tableManager'
 import { ApolloClient } from '@apollo/client'
 import { GraphQLErrorCode } from '../errors'
 import { Tenant as TenantModel } from '../../tenants/model'
+import { v4 } from 'uuid'
 
 describe('Tenant Resolvers', (): void => {
   let deps: IocContract<AppServices>
@@ -252,6 +253,38 @@ describe('Tenant Resolvers', (): void => {
         expect(mutation.tenant).toEqual({
           ...input,
           id: expect.any(String),
+          __typename: 'Tenant'
+        })
+      })
+
+      test('can create a tenant with specific id', async (): Promise<void> => {
+        const inputId = v4()
+        const input = { ...generateTenantInput(), id: inputId }
+
+        const mutation = await appContainer.apolloClient
+          .mutate({
+            mutation: gql`
+              mutation CreateTenant($input: CreateTenantInput!) {
+                createTenant(input: $input) {
+                  tenant {
+                    id
+                    email
+                    apiSecret
+                    idpConsentUrl
+                    idpSecret
+                    publicName
+                  }
+                }
+              }
+            `,
+            variables: {
+              input
+            }
+          })
+          .then((query): TenantMutationResponse => query.data?.createTenant)
+
+        expect(mutation.tenant).toEqual({
+          ...input,
           __typename: 'Tenant'
         })
       })

--- a/packages/backend/src/graphql/resolvers/tenant.test.ts
+++ b/packages/backend/src/graphql/resolvers/tenant.test.ts
@@ -22,6 +22,7 @@ import { ApolloClient } from '@apollo/client'
 import { GraphQLErrorCode } from '../errors'
 import { Tenant as TenantModel } from '../../tenants/model'
 import { v4 } from 'uuid'
+import { errorToMessage, TenantError } from '../../tenants/errors'
 
 describe('Tenant Resolvers', (): void => {
   let deps: IocContract<AppServices>
@@ -287,6 +288,45 @@ describe('Tenant Resolvers', (): void => {
           ...input,
           __typename: 'Tenant'
         })
+      })
+
+      test('cannot create tenant with invalid uuid specified', async (): Promise<void> => {
+        expect.assertions(2)
+        try {
+          const input = { ...generateTenantInput(), id: 'invalid-id-format' }
+
+          await appContainer.apolloClient
+            .mutate({
+              mutation: gql`
+                mutation CreateTenant($input: CreateTenantInput!) {
+                  createTenant(input: $input) {
+                    tenant {
+                      id
+                      email
+                      apiSecret
+                      idpConsentUrl
+                      idpSecret
+                      publicName
+                    }
+                  }
+                }
+              `,
+              variables: {
+                input
+              }
+            })
+            .then((query): TenantMutationResponse => query.data?.createTenant)
+        } catch (error) {
+          expect(error).toBeInstanceOf(ApolloError)
+          expect((error as ApolloError).graphQLErrors).toContainEqual(
+            expect.objectContaining({
+              message: errorToMessage[TenantError.InvalidTenantId],
+              extensions: expect.objectContaining({
+                code: GraphQLErrorCode.BadUserInput
+              })
+            })
+          )
+        }
       })
 
       test('cannot create tenant as non-operator', async (): Promise<void> => {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1619,7 +1619,7 @@ type TenantSetting {
 }
 
 input CreateTenantInput {
-  "Unique identifier of the tenant. Will be generated automatically if not provided."
+  "Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided."
   id: ID
   "Contact email of the tenant owner."
   email: String

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1619,6 +1619,8 @@ type TenantSetting {
 }
 
 input CreateTenantInput {
+  "Unique identifier of the tenant. Will be generated automatically if not provided."
+  id: ID
   "Contact email of the tenant owner."
   email: String
   "Secret used to secure requests made for this tenant."

--- a/packages/backend/src/tenants/errors.ts
+++ b/packages/backend/src/tenants/errors.ts
@@ -1,5 +1,6 @@
 export enum TenantError {
-  TenantNotFound = 'TenantNotFound'
+  TenantNotFound = 'TenantNotFound',
+  InvalidTenantId = 'InvalidTenantId'
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
@@ -9,5 +10,6 @@ export const isTenantError = (o: any): o is TenantError =>
 export const errorToMessage: {
   [key in TenantError]: string
 } = {
-  [TenantError.TenantNotFound]: 'Tenant not found'
+  [TenantError.TenantNotFound]: 'Tenant not found',
+  [TenantError.InvalidTenantId]: 'Invalid Tenant ID'
 }

--- a/packages/backend/src/tenants/service.test.ts
+++ b/packages/backend/src/tenants/service.test.ts
@@ -18,6 +18,7 @@ import { withConfigOverride } from '../tests/helpers'
 import { TenantSetting, TenantSettingKeys } from './settings/model'
 import { TenantSettingService } from './settings/service'
 import { isTenantError, TenantError } from './errors'
+import { v4 } from 'uuid'
 
 describe('Tenant Service', (): void => {
   let deps: IocContract<AppServices>
@@ -173,6 +174,25 @@ describe('Tenant Service', (): void => {
 
       expect(tenantSetting.length).toBe(1)
       expect(tenantSetting[0].value).toEqual(walletAddressUrl)
+    })
+
+    test('can create tenant with a specified id', async (): Promise<void> => {
+      const inputId = v4()
+      const createOptions = {
+        id: inputId,
+        apiSecret: 'test-api-secret',
+        publicName: 'test tenant',
+        email: faker.internet.email(),
+        idpConsentUrl: faker.internet.url(),
+        idpSecret: 'test-idp-secret'
+      }
+
+      jest
+        .spyOn(authServiceClient.tenant, 'create')
+        .mockImplementationOnce(async () => undefined)
+
+      const tenant = await tenantService.create(createOptions)
+      expect(tenant.id).toEqual(inputId)
     })
 
     test('tenant creation rolls back if auth tenant create fails', async (): Promise<void> => {

--- a/packages/backend/src/tenants/service.test.ts
+++ b/packages/backend/src/tenants/service.test.ts
@@ -129,7 +129,7 @@ describe('Tenant Service', (): void => {
         .mockImplementationOnce(async () => undefined)
 
       const tenant = await tenantService.create(createOptions)
-
+      assert(!isTenantError(tenant))
       expect(tenant).toEqual(expect.objectContaining(createOptions))
 
       expect(spy).toHaveBeenCalledWith(
@@ -168,6 +168,7 @@ describe('Tenant Service', (): void => {
         .mockImplementationOnce(async () => undefined)
 
       const tenant = await tenantService.create(createOptions)
+      assert(!isTenantError(tenant))
       const tenantSetting = await TenantSetting.query()
         .where('tenantId', tenant.id)
         .andWhere('key', TenantSettingKeys.WALLET_ADDRESS_URL.name)
@@ -192,6 +193,7 @@ describe('Tenant Service', (): void => {
         .mockImplementationOnce(async () => undefined)
 
       const tenant = await tenantService.create(createOptions)
+      assert(!isTenantError(tenant))
       expect(tenant.id).toEqual(inputId)
     })
 
@@ -246,6 +248,7 @@ describe('Tenant Service', (): void => {
         .mockImplementationOnce(async () => undefined)
 
       const tenant = await tenantService.create(originalTenantInfo)
+      assert(!isTenantError(tenant))
 
       const updatedTenantInfo = {
         id: tenant.id,
@@ -282,6 +285,7 @@ describe('Tenant Service', (): void => {
         .mockImplementationOnce(async () => undefined)
 
       const tenant = await tenantService.create(originalTenantInfo)
+      assert(!isTenantError(tenant))
       const updatedTenantInfo = {
         id: tenant.id,
         apiSecret: 'test-api-secret-two',
@@ -358,6 +362,7 @@ describe('Tenant Service', (): void => {
         .spyOn(authServiceClient.tenant, 'create')
         .mockImplementationOnce(async () => undefined)
       const tenant = await tenantService.create(createOptions)
+      assert(!isTenantError(tenant))
 
       const spy = jest
         .spyOn(authServiceClient.tenant, 'delete')
@@ -390,6 +395,7 @@ describe('Tenant Service', (): void => {
         .spyOn(authServiceClient.tenant, 'create')
         .mockImplementationOnce(async () => undefined)
       const tenant = await tenantService.create(createOptions)
+      assert(!isTenantError(tenant))
 
       const spy = jest
         .spyOn(authServiceClient.tenant, 'delete')
@@ -440,6 +446,7 @@ describe('Tenant Service', (): void => {
 
             const spyCacheSet = jest.spyOn(tenantCache, 'set')
             const tenant = await tenantService.create(createOptions)
+            assert(!isTenantError(tenant))
             expect(tenant).toMatchObject({
               ...createOptions,
               id: tenant.id

--- a/packages/backend/src/tenants/service.ts
+++ b/packages/backend/src/tenants/service.ts
@@ -1,3 +1,4 @@
+import { validate as validateUuid } from 'uuid'
 import { Tenant } from './model'
 import { BaseService } from '../shared/baseService'
 import { TransactionOrKnex } from 'objection'
@@ -7,12 +8,12 @@ import type { AuthServiceClient } from '../auth-service-client/client'
 import { TenantSettingService } from './settings/service'
 import { TenantSetting } from './settings/model'
 import type { IAppConfig } from '../config/app'
-import { TenantError } from './errors'
+import { isTenantError, TenantError } from './errors'
 import { TenantSettingInput } from '../graphql/generated/graphql'
 
 export interface TenantService {
   get: (id: string, includeDeleted?: boolean) => Promise<Tenant | undefined>
-  create: (options: CreateTenantOptions) => Promise<Tenant>
+  create: (options: CreateTenantOptions) => Promise<Tenant | TenantError>
   update: (options: UpdateTenantOptions) => Promise<Tenant>
   delete: (id: string) => Promise<void>
   getPage: (pagination?: Pagination, sortOrder?: SortOrder) => Promise<Tenant[]>
@@ -87,7 +88,7 @@ interface CreateTenantOptions {
 async function createTenant(
   deps: ServiceDependencies,
   options: CreateTenantOptions
-): Promise<Tenant> {
+): Promise<Tenant | TenantError> {
   const trx = await deps.knex.transaction()
   try {
     const {
@@ -99,6 +100,9 @@ async function createTenant(
       idpConsentUrl,
       settings
     } = options
+    if (id && !validateUuid(id)) {
+      throw TenantError.InvalidTenantId
+    }
     const tenant = await Tenant.query(trx).insertAndFetch({
       id,
       email,
@@ -134,6 +138,7 @@ async function createTenant(
     return tenant
   } catch (err) {
     await trx.rollback()
+    if (isTenantError(err)) return err
     throw err
   }
 }

--- a/packages/backend/src/tenants/service.ts
+++ b/packages/backend/src/tenants/service.ts
@@ -75,6 +75,7 @@ async function getTenantPage(
 }
 
 interface CreateTenantOptions {
+  id?: string
   email?: string
   apiSecret: string
   idpSecret?: string
@@ -89,9 +90,17 @@ async function createTenant(
 ): Promise<Tenant> {
   const trx = await deps.knex.transaction()
   try {
-    const { email, apiSecret, publicName, idpSecret, idpConsentUrl, settings } =
-      options
+    const {
+      id,
+      email,
+      apiSecret,
+      publicName,
+      idpSecret,
+      idpConsentUrl,
+      settings
+    } = options
     const tenant = await Tenant.query(trx).insertAndFetch({
+      id,
       email,
       publicName,
       apiSecret,

--- a/packages/backend/src/tenants/settings/service.test.ts
+++ b/packages/backend/src/tenants/settings/service.test.ts
@@ -21,6 +21,7 @@ import { AuthServiceClient } from '../../auth-service-client/client'
 import { v4 as uuid } from 'uuid'
 import { createTenant } from '../../tests/tenant'
 import { isTenantSettingError, TenantSettingError } from './errors'
+import { isTenantError } from '../errors'
 
 describe('TenantSetting Service', (): void => {
   let deps: IocContract<AppServices>
@@ -50,12 +51,14 @@ describe('TenantSetting Service', (): void => {
       .spyOn(authServiceClient.tenant, 'delete')
       .mockResolvedValueOnce(undefined)
 
-    tenant = await tenantService.create({
+    const tenantOrError = await tenantService.create({
       apiSecret: faker.string.uuid(),
       email: faker.internet.email(),
       idpConsentUrl: faker.internet.url(),
       idpSecret: faker.string.uuid()
     })
+    assert(!isTenantError(tenantOrError))
+    tenant = tenantOrError
   })
 
   afterEach(async (): Promise<void> => {

--- a/packages/backend/src/tests/tenant.ts
+++ b/packages/backend/src/tests/tenant.ts
@@ -11,6 +11,7 @@ import {
 } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
 import { TestContainer } from './app'
+import { isTenantError } from '../tenants/errors'
 
 interface CreateOptions {
   email: string
@@ -75,7 +76,7 @@ export async function createTenant(
   jest
     .spyOn(authServiceClient.tenant, 'create')
     .mockImplementationOnce(async () => undefined)
-  const tenant = await tenantService.create(
+  const tenantOrError = await tenantService.create(
     options || {
       email: faker.internet.email(),
       apiSecret: 'test-api-secret',
@@ -85,9 +86,9 @@ export async function createTenant(
     }
   )
 
-  if (!tenant) {
+  if (!tenantOrError || isTenantError(tenantOrError)) {
     throw Error('Failed to create test tenant')
   }
 
-  return tenant
+  return tenantOrError
 }

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -372,6 +372,8 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
+  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;
   /** Secret used to secure requests from the tenant's identity provider. */

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -372,7 +372,7 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
-  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  /** Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided. */
   id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -372,6 +372,8 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
+  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;
   /** Secret used to secure requests from the tenant's identity provider. */

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -372,7 +372,7 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
-  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  /** Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided. */
   id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;

--- a/packages/mock-account-service-lib/src/requesters.ts
+++ b/packages/mock-account-service-lib/src/requesters.ts
@@ -133,9 +133,11 @@ export async function createTenant(
   idpConsentUrl: string,
   idpSecret: string,
   walletAddressUrl: string,
-  webhookUrl: string
+  webhookUrl: string,
+  id?: string
 ): Promise<TenantMutationResponse> {
   const input: CreateTenantInput = {
+    id,
     apiSecret,
     publicName,
     idpConsentUrl,

--- a/packages/mock-account-service-lib/src/seed.ts
+++ b/packages/mock-account-service-lib/src/seed.ts
@@ -47,7 +47,8 @@ export async function setupFromSeed(
         seedTenant.idpConsentUrl,
         seedTenant.idpSecret,
         seedTenant.walletAddressPrefix,
-        seedTenant.webhookUrl
+        seedTenant.webhookUrl,
+        seedTenant.id
       )
     ).tenant
     requesterApolloClient = generateApolloClient({

--- a/packages/mock-account-service-lib/src/types.ts
+++ b/packages/mock-account-service-lib/src/types.ts
@@ -37,6 +37,7 @@ export interface Fee {
 }
 
 export interface Tenant {
+  id?: string
   apiSecret: string
   publicName: string
   idpConsentUrl: string

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -372,6 +372,8 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
+  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;
   /** Secret used to secure requests from the tenant's identity provider. */

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -372,7 +372,7 @@ export type CreateTenantInput = {
   apiSecret: Scalars['String']['input'];
   /** Contact email of the tenant owner. */
   email?: InputMaybe<Scalars['String']['input']>;
-  /** Unique identifier of the tenant. Will be generated automatically if not provided. */
+  /** Unique identifier of the tenant. Must be compliant with uuid v4. Will be generated automatically if not provided. */
   id?: InputMaybe<Scalars['ID']['input']>;
   /** URL of the tenant's identity provider's consent screen. */
   idpConsentUrl?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Allows `id` to be specified during the `createTenant` mutation. If not provided, the id will be generated automatically.
- Adds a specified `id` to the tenant seed for the Tenanted Mock ASE.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3456 or #RAF-1070.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
