### PR TITLE
Feat: add paymentMethodProviderService

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -110,6 +110,8 @@ import {
 import { TenantService } from './tenants/service'
 import { AuthServiceClient } from './auth-service-client/client'
 import { TenantSettingService } from './tenants/settings/service'
+import { StreamCredentialsService } from './payment-method/ilp/stream-credentials/service'
+import { PaymentMethodProviderService } from './payment-method/provider/service'
 
 export interface AppContextData {
   logger: Logger
@@ -278,6 +280,8 @@ export interface AppServices {
   tenantService: Promise<TenantService>
   authServiceClient: AuthServiceClient
   tenantSettingService: Promise<TenantSettingService>
+  streamCredentialsService: Promise<StreamCredentialsService>
+  paymentMethodProviderService: Promise<PaymentMethodProviderService>
 }
 
 export type AppContainer = IocContract<AppServices>

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -76,6 +76,7 @@ import { createInMemoryDataStore } from './middleware/cache/data-stores/in-memor
 import { createTenantService } from './tenants/service'
 import { AuthServiceClient } from './auth-service-client/client'
 import { createTenantSettingService } from './tenants/settings/service'
+import { createPaymentMethodProviderService } from './payment-method/provider/service'
 
 BigInt.prototype.toJSON = function () {
   return this.toString()
@@ -247,6 +248,16 @@ export function initIocContainer(
       deps.use('knex')
     ])
     return createTenantSettingService({ logger, knex })
+  })
+
+  container.singleton('paymentMethodProviderService', async (deps) => {
+    return createPaymentMethodProviderService({
+      logger: await deps.use('logger'),
+      knex: await deps.use('knex'),
+      config: await deps.use('config'),
+      streamCredentialsService: await deps.use('streamCredentialsService'),
+      tenantSettingsService: await deps.use('tenantSettingService')
+    })
   })
 
   container.singleton('ratesService', async (deps) => {
@@ -460,7 +471,9 @@ export function initIocContainer(
       config: await deps.use('config'),
       logger: await deps.use('logger'),
       incomingPaymentService: await deps.use('incomingPaymentService'),
-      streamCredentialsService: await deps.use('streamCredentialsService')
+      paymentMethodProviderService: await deps.use(
+        'paymentMethodProviderService'
+      )
     })
   })
   container.singleton('walletAddressRoutes', async (deps) => {
@@ -487,13 +500,15 @@ export function initIocContainer(
     return await createReceiverService({
       logger: await deps.use('logger'),
       config: await deps.use('config'),
-      streamCredentialsService: await deps.use('streamCredentialsService'),
       incomingPaymentService: await deps.use('incomingPaymentService'),
       walletAddressService: await deps.use('walletAddressService'),
       remoteIncomingPaymentService: await deps.use(
         'remoteIncomingPaymentService'
       ),
-      telemetry: await deps.use('telemetry')
+      telemetry: await deps.use('telemetry'),
+      paymentMethodProviderService: await deps.use(
+        'paymentMethodProviderService'
+      )
     })
   })
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -478,11 +478,9 @@ export function initIocContainer(
     })
   })
   container.singleton('streamCredentialsService', async (deps) => {
-    const config = await deps.use('config')
     return await createStreamCredentialsService({
       logger: await deps.use('logger'),
-      openPaymentsUrl: config.openPaymentsUrl,
-      streamServer: await deps.use('streamServer')
+      config: await deps.use('config')
     })
   })
   container.singleton('receiverService', async (deps) => {

--- a/packages/backend/src/open_payments/payment/incoming/model.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.test.ts
@@ -17,6 +17,7 @@ import {
   IncomingPaymentEventError
 } from './model'
 import { WalletAddress } from '../../wallet_address/model'
+import { OpenPaymentsPaymentMethod } from '../../../payment-method/provider/service'
 
 describe('Models', (): void => {
   let deps: IocContract<AppServices>
@@ -80,16 +81,19 @@ describe('Models', (): void => {
 
     describe('toOpenPaymentsTypeWithMethods', () => {
       test('returns incoming payment with payment methods', async () => {
-        const streamCredentials: IlpStreamCredentials = {
-          ilpAddress: 'test.ilp' as IlpAddress,
-          sharedSecret: Buffer.from('')
-        }
+        const paymentMethods: OpenPaymentsPaymentMethod[] = [
+          {
+            type: 'ilp',
+            ilpAddress: 'test.ilp' as IlpAddress,
+            sharedSecret: ''
+          }
+        ]
 
         expect(
           incomingPayment.toOpenPaymentsTypeWithMethods(
             config.openPaymentsUrl,
             walletAddress,
-            streamCredentials
+            paymentMethods
           )
         ).toEqual({
           id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
@@ -112,67 +116,6 @@ describe('Models', (): void => {
           ]
         })
       })
-
-      test('returns incoming payment with empty methods when stream credentials are undefined', async () => {
-        expect(
-          incomingPayment.toOpenPaymentsTypeWithMethods(
-            config.openPaymentsUrl,
-            walletAddress
-          )
-        ).toEqual({
-          id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
-          walletAddress: walletAddress.address,
-          completed: incomingPayment.completed,
-          receivedAmount: serializeAmount(incomingPayment.receivedAmount),
-          incomingAmount: incomingPayment.incomingAmount
-            ? serializeAmount(incomingPayment.incomingAmount)
-            : undefined,
-          expiresAt: incomingPayment.expiresAt.toISOString(),
-          metadata: incomingPayment.metadata ?? undefined,
-          updatedAt: incomingPayment.updatedAt.toISOString(),
-          createdAt: incomingPayment.createdAt.toISOString(),
-          methods: []
-        })
-      })
-
-      test.each([IncomingPaymentState.Completed, IncomingPaymentState.Expired])(
-        'returns incoming payment with existing methods if payment state is %s',
-        async (paymentState): Promise<void> => {
-          incomingPayment.state = paymentState
-
-          const streamCredentials: IlpStreamCredentials = {
-            ilpAddress: 'test.ilp' as IlpAddress,
-            sharedSecret: Buffer.from('')
-          }
-
-          expect(
-            incomingPayment.toOpenPaymentsTypeWithMethods(
-              config.openPaymentsUrl,
-              walletAddress,
-              streamCredentials
-            )
-          ).toMatchObject({
-            id: `${baseUrl}/${Config.operatorTenantId}${IncomingPayment.urlPath}/${incomingPayment.id}`,
-            walletAddress: walletAddress.address,
-            completed: incomingPayment.completed,
-            receivedAmount: serializeAmount(incomingPayment.receivedAmount),
-            incomingAmount: incomingPayment.incomingAmount
-              ? serializeAmount(incomingPayment.incomingAmount)
-              : undefined,
-            expiresAt: incomingPayment.expiresAt.toISOString(),
-            metadata: incomingPayment.metadata ?? undefined,
-            updatedAt: incomingPayment.updatedAt.toISOString(),
-            createdAt: incomingPayment.createdAt.toISOString(),
-            methods: [
-              expect.objectContaining({
-                type: 'ilp',
-                ilpAddress: streamCredentials.ilpAddress,
-                sharedSecret: expect.any(String)
-              })
-            ]
-          })
-        }
-      )
     })
   })
 

--- a/packages/backend/src/open_payments/payment/incoming/model.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.ts
@@ -1,7 +1,6 @@
 import { Model, QueryContext } from 'objection'
 
 import { Amount, AmountJSON, serializeAmount } from '../../amount'
-import { IlpStreamCredentials } from '../../../payment-method/ilp/stream-credentials/service'
 import {
   WalletAddress,
   WalletAddressSubresource
@@ -14,7 +13,7 @@ import {
   IncomingPayment as OpenPaymentsIncomingPayment,
   IncomingPaymentWithPaymentMethods as OpenPaymentsIncomingPaymentWithPaymentMethod
 } from '@interledger/open-payments'
-import base64url from 'base64url'
+import { OpenPaymentsPaymentMethod } from '../../../payment-method/provider/service'
 
 export enum IncomingPaymentEventType {
   IncomingPaymentCreated = 'incoming_payment.created',
@@ -242,19 +241,11 @@ export class IncomingPayment
   public toOpenPaymentsTypeWithMethods(
     resourceServerUrl: string,
     walletAddress: WalletAddress,
-    ilpStreamCredentials?: IlpStreamCredentials
+    paymentMethods: OpenPaymentsPaymentMethod[]
   ): OpenPaymentsIncomingPaymentWithPaymentMethod {
     return {
       ...this.toOpenPaymentsType(resourceServerUrl, walletAddress),
-      methods: !ilpStreamCredentials
-        ? []
-        : [
-            {
-              type: 'ilp',
-              ilpAddress: ilpStreamCredentials.ilpAddress,
-              sharedSecret: base64url(ilpStreamCredentials.sharedSecret)
-            }
-          ]
+      methods: paymentMethods
     }
   }
 

--- a/packages/backend/src/open_payments/payment/incoming/routes.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.test.ts
@@ -23,6 +23,7 @@ import { Asset } from '../../../asset/model'
 import { IncomingPaymentError, errorToHTTPCode, errorToMessage } from './errors'
 import { IncomingPaymentService } from './service'
 import { IncomingPaymentWithPaymentMethods as OpenPaymentsIncomingPaymentWithPaymentMethods } from '@interledger/open-payments'
+import { PaymentMethodProviderService } from '../../../payment-method/provider/service'
 
 describe('Incoming Payment Routes', (): void => {
   let deps: IocContract<AppServices>
@@ -30,6 +31,7 @@ describe('Incoming Payment Routes', (): void => {
   let config: IAppConfig
   let incomingPaymentRoutes: IncomingPaymentRoutes
   let incomingPaymentService: IncomingPaymentService
+  let paymentMethodProviderService: PaymentMethodProviderService
   let tenantId: string
 
   beforeAll(async (): Promise<void> => {
@@ -52,6 +54,9 @@ describe('Incoming Payment Routes', (): void => {
     config = await deps.use('config')
     incomingPaymentRoutes = await deps.use('incomingPaymentRoutes')
     incomingPaymentService = await deps.use('incomingPaymentService')
+    paymentMethodProviderService = await deps.use(
+      'paymentMethodProviderService'
+    )
 
     expiresAt = new Date(Date.now() + 30_000)
     asset = await createAsset(deps)
@@ -91,8 +96,14 @@ describe('Incoming Payment Routes', (): void => {
           metadata,
           tenantId
         }),
-      get: (ctx) =>
-        incomingPaymentRoutes.get(ctx as ReadContextWithAuthenticatedStatus),
+      get: (ctx) => {
+        jest
+          .spyOn(paymentMethodProviderService, 'getPaymentMethods')
+          .mockResolvedValueOnce([])
+        return incomingPaymentRoutes.get(
+          ctx as ReadContextWithAuthenticatedStatus
+        )
+      },
       getBody: (incomingPayment, list) => {
         const response: Partial<OpenPaymentsIncomingPaymentWithPaymentMethods> =
           {
@@ -110,15 +121,7 @@ describe('Incoming Payment Routes', (): void => {
           }
 
         if (!list) {
-          response.methods = [
-            {
-              type: 'ilp',
-              ilpAddress: expect.stringMatching(
-                /^test\.rafiki\.[a-zA-Z0-9_-]{95}$/
-              ),
-              sharedSecret: expect.any(String)
-            }
-          ]
+          response.methods = []
         }
         return response
       },
@@ -180,19 +183,14 @@ describe('Incoming Payment Routes', (): void => {
           walletAddress
         })
 
+        jest
+          .spyOn(paymentMethodProviderService, 'getPaymentMethods')
+          .mockResolvedValueOnce([])
         await expect(incomingPaymentRoutes.get(ctx)).resolves.toBeUndefined()
 
         expect(ctx.response).toSatisfyApiSpec()
         expect(ctx.body).toMatchObject({
-          methods: [
-            {
-              type: 'ilp',
-              ilpAddress: expect.stringMatching(
-                /^test\.rafiki\.[a-zA-Z0-9_-]{95}$/
-              ),
-              sharedSecret: expect.any(String)
-            }
-          ]
+          id: `${baseUrl}/${tenantId}/incoming-payments/${incomingPayment.id}`
         })
       })
   })
@@ -262,6 +260,9 @@ describe('Incoming Payment Routes', (): void => {
         })
         const incomingPaymentService = await deps.use('incomingPaymentService')
         const createSpy = jest.spyOn(incomingPaymentService, 'create')
+        jest
+          .spyOn(paymentMethodProviderService, 'getPaymentMethods')
+          .mockResolvedValueOnce([])
         await expect(incomingPaymentRoutes.create(ctx)).resolves.toBeUndefined()
         expect(createSpy).toHaveBeenCalledWith({
           walletAddressId: walletAddress.id,
@@ -292,15 +293,7 @@ describe('Incoming Payment Routes', (): void => {
           },
           metadata,
           completed: false,
-          methods: [
-            {
-              type: 'ilp',
-              ilpAddress: expect.stringMatching(
-                /^test\.rafiki\.[a-zA-Z0-9_-]{95}$/
-              ),
-              sharedSecret: expect.any(String)
-            }
-          ]
+          methods: []
         })
       }
     )

--- a/packages/backend/src/open_payments/payment/incoming/routes.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.ts
@@ -111,7 +111,13 @@ async function getIncomingPaymentPrivate(
 
   const streamCredentials = incomingPayment.isExpiredOrComplete()
     ? undefined
-    : deps.streamCredentialsService.get(incomingPayment)
+    : deps.streamCredentialsService.get({
+        paymentTag: incomingPayment.id,
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
 
   ctx.body = incomingPayment.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,
@@ -155,9 +161,13 @@ async function createIncomingPayment(
   }
 
   ctx.status = 201
-  const streamCredentials = deps.streamCredentialsService.get(
-    incomingPaymentOrError
-  )
+  const streamCredentials = deps.streamCredentialsService.get({
+    paymentTag: incomingPaymentOrError.id,
+    asset: {
+      code: incomingPaymentOrError.asset.code,
+      scale: incomingPaymentOrError.asset.scale
+    }
+  })
   ctx.body = incomingPaymentOrError.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,
     ctx.walletAddress,

--- a/packages/backend/src/open_payments/payment/incoming/routes.ts
+++ b/packages/backend/src/open_payments/payment/incoming/routes.ts
@@ -15,15 +15,15 @@ import {
 } from './errors'
 import { AmountJSON, parseAmount } from '../../amount'
 import { listSubresource } from '../../wallet_address/routes'
-import { StreamCredentialsService } from '../../../payment-method/ilp/stream-credentials/service'
 import { AccessAction } from '@interledger/open-payments'
 import { OpenPaymentsServerRouteError } from '../../route-errors'
+import { PaymentMethodProviderService } from '../../../payment-method/provider/service'
 
 interface ServiceDependencies {
   config: IAppConfig
   logger: Logger
   incomingPaymentService: IncomingPaymentService
-  streamCredentialsService: StreamCredentialsService
+  paymentMethodProviderService: PaymentMethodProviderService
 }
 
 export type ReadContextWithAuthenticatedStatus = ReadContext &
@@ -109,20 +109,14 @@ async function getIncomingPaymentPrivate(
     )
   }
 
-  const streamCredentials = incomingPayment.isExpiredOrComplete()
-    ? undefined
-    : deps.streamCredentialsService.get({
-        paymentTag: incomingPayment.id,
-        asset: {
-          code: incomingPayment.asset.code,
-          scale: incomingPayment.asset.scale
-        }
-      })
+  const paymentMethods = incomingPayment.isExpiredOrComplete()
+    ? []
+    : await deps.paymentMethodProviderService.getPaymentMethods(incomingPayment)
 
   ctx.body = incomingPayment.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,
     ctx.walletAddress,
-    streamCredentials
+    paymentMethods
   )
 }
 
@@ -159,19 +153,16 @@ async function createIncomingPayment(
       errorToMessage[incomingPaymentOrError]
     )
   }
+  const paymentMethods =
+    await deps.paymentMethodProviderService.getPaymentMethods(
+      incomingPaymentOrError
+    )
 
   ctx.status = 201
-  const streamCredentials = deps.streamCredentialsService.get({
-    paymentTag: incomingPaymentOrError.id,
-    asset: {
-      code: incomingPaymentOrError.asset.code,
-      scale: incomingPaymentOrError.asset.scale
-    }
-  })
   ctx.body = incomingPaymentOrError.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,
     ctx.walletAddress,
-    streamCredentials
+    paymentMethods
   )
 }
 

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -667,7 +667,8 @@ describe('OutgoingPaymentService', (): void => {
       const walletAddressId = receiverWalletAddress.id
       const incomingPaymentUrl = incomingPayment.toOpenPaymentsTypeWithMethods(
         config.openPaymentsUrl,
-        receiverWalletAddress
+        receiverWalletAddress,
+        []
       ).id
       const debitAmount = {
         value: BigInt(123),
@@ -725,7 +726,8 @@ describe('OutgoingPaymentService', (): void => {
             debitAmount,
             incomingPayment: incomingPayment.toOpenPaymentsTypeWithMethods(
               config.openPaymentsUrl,
-              receiverWalletAddress
+              receiverWalletAddress,
+              []
             ).id,
             grant
           }
@@ -772,7 +774,8 @@ describe('OutgoingPaymentService', (): void => {
             debitAmount,
             incomingPayment: incomingPayment.toOpenPaymentsTypeWithMethods(
               config.openPaymentsUrl,
-              receiverWalletAddress
+              receiverWalletAddress,
+              []
             ).id,
             grant
           }
@@ -793,7 +796,8 @@ describe('OutgoingPaymentService', (): void => {
       const walletAddressId = receiverWalletAddress.id
       const incomingPaymentUrl = incomingPayment.toOpenPaymentsTypeWithMethods(
         config.openPaymentsUrl,
-        receiverWalletAddress
+        receiverWalletAddress,
+        []
       ).id
       const debitAmount = {
         value: BigInt(123),

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -349,10 +349,15 @@ async function createOutgoingPayment(
             description: 'Time to retrieve peer in outgoing payment'
           }
         )
-        const peer = await deps.peerService.getByDestinationAddress(
-          receiver.ilpAddress,
-          tenantId
+        const ilpPaymentMethod = receiver.paymentMethods.find(
+          (method) => method.type === 'ilp'
         )
+        const peer = ilpPaymentMethod
+          ? await deps.peerService.getByDestinationAddress(
+              ilpPaymentMethod.ilpAddress,
+              tenantId
+            )
+          : undefined
         stopTimerPeer()
 
         const payment = await OutgoingPayment.transaction(async (trx) => {

--- a/packages/backend/src/open_payments/receiver/model.test.ts
+++ b/packages/backend/src/open_payments/receiver/model.test.ts
@@ -49,7 +49,13 @@ describe('Receiver Model', (): void => {
       })
       const isLocal = true
 
-      const streamCredentials = streamCredentialsService.get(incomingPayment)
+      const streamCredentials = streamCredentialsService.get({
+        paymentTag: incomingPayment.id,
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
       assert(streamCredentials)
 
       const receiver = new Receiver(
@@ -124,7 +130,13 @@ describe('Receiver Model', (): void => {
       })
 
       incomingPayment.expiresAt = new Date(Date.now() - 1)
-      const streamCredentials = streamCredentialsService.get(incomingPayment)
+      const streamCredentials = streamCredentialsService.get({
+        paymentTag: incomingPayment.id,
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
       assert(streamCredentials)
       const openPaymentsIncomingPayment =
         incomingPayment.toOpenPaymentsTypeWithMethods(
@@ -147,7 +159,13 @@ describe('Receiver Model', (): void => {
         tenantId: Config.operatorTenantId
       })
 
-      const streamCredentials = streamCredentialsService.get(incomingPayment)
+      const streamCredentials = streamCredentialsService.get({
+        paymentTag: incomingPayment.id,
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
       assert(streamCredentials)
       ;(streamCredentials.ilpAddress as string) = 'not base 64 encoded'
 
@@ -198,7 +216,13 @@ describe('Receiver Model', (): void => {
       })
 
       incomingPayment.expiresAt = new Date(Date.now() - 1)
-      const streamCredentials = streamCredentialsService.get(incomingPayment)
+      const streamCredentials = streamCredentialsService.get({
+        paymentTag: incomingPayment.id,
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
       assert(streamCredentials)
       const openPaymentsIncomingPayment =
         incomingPayment.toOpenPaymentsTypeWithMethods(

--- a/packages/backend/src/open_payments/receiver/model.ts
+++ b/packages/backend/src/open_payments/receiver/model.ts
@@ -1,10 +1,7 @@
-import { Counter, ResolvedPayment } from '@interledger/pay'
-import base64url from 'base64url'
-
 import { Amount, parseAmount } from '../amount'
 import { AssetOptions } from '../../asset/service'
 import { IncomingPaymentWithPaymentMethods as OpenPaymentsIncomingPaymentWithPaymentMethod } from '@interledger/open-payments'
-import { IlpAddress, isValidIlpAddress } from 'ilp-packet'
+import { OpenPaymentsPaymentMethod } from '../../payment-method/provider/service'
 
 type ReceiverIncomingPayment = Readonly<
   Omit<
@@ -24,8 +21,6 @@ type ReceiverIncomingPayment = Readonly<
 >
 
 export class Receiver {
-  public readonly ilpAddress: IlpAddress
-  public readonly sharedSecret: Buffer
   public readonly assetCode: string
   public readonly assetScale: number
   public readonly incomingPayment: ReceiverIncomingPayment
@@ -44,19 +39,6 @@ export class Receiver {
       : undefined
     const receivedAmount = parseAmount(incomingPayment.receivedAmount)
 
-    // TODO: handle multiple payment methods
-    const ilpMethod = incomingPayment.methods?.find(
-      (method) => method.type === 'ilp'
-    )
-    if (!ilpMethod) {
-      throw new Error('Cannot create receiver from unsupported payment method')
-    }
-    if (!isValidIlpAddress(ilpMethod.ilpAddress)) {
-      throw new Error('Invalid ILP address on ilp payment method')
-    }
-
-    this.ilpAddress = ilpMethod.ilpAddress
-    this.sharedSecret = base64url.toBuffer(ilpMethod.sharedSecret)
     this.assetCode = incomingPayment.receivedAmount.assetCode
     this.assetScale = incomingPayment.receivedAmount.assetScale
 
@@ -100,13 +82,8 @@ export class Receiver {
     return undefined
   }
 
-  public toResolvedPayment(): ResolvedPayment {
-    return {
-      destinationAsset: this.asset,
-      destinationAddress: this.ilpAddress,
-      sharedSecret: this.sharedSecret,
-      requestCounter: Counter.from(0) as Counter
-    }
+  public get paymentMethods(): OpenPaymentsPaymentMethod[] {
+    return this.incomingPayment.methods
   }
 
   public isActive(): boolean {

--- a/packages/backend/src/open_payments/receiver/service.ts
+++ b/packages/backend/src/open_payments/receiver/service.ts
@@ -126,9 +126,13 @@ async function createLocalIncomingPayment(
     return incomingPaymentOrError
   }
 
-  const streamCredentials = deps.streamCredentialsService.get(
-    incomingPaymentOrError
-  )
+  const streamCredentials = deps.streamCredentialsService.get({
+    paymentTag: incomingPaymentOrError.id,
+    asset: {
+      code: incomingPaymentOrError.asset.code,
+      scale: incomingPaymentOrError.asset.scale
+    }
+  })
 
   if (!streamCredentials) {
     const errorMessage =
@@ -213,7 +217,13 @@ export async function getLocalIncomingPayment(
     throw new Error(errorMessage)
   }
 
-  const streamCredentials = deps.streamCredentialsService.get(incomingPayment)
+  const streamCredentials = deps.streamCredentialsService.get({
+    paymentTag: incomingPayment.id,
+    asset: {
+      code: incomingPayment.asset.code,
+      scale: incomingPayment.asset.scale
+    }
+  })
 
   return incomingPayment.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,

--- a/packages/backend/src/open_payments/receiver/service.ts
+++ b/packages/backend/src/open_payments/receiver/service.ts
@@ -1,5 +1,4 @@
 import { IncomingPaymentWithPaymentMethods as OpenPaymentsIncomingPaymentWithPaymentMethods } from '@interledger/open-payments'
-import { StreamCredentialsService } from '../../payment-method/ilp/stream-credentials/service'
 import { WalletAddressService } from '../wallet_address/service'
 import { BaseService } from '../../shared/baseService'
 import { IncomingPaymentService } from '../payment/incoming/service'
@@ -16,6 +15,7 @@ import {
 import { isRemoteIncomingPaymentError } from '../payment/incoming_remote/errors'
 import { TelemetryService } from '../../telemetry/service'
 import { IAppConfig } from '../../config/app'
+import { PaymentMethodProviderService } from '../../payment-method/provider/service'
 
 interface CreateReceiverArgs {
   walletAddressUrl: string
@@ -33,11 +33,11 @@ export interface ReceiverService {
 
 export interface ServiceDependencies extends BaseService {
   config: IAppConfig
-  streamCredentialsService: StreamCredentialsService
   incomingPaymentService: IncomingPaymentService
   walletAddressService: WalletAddressService
   remoteIncomingPaymentService: RemoteIncomingPaymentService
   telemetry: TelemetryService
+  paymentMethodProviderService: PaymentMethodProviderService
 }
 
 const INCOMING_PAYMENT_URL_REGEX =
@@ -126,18 +126,18 @@ async function createLocalIncomingPayment(
     return incomingPaymentOrError
   }
 
-  const streamCredentials = deps.streamCredentialsService.get({
-    paymentTag: incomingPaymentOrError.id,
-    asset: {
-      code: incomingPaymentOrError.asset.code,
-      scale: incomingPaymentOrError.asset.scale
-    }
-  })
+  const paymentMethods =
+    await deps.paymentMethodProviderService.getPaymentMethods(
+      incomingPaymentOrError
+    )
 
-  if (!streamCredentials) {
+  if (paymentMethods.length === 0) {
     const errorMessage =
-      'Could not get stream credentials for local incoming payment'
-    deps.logger.error({ err: incomingPaymentOrError }, errorMessage)
+      'Could not get any payment methods during local incoming payment creation'
+    deps.logger.error(
+      { incomingPaymentId: incomingPaymentOrError.id },
+      errorMessage
+    )
 
     throw new Error(errorMessage)
   }
@@ -145,7 +145,7 @@ async function createLocalIncomingPayment(
   return incomingPaymentOrError.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,
     walletAddress,
-    streamCredentials
+    paymentMethods
   )
 }
 
@@ -217,18 +217,13 @@ export async function getLocalIncomingPayment(
     throw new Error(errorMessage)
   }
 
-  const streamCredentials = deps.streamCredentialsService.get({
-    paymentTag: incomingPayment.id,
-    asset: {
-      code: incomingPayment.asset.code,
-      scale: incomingPayment.asset.scale
-    }
-  })
+  const paymentMethods =
+    await deps.paymentMethodProviderService.getPaymentMethods(incomingPayment)
 
   return incomingPayment.toOpenPaymentsTypeWithMethods(
     deps.config.openPaymentsUrl,
     incomingPayment.walletAddress,
-    streamCredentials
+    paymentMethods
   )
 }
 

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.test.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.test.ts
@@ -46,7 +46,13 @@ describe('Stream Credentials Service', (): void => {
 
   describe('get', (): void => {
     test('returns stream credentials for incoming payment', (): void => {
-      const credentials = streamCredentialsService.get(incomingPayment)
+      const credentials = streamCredentialsService.get({
+        paymentTag: incomingPayment.id,
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
       assert.ok(credentials)
       expect(credentials).toMatchObject({
         ilpAddress: expect.stringMatching(/^test\.rafiki\.[a-zA-Z0-9_-]{95}$/),
@@ -66,7 +72,15 @@ describe('Stream Credentials Service', (): void => {
           expiresAt:
             state === IncomingPaymentState.Expired ? new Date() : undefined
         })
-        expect(streamCredentialsService.get(incomingPayment)).toMatchObject({
+        expect(
+          streamCredentialsService.get({
+            paymentTag: incomingPayment.id,
+            asset: {
+              code: incomingPayment.asset.code,
+              scale: incomingPayment.asset.scale
+            }
+          })
+        ).toMatchObject({
           ilpAddress: expect.stringMatching(
             /^test\.rafiki\.[a-zA-Z0-9_-]{95}$/
           ),

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.test.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.test.ts
@@ -1,39 +1,21 @@
-import { Knex } from 'knex'
 import { createTestApp, TestContainer } from '../../../tests/app'
 import { StreamCredentialsService } from './service'
-import { IncomingPayment } from '../../../open_payments/payment/incoming/model'
 import { Config } from '../../../config/app'
 import { IocContract } from '@adonisjs/fold'
 import { initIocContainer } from '../../..'
 import { AppServices } from '../../../app'
-import { createIncomingPayment } from '../../../tests/incomingPayment'
-import { createWalletAddress } from '../../../tests/walletAddress'
 import { truncateTables } from '../../../tests/tableManager'
 import assert from 'assert'
-import { IncomingPaymentState } from '../../../graphql/generated/graphql'
 
 describe('Stream Credentials Service', (): void => {
   let deps: IocContract<AppServices>
   let appContainer: TestContainer
   let streamCredentialsService: StreamCredentialsService
-  let knex: Knex
-  let incomingPayment: IncomingPayment
 
   beforeAll(async (): Promise<void> => {
     deps = await initIocContainer(Config)
     appContainer = await createTestApp(deps)
     streamCredentialsService = await deps.use('streamCredentialsService')
-    knex = appContainer.knex
-  })
-
-  beforeEach(async (): Promise<void> => {
-    const { id: walletAddressId } = await createWalletAddress(deps, {
-      tenantId: Config.operatorTenantId
-    })
-    incomingPayment = await createIncomingPayment(deps, {
-      walletAddressId,
-      tenantId: Config.operatorTenantId
-    })
   })
 
   afterEach(async (): Promise<void> => {
@@ -45,12 +27,13 @@ describe('Stream Credentials Service', (): void => {
   })
 
   describe('get', (): void => {
-    test('returns stream credentials for incoming payment', (): void => {
+    test('generates stream credentials', (): void => {
       const credentials = streamCredentialsService.get({
-        paymentTag: incomingPayment.id,
+        ilpAddress: 'test.rafiki',
+        paymentTag: crypto.randomUUID(),
         asset: {
-          code: incomingPayment.asset.code,
-          scale: incomingPayment.asset.scale
+          code: 'USD',
+          scale: 2
         }
       })
       assert.ok(credentials)
@@ -60,33 +43,24 @@ describe('Stream Credentials Service', (): void => {
       })
     })
 
-    test.each`
-      state
-      ${IncomingPaymentState.Completed}
-      ${IncomingPaymentState.Expired}
-    `(
-      `returns stream credentials for $state incoming payment`,
-      async ({ state }): Promise<void> => {
-        await incomingPayment.$query(knex).patch({
-          state,
-          expiresAt:
-            state === IncomingPaymentState.Expired ? new Date() : undefined
-        })
-        expect(
-          streamCredentialsService.get({
-            paymentTag: incomingPayment.id,
-            asset: {
-              code: incomingPayment.asset.code,
-              scale: incomingPayment.asset.scale
-            }
-          })
-        ).toMatchObject({
-          ilpAddress: expect.stringMatching(
-            /^test\.rafiki\.[a-zA-Z0-9_-]{95}$/
-          ),
-          sharedSecret: expect.any(Buffer)
-        })
+    test('generates different stream credentials for a different ilpAddress', (): void => {
+      const args = {
+        paymentTag: crypto.randomUUID(),
+        asset: {
+          code: 'USD',
+          scale: 2
+        }
       }
-    )
+
+      expect(
+        streamCredentialsService.get({ ...args, ilpAddress: 'test.rafiki' })
+          ?.ilpAddress
+      ).not.toEqual(
+        streamCredentialsService.get({
+          ...args,
+          ilpAddress: 'test.rafiki.sub-account'
+        })?.ilpAddress
+      )
+    })
   })
 })

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
@@ -1,12 +1,19 @@
 import { StreamServer } from '@interledger/stream-receiver'
 import { BaseService } from '../../../shared/baseService'
-import { IncomingPayment } from '../../../open_payments/payment/incoming/model'
 import { StreamCredentials as IlpStreamCredentials } from '@interledger/stream-receiver'
 
 export { IlpStreamCredentials }
 
+interface GetStreamCredentialsArgs {
+  paymentTag: string
+  asset: {
+    scale: number
+    code: string
+  }
+}
+
 export interface StreamCredentialsService {
-  get(payment: IncomingPayment): IlpStreamCredentials | undefined
+  get(payment: GetStreamCredentialsArgs): IlpStreamCredentials | undefined
 }
 
 export interface ServiceDependencies extends BaseService {
@@ -31,14 +38,11 @@ export async function createStreamCredentialsService(
 
 function getStreamCredentials(
   deps: ServiceDependencies,
-  payment: IncomingPayment
+  args: GetStreamCredentialsArgs
 ): IlpStreamCredentials | undefined {
   const credentials = deps.streamServer.generateCredentials({
-    paymentTag: payment.id,
-    asset: {
-      code: payment.asset.code,
-      scale: payment.asset.scale
-    }
+    paymentTag: args.paymentTag,
+    asset: args.asset
   })
   return credentials
 }

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
@@ -1,6 +1,7 @@
 import { StreamServer } from '@interledger/stream-receiver'
 import { BaseService } from '../../../shared/baseService'
 import { StreamCredentials as IlpStreamCredentials } from '@interledger/stream-receiver'
+import { IAppConfig } from '../../../config/app'
 
 export { IlpStreamCredentials }
 
@@ -17,8 +18,7 @@ export interface StreamCredentialsService {
 }
 
 export interface ServiceDependencies extends BaseService {
-  openPaymentsUrl: string
-  streamServer: StreamServer
+  config: IAppConfig
 }
 
 export async function createStreamCredentialsService(
@@ -40,7 +40,12 @@ function getStreamCredentials(
   deps: ServiceDependencies,
   args: GetStreamCredentialsArgs
 ): IlpStreamCredentials | undefined {
-  const credentials = deps.streamServer.generateCredentials({
+  const streamServer = new StreamServer({
+    serverSecret: deps.config.streamSecret,
+    serverAddress: deps.config.ilpAddress
+  })
+
+  const credentials = streamServer.generateCredentials({
     paymentTag: args.paymentTag,
     asset: args.asset
   })

--- a/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
+++ b/packages/backend/src/payment-method/ilp/stream-credentials/service.ts
@@ -6,6 +6,7 @@ import { IAppConfig } from '../../../config/app'
 export { IlpStreamCredentials }
 
 interface GetStreamCredentialsArgs {
+  ilpAddress: string
   paymentTag: string
   asset: {
     scale: number
@@ -14,7 +15,7 @@ interface GetStreamCredentialsArgs {
 }
 
 export interface StreamCredentialsService {
-  get(payment: GetStreamCredentialsArgs): IlpStreamCredentials | undefined
+  get(args: GetStreamCredentialsArgs): IlpStreamCredentials | undefined
 }
 
 export interface ServiceDependencies extends BaseService {
@@ -32,7 +33,7 @@ export async function createStreamCredentialsService(
     logger: log
   }
   return {
-    get: (payment) => getStreamCredentials(deps, payment)
+    get: (args) => getStreamCredentials(deps, args)
   }
 }
 
@@ -42,7 +43,7 @@ function getStreamCredentials(
 ): IlpStreamCredentials | undefined {
   const streamServer = new StreamServer({
     serverSecret: deps.config.streamSecret,
-    serverAddress: deps.config.ilpAddress
+    serverAddress: args.ilpAddress
   })
 
   const credentials = streamServer.generateCredentials({

--- a/packages/backend/src/payment-method/provider/service.test.ts
+++ b/packages/backend/src/payment-method/provider/service.test.ts
@@ -1,0 +1,179 @@
+import { PaymentMethodProviderService } from './service'
+import { initIocContainer } from '../../'
+import { createTestApp, TestContainer } from '../../tests/app'
+import { Config } from '../../config/app'
+import { IocContract } from '@adonisjs/fold'
+import { AppServices } from '../../app'
+import { createAsset } from '../../tests/asset'
+import { createWalletAddress } from '../../tests/walletAddress'
+
+import { truncateTables } from '../../tests/tableManager'
+import { createIncomingPayment } from '../../tests/incomingPayment'
+import { StreamCredentialsService } from '../ilp/stream-credentials/service'
+import { IlpAddress } from 'ilp-packet'
+import base64url from 'base64url'
+import { TenantSettingService } from '../../tenants/settings/service'
+import { TenantSetting, TenantSettingKeys } from '../../tenants/settings/model'
+import { IncomingPayment } from '../../open_payments/payment/incoming/model'
+
+describe('PaymentMethodProviderService', (): void => {
+  let deps: IocContract<AppServices>
+  let appContainer: TestContainer
+  let paymentMethodProviderService: PaymentMethodProviderService
+  let streamCredentialsService: StreamCredentialsService
+  let tenantSettingService: TenantSettingService
+
+  beforeAll(async (): Promise<void> => {
+    deps = initIocContainer(Config)
+    appContainer = await createTestApp(deps)
+
+    paymentMethodProviderService = await deps.use(
+      'paymentMethodProviderService'
+    )
+    streamCredentialsService = await deps.use('streamCredentialsService')
+    tenantSettingService = await deps.use('tenantSettingService')
+  })
+
+  afterEach(async (): Promise<void> => {
+    jest.restoreAllMocks()
+    await truncateTables(deps)
+  })
+
+  afterAll(async (): Promise<void> => {
+    await appContainer.shutdown()
+  })
+
+  describe('getPaymentMethods', (): void => {
+    const tenantId = Config.operatorTenantId
+    let incomingPayment: IncomingPayment
+
+    beforeEach(async (): Promise<void> => {
+      const asset = await createAsset(deps)
+      const walletAddress = await createWalletAddress(deps, {
+        tenantId,
+        assetId: asset.id
+      })
+      incomingPayment = await createIncomingPayment(deps, {
+        walletAddressId: walletAddress.id,
+        tenantId: Config.operatorTenantId
+      })
+    })
+    test('returns payment methods with ILP payment method for operator tenant', async (): Promise<void> => {
+      const tenantSettingsServiceGetSpy = jest.spyOn(
+        tenantSettingService,
+        'get'
+      )
+
+      const streamCredentialsServiceGetSpy = jest
+        .spyOn(streamCredentialsService, 'get')
+        .mockImplementationOnce(({ ilpAddress }) => ({
+          ilpAddress: ilpAddress as IlpAddress,
+          sharedSecret: Buffer.from('secret')
+        }))
+
+      await expect(
+        paymentMethodProviderService.getPaymentMethods(incomingPayment)
+      ).resolves.toEqual([
+        {
+          type: 'ilp',
+          ilpAddress: 'test.rafiki',
+          sharedSecret: base64url(Buffer.from('secret'))
+        }
+      ])
+
+      expect(tenantSettingsServiceGetSpy).not.toHaveBeenCalled()
+      expect(streamCredentialsServiceGetSpy).toHaveBeenCalledWith({
+        paymentTag: incomingPayment.id,
+        ilpAddress: 'test.rafiki',
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
+    })
+
+    test('returns payment methods with ILP payment method for non-operator tenant', async (): Promise<void> => {
+      const tenantId = crypto.randomUUID()
+      const tenantSettingsServiceGetSpy = jest
+        .spyOn(tenantSettingService, 'get')
+        .mockResolvedValueOnce([
+          {
+            tenantId,
+            key: TenantSettingKeys.ILP_ADDRESS.name,
+            value: 'test.rafiki'
+          }
+        ] as TenantSetting[])
+
+      const streamCredentialsServiceGetSpy = jest
+        .spyOn(streamCredentialsService, 'get')
+        .mockImplementationOnce(({ ilpAddress }) => ({
+          ilpAddress: ilpAddress as IlpAddress,
+          sharedSecret: Buffer.from('secret')
+        }))
+
+      await expect(
+        paymentMethodProviderService.getPaymentMethods({
+          ...incomingPayment,
+          tenantId
+        } as IncomingPayment)
+      ).resolves.toEqual([
+        {
+          type: 'ilp',
+          ilpAddress: 'test.rafiki',
+          sharedSecret: base64url(Buffer.from('secret'))
+        }
+      ])
+
+      expect(tenantSettingsServiceGetSpy).toHaveBeenCalledWith({
+        tenantId: tenantId,
+        key: TenantSettingKeys.ILP_ADDRESS.name
+      })
+      expect(streamCredentialsServiceGetSpy).toHaveBeenCalledWith({
+        paymentTag: incomingPayment.id,
+        ilpAddress: 'test.rafiki',
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
+    })
+
+    test('does not return ILP payment method when missing ILP address in tenant settings for non-operator tenant', async (): Promise<void> => {
+      const tenantId = crypto.randomUUID()
+      const tenantSettingsServiceGetSpy = jest
+        .spyOn(tenantSettingService, 'get')
+        .mockResolvedValueOnce([])
+
+      await expect(
+        paymentMethodProviderService.getPaymentMethods({
+          ...incomingPayment,
+          tenantId
+        } as IncomingPayment)
+      ).resolves.toEqual([])
+
+      expect(tenantSettingsServiceGetSpy).toHaveBeenCalledWith({
+        tenantId,
+        key: TenantSettingKeys.ILP_ADDRESS.name
+      })
+    })
+
+    test('does not return ILP payment method when failed to generate stream credentials', async (): Promise<void> => {
+      const streamCredentialsServiceGetSpy = jest
+        .spyOn(streamCredentialsService, 'get')
+        .mockImplementationOnce(() => undefined)
+
+      await expect(
+        paymentMethodProviderService.getPaymentMethods(incomingPayment)
+      ).resolves.toEqual([])
+
+      expect(streamCredentialsServiceGetSpy).toHaveBeenCalledWith({
+        paymentTag: incomingPayment.id,
+        ilpAddress: 'test.rafiki',
+        asset: {
+          code: incomingPayment.asset.code,
+          scale: incomingPayment.asset.scale
+        }
+      })
+    })
+  })
+})

--- a/packages/backend/src/payment-method/provider/service.ts
+++ b/packages/backend/src/payment-method/provider/service.ts
@@ -1,0 +1,120 @@
+import { BaseService } from '../../shared/baseService'
+import { IncomingPayment } from '../../open_payments/payment/incoming/model'
+import { StreamCredentialsService } from '../ilp/stream-credentials/service'
+import { TenantSettingService } from '../../tenants/settings/service'
+import { TenantSettingKeys } from '../../tenants/settings/model'
+import base64url from 'base64url'
+import { TenantService } from '../../tenants/service'
+import { IAppConfig } from '../../config/app'
+
+interface BasePaymentMethod {
+  type: 'ilp'
+}
+
+interface IlpPaymentMethod extends BasePaymentMethod {
+  type: 'ilp'
+  ilpAddress: string
+  sharedSecret: string
+}
+
+export type OpenPaymentsPaymentMethod = IlpPaymentMethod
+
+export interface PaymentMethodProviderService {
+  getPaymentMethods(
+    incomingPayment: IncomingPayment
+  ): Promise<OpenPaymentsPaymentMethod[]>
+}
+
+interface ServiceDependencies extends BaseService {
+  streamCredentialsService: StreamCredentialsService
+  tenantSettingsService: TenantSettingService
+  config: IAppConfig
+}
+
+export async function createPaymentMethodProviderService({
+  logger,
+  knex,
+  config,
+  streamCredentialsService,
+  tenantSettingsService
+}: ServiceDependencies): Promise<PaymentMethodProviderService> {
+  const log = logger.child({
+    service: 'PaymentMethodProvider'
+  })
+  const deps: ServiceDependencies = {
+    logger: log,
+    knex,
+    config,
+    streamCredentialsService,
+    tenantSettingsService
+  }
+
+  return {
+    getPaymentMethods: (incomingPayment) =>
+      getPaymentMethods(deps, incomingPayment)
+  }
+}
+
+async function getPaymentMethods(
+  deps: ServiceDependencies,
+  incomingPayment: IncomingPayment
+): Promise<OpenPaymentsPaymentMethod[]> {
+  const ilpPaymentMethod = await generateIlpPaymentMethod(deps, incomingPayment)
+
+  return ilpPaymentMethod ? [ilpPaymentMethod] : []
+}
+
+async function generateIlpPaymentMethod(
+  deps: ServiceDependencies,
+  incomingPayment: IncomingPayment
+): Promise<IlpPaymentMethod | undefined> {
+  let tenantIlpAddress
+
+  if (deps.config.operatorTenantId === incomingPayment.tenantId) {
+    tenantIlpAddress = deps.config.ilpAddress
+  } else {
+    const tenantSettings = await deps.tenantSettingsService.get({
+      tenantId: incomingPayment.tenantId,
+      key: TenantSettingKeys.ILP_ADDRESS.name
+    })
+
+    if (tenantSettings.length === 0) {
+      deps.logger.error(
+        {
+          tenantId: incomingPayment.tenantId,
+          incomingPaymentId: incomingPayment.id
+        },
+        'Could not get tenant settings for tenant when generating ILP payment method'
+      )
+      return
+    }
+
+    tenantIlpAddress = tenantSettings[0].value
+  }
+
+  const ilpStreamCredentials = deps.streamCredentialsService.get({
+    paymentTag: incomingPayment.id,
+    ilpAddress: tenantIlpAddress,
+    asset: {
+      code: incomingPayment.asset.code,
+      scale: incomingPayment.asset.scale
+    }
+  })
+
+  if (!ilpStreamCredentials) {
+    deps.logger.error(
+      {
+        tenantId: incomingPayment.tenantId,
+        incomingPaymentId: incomingPayment.id
+      },
+      'Could not get generate ILP STREAM credentials when generating ILP payment method'
+    )
+    return
+  }
+
+  return {
+    type: 'ilp',
+    ilpAddress: ilpStreamCredentials.ilpAddress,
+    sharedSecret: base64url(ilpStreamCredentials.sharedSecret)
+  }
+}

--- a/packages/backend/src/tenants/service.ts
+++ b/packages/backend/src/tenants/service.ts
@@ -4,8 +4,8 @@ import { TransactionOrKnex } from 'objection'
 import { Pagination, SortOrder } from '../shared/baseModel'
 import { CacheDataStore } from '../middleware/cache/data-stores'
 import type { AuthServiceClient } from '../auth-service-client/client'
-import { TenantSettingService } from './settings/service'
-import { TenantSetting } from './settings/model'
+import { KeyValuePair, TenantSettingService } from './settings/service'
+import { TenantSetting, TenantSettingKeys } from './settings/model'
 import type { IAppConfig } from '../config/app'
 import { TenantError } from './errors'
 import { TenantSettingInput } from '../graphql/generated/graphql'
@@ -109,6 +109,13 @@ async function createTenant(
       tenantId: tenant.id,
       setting: TenantSetting.default()
     }
+
+    const defaultIlpAddressSetting: KeyValuePair = {
+      key: TenantSettingKeys.ILP_ADDRESS.name,
+      value: `${deps.config.ilpAddress}.${tenant.id}`
+    }
+
+    createInitialTenantSettingsOptions.setting.push(defaultIlpAddressSetting)
 
     if (settings) {
       createInitialTenantSettingsOptions.setting =

--- a/packages/backend/src/tenants/settings/model.ts
+++ b/packages/backend/src/tenants/settings/model.ts
@@ -1,6 +1,7 @@
 import { Pojo } from 'objection'
 import { BaseModel } from '../../shared/baseModel'
 import { KeyValuePair } from './service'
+import { isValidIlpAddress } from 'ilp-packet'
 
 interface TenantSettingKeyType {
   name: string
@@ -12,7 +13,8 @@ export const TenantSettingKeys: { [key: string]: TenantSettingKeyType } = {
   WEBHOOK_URL: { name: 'WEBHOOK_URL' },
   WEBHOOK_TIMEOUT: { name: 'WEBHOOK_TIMEOUT', default: 2000 },
   WEBHOOK_MAX_RETRY: { name: 'WEBHOOK_MAX_RETRY', default: 10 },
-  WALLET_ADDRESS_URL: { name: 'WALLET_ADDRESS_URL' }
+  WALLET_ADDRESS_URL: { name: 'WALLET_ADDRESS_URL' },
+  ILP_ADDRESS: { name: 'ILP_ADDRESS' }
 }
 
 export class TenantSetting extends BaseModel {
@@ -57,7 +59,8 @@ const TENANT_KEY_MAPPING = {
   [TenantSettingKeys.WEBHOOK_MAX_RETRY.name]: 'webhookMaxRetry',
   [TenantSettingKeys.WEBHOOK_TIMEOUT.name]: 'webhookTimeout',
   [TenantSettingKeys.WEBHOOK_URL.name]: 'webhookUrl',
-  [TenantSettingKeys.WALLET_ADDRESS_URL.name]: 'walletAddressUrl'
+  [TenantSettingKeys.WALLET_ADDRESS_URL.name]: 'walletAddressUrl',
+  [TenantSettingKeys.ILP_ADDRESS.name]: 'ilpAddress'
 } as const
 
 export type FormattedTenantSettings = Record<
@@ -84,6 +87,10 @@ const validateUrlTenantSetting = (url: string): boolean => {
   }
 }
 
+const validateIlpAddressTenantSetting = (ilpAddress: string): boolean => {
+  return isValidIlpAddress(ilpAddress)
+}
+
 const validateNonNegativeTenantSetting = (numberString: string): boolean => {
   return !!(Number.isFinite(Number(numberString)) && Number(numberString) > -1)
 }
@@ -97,5 +104,6 @@ export const TENANT_SETTING_VALIDATORS = {
   [TenantSettingKeys.WEBHOOK_MAX_RETRY.name]: validateNonNegativeTenantSetting,
   [TenantSettingKeys.WEBHOOK_TIMEOUT.name]: validatePositiveTenantSetting,
   [TenantSettingKeys.WEBHOOK_URL.name]: validateUrlTenantSetting,
-  [TenantSettingKeys.WALLET_ADDRESS_URL.name]: validateUrlTenantSetting
+  [TenantSettingKeys.WALLET_ADDRESS_URL.name]: validateUrlTenantSetting,
+  [TenantSettingKeys.ILP_ADDRESS.name]: validateIlpAddressTenantSetting
 }

--- a/packages/backend/src/tenants/settings/service.test.ts
+++ b/packages/backend/src/tenants/settings/service.test.ts
@@ -241,6 +241,44 @@ describe('TenantSetting Service', (): void => {
         tenantSettingService.create(negativeOption)
       ).resolves.toEqual(TenantSettingError.InvalidSetting)
     })
+
+    test('accepts valid ILP address for ILP address tenant setting', async (): Promise<void> => {
+      const invalidIlpAddressSetting: CreateOptions = {
+        tenantId: tenant.id,
+        setting: [
+          {
+            key: TenantSettingKeys.ILP_ADDRESS.name,
+            value: 'test.net'
+          }
+        ]
+      }
+
+      await expect(
+        tenantSettingService.create(invalidIlpAddressSetting)
+      ).resolves.toEqual([
+        expect.objectContaining({
+          tenantId: tenant.id,
+          key: TenantSettingKeys.ILP_ADDRESS.name,
+          value: 'test.net'
+        })
+      ])
+    })
+
+    test('cannot use invalid ILP address for ILP address tenant setting', async (): Promise<void> => {
+      const invalidIlpAddressSetting: CreateOptions = {
+        tenantId: tenant.id,
+        setting: [
+          {
+            key: TenantSettingKeys.ILP_ADDRESS.name,
+            value: 'test'
+          }
+        ]
+      }
+
+      await expect(
+        tenantSettingService.create(invalidIlpAddressSetting)
+      ).resolves.toEqual(TenantSettingError.InvalidSetting)
+    })
   })
 
   describe('get', () => {

--- a/packages/backend/src/tests/receiver.ts
+++ b/packages/backend/src/tests/receiver.ts
@@ -5,26 +5,37 @@ import { CreateIncomingPaymentOptions } from '../open_payments/payment/incoming/
 import { WalletAddress } from '../open_payments/wallet_address/model'
 import { Receiver } from '../open_payments/receiver/model'
 import { createIncomingPayment } from './incomingPayment'
+import { OpenPaymentsPaymentMethod } from '../payment-method/provider/service'
+
+type CreateReceiverOptions = Omit<
+  CreateIncomingPaymentOptions,
+  'walletAddressId'
+> & {
+  paymentMethods?: OpenPaymentsPaymentMethod[]
+}
 
 export async function createReceiver(
   deps: IocContract<AppServices>,
   walletAddress: WalletAddress,
-  options?: Omit<CreateIncomingPaymentOptions, 'walletAddressId'>
+  options?: CreateReceiverOptions
 ): Promise<Receiver> {
   const config = await deps.use('config')
+  const paymentMethodProviderService = await deps.use(
+    'paymentMethodProviderService'
+  )
+
   const incomingPayment = await createIncomingPayment(deps, {
     ...options,
     walletAddressId: walletAddress.id,
     tenantId: options?.tenantId ?? config.operatorTenantId
   })
 
-  const streamCredentialsService = await deps.use('streamCredentialsService')
-
   return new Receiver(
     incomingPayment.toOpenPaymentsTypeWithMethods(
       config.openPaymentsUrl,
       walletAddress,
-      streamCredentialsService.get(incomingPayment)!
+      options?.paymentMethods ||
+        (await paymentMethodProviderService.getPaymentMethods(incomingPayment))
     ),
     false
   )


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Add ILP_ADDRESS tenantSetting, which by default is the root, operators ilpAddress (ILP_ADDRESS environment variable) concatenated with the tenants id. In the future this can be tenant defined instead.
- Add paymentMethodProviderService that abstracts away payment method generation for incomingPayments
    - Centralized place to generateStreamCredentials (ILP payment method details) where we generate credentials using the configured ilpAddress, which could be the root ilpAddress defined in the environment variable, or looked up using the tenantSettings
    


## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes RAF-1069

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
