### PR TITLE
feat(backend): add tenantId to webhook, outgoing + combined payments pagination resolvers

### DIFF
--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -1369,6 +1369,7 @@ export type QueryWebhookEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<SortOrder>;
+  tenantId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Quote = {

--- a/packages/backend/migrations/20250625121526_replace_combined_payments_view.js
+++ b/packages/backend/migrations/20250625121526_replace_combined_payments_view.js
@@ -1,0 +1,65 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.raw(`
+    DROP VIEW IF EXISTS "combinedPaymentsView";
+    CREATE VIEW "combinedPaymentsView" AS
+    SELECT
+      "id",
+      "walletAddressId",
+      "state",
+      "client",
+      "createdAt",
+      "updatedAt",
+      "metadata",
+      "tenantId",
+      'INCOMING' AS "type"
+    FROM "incomingPayments"
+    UNION ALL
+    SELECT
+      "id",
+      "walletAddressId",
+      "state",
+      "client",
+      "createdAt",
+      "updatedAt",
+      "metadata",
+      "tenantId",
+      'OUTGOING' AS "type"
+    FROM "outgoingPayments"
+  `)
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.raw(`
+    DROP VIEW IF EXISTS "combinedPaymentsView";
+    CREATE VIEW "combinedPaymentsView" AS
+    SELECT
+      "id",
+      "walletAddressId",
+      "state",
+      "client",
+      "createdAt",
+      "updatedAt",
+      "metadata",
+      'INCOMING' AS "type"
+    FROM "incomingPayments"
+    UNION ALL
+    SELECT
+      "id",
+      "walletAddressId",
+      "state",
+      "client",
+      "createdAt",
+      "updatedAt",
+      "metadata",
+      'OUTGOING' AS "type"
+    FROM "outgoingPayments"
+  `)
+}

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -7704,6 +7704,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "tenantId",
+                "description": "Unique identifier of the tenant associated with the wallet address. Optional, if not provided, the tenantId will be obtained from the signature.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -1369,6 +1369,7 @@ export type QueryWebhookEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<SortOrder>;
+  tenantId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Quote = {

--- a/packages/backend/src/graphql/resolvers/combined_payments.ts
+++ b/packages/backend/src/graphql/resolvers/combined_payments.ts
@@ -3,24 +3,25 @@ import {
   QueryResolvers,
   Payment as SchemaPayment
 } from '../generated/graphql'
-import { ApolloContext } from '../../app'
+import { TenantedApolloContext } from '../../app'
 import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 import { CombinedPayment } from '../../open_payments/payment/combined/model'
 
-export const getCombinedPayments: QueryResolvers<ApolloContext>['payments'] =
+export const getCombinedPayments: QueryResolvers<TenantedApolloContext>['payments'] =
   async (parent, args, ctx): Promise<ResolversTypes['PaymentConnection']> => {
     const combinedPaymentService = await ctx.container.use(
       'combinedPaymentService'
     )
-    const { filter, sortOrder, ...pagination } = args
+    const { filter, sortOrder, tenantId, ...pagination } = args
     const order = sortOrder === 'ASC' ? SortOrder.Asc : SortOrder.Desc
 
     const getPageFn = (pagination_: Pagination, sortOrder_?: SortOrder) =>
       combinedPaymentService.getPage({
         pagination: pagination_,
         filter,
-        sortOrder: sortOrder_
+        sortOrder: sortOrder_,
+        tenantId: ctx.isOperator ? tenantId : ctx.tenant.id
       })
 
     const payments = await getPageFn(pagination, order)

--- a/packages/backend/src/graphql/resolvers/webhooks.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.ts
@@ -1,4 +1,4 @@
-import { ApolloContext } from '../../app'
+import { TenantedApolloContext } from '../../app'
 import {
   QueryResolvers,
   ResolversTypes,
@@ -8,20 +8,21 @@ import { getPageInfo } from '../../shared/pagination'
 import { WebhookEvent } from '../../webhook/event/model'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 
-export const getWebhookEvents: QueryResolvers<ApolloContext>['webhookEvents'] =
+export const getWebhookEvents: QueryResolvers<TenantedApolloContext>['webhookEvents'] =
   async (
     parent,
     args,
     ctx
   ): Promise<ResolversTypes['WebhookEventsConnection']> => {
-    const { filter, sortOrder, ...pagination } = args
+    const { filter, sortOrder, tenantId, ...pagination } = args
     const order = sortOrder === 'ASC' ? SortOrder.Asc : SortOrder.Desc
     const webhookService = await ctx.container.use('webhookService')
     const getPageFn = (pagination_: Pagination, sortOrder_?: SortOrder) =>
       webhookService.getPage({
         pagination: pagination_,
         filter,
-        sortOrder: sortOrder_
+        sortOrder: sortOrder_,
+        tenantId: ctx.isOperator ? tenantId : ctx.tenant.id
       })
     const webhookEvents = await getPageFn(pagination, order)
     const pageInfo = await getPageInfo({

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -125,6 +125,8 @@ type Query {
     sortOrder: SortOrder
     "Filter webhook events based on specific criteria."
     filter: WebhookEventFilter
+    "Unique identifier of the tenant associated with the wallet address. Optional, if not provided, the tenantId will be obtained from the signature."
+    tenantId: String
   ): WebhookEventsConnection!
 
   "Fetch a paginated list of combined payments, including incoming and outgoing payments."

--- a/packages/backend/src/open_payments/payment/combined/model.ts
+++ b/packages/backend/src/open_payments/payment/combined/model.ts
@@ -21,6 +21,7 @@ export class CombinedPayment extends PaginationModel {
   public state!: OutgoingPaymentState | IncomingPaymentState
   public walletAddressId!: string
   public metadata?: Record<string, unknown>
+  public tenantId!: string
   public client?: string
   public createdAt!: Date
   public updatedAt!: Date

--- a/packages/backend/src/open_payments/payment/combined/service.test.ts
+++ b/packages/backend/src/open_payments/payment/combined/service.test.ts
@@ -142,5 +142,19 @@ describe('Combined Payment Service', (): void => {
         toCombinedPayment(PaymentType.Outgoing, outgoingPayment)
       )
     })
+
+    test('can filter by tenantId', async (): Promise<void> => {
+      await setupPayments(deps)
+      await expect(
+        combinedPaymentService.getPage({
+          tenantId: crypto.randomUUID()
+        })
+      ).resolves.toHaveLength(0)
+      await expect(
+        combinedPaymentService.getPage({
+          tenantId: Config.operatorTenantId
+        })
+      ).resolves.toHaveLength(2)
+    })
   })
 })

--- a/packages/backend/src/open_payments/payment/combined/service.ts
+++ b/packages/backend/src/open_payments/payment/combined/service.ts
@@ -14,6 +14,7 @@ interface GetPageOptions {
   pagination?: Pagination
   filter?: CombinedPaymentFilter
   sortOrder?: SortOrder
+  tenantId?: string
 }
 
 export interface CombinedPaymentService {
@@ -43,9 +44,13 @@ async function getCombinedPaymentsPage(
   deps: ServiceDependencies,
   options?: GetPageOptions
 ) {
-  const { filter, pagination, sortOrder } = options ?? {}
+  const { filter, pagination, sortOrder, tenantId } = options ?? {}
 
   const query = CombinedPayment.query(deps.knex)
+
+  if (tenantId) {
+    query.where('tenantId', tenantId)
+  }
 
   if (filter?.walletAddressId?.in && filter.walletAddressId.in.length) {
     query.whereIn('walletAddressId', filter.walletAddressId.in)

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -539,6 +539,20 @@ describe('OutgoingPaymentService', (): void => {
           expect.objectContaining({ id: otherOutgoingPayment.id })
         )
       })
+
+      test('can filter by tenantId', async (): Promise<void> => {
+        await expect(
+          outgoingPaymentService.getPage({
+            tenantId: crypto.randomUUID()
+          })
+        ).resolves.toHaveLength(0)
+
+        await expect(
+          outgoingPaymentService.getPage({
+            tenantId: Config.operatorTenantId
+          })
+        ).resolves.toHaveLength(2)
+      })
     })
   })
 

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -111,9 +111,13 @@ async function getOutgoingPaymentsPage(
   deps: ServiceDependencies,
   options?: GetPageOptions
 ): Promise<OutgoingPayment[]> {
-  const { filter, pagination, sortOrder } = options ?? {}
+  const { filter, pagination, sortOrder, tenantId } = options ?? {}
 
   const query = OutgoingPayment.query(deps.knex).withGraphFetched('quote')
+
+  if (tenantId) {
+    query.where('tenantId', tenantId)
+  }
 
   if (filter?.receiver?.in && filter.receiver.in.length) {
     query

--- a/packages/backend/src/tests/combinedPayment.ts
+++ b/packages/backend/src/tests/combinedPayment.ts
@@ -22,6 +22,7 @@ export function toCombinedPayment(
     id: payment.id,
     walletAddressId: payment.walletAddressId,
     state: payment.state,
+    tenantId: payment.tenantId,
     metadata: payment.metadata,
     client: payment.client,
     createdAt: payment.createdAt,

--- a/packages/backend/src/webhook/service.test.ts
+++ b/packages/backend/src/webhook/service.test.ts
@@ -255,6 +255,26 @@ describe('Webhook Service', (): void => {
       getPage: (pagination?: Pagination, sortOrder?: SortOrder) =>
         webhookService.getPage({ pagination, sortOrder })
     })
+
+    test('can filter by tenantId', async () => {
+      await WebhookEvent.query(knex).insertAndFetch({
+        id: uuid(),
+        type: WalletAddressEventType.WalletAddressNotFound,
+        data: {
+          account: {
+            id: uuid()
+          }
+        },
+        tenantId: Config.operatorTenantId
+      })
+
+      await expect(
+        webhookService.getPage({ tenantId: Config.operatorTenantId })
+      ).resolves.toHaveLength(1)
+      await expect(
+        webhookService.getPage({ tenantId: crypto.randomUUID() })
+      ).resolves.toHaveLength(0)
+    })
   })
 
   describe('getWebhookEventsPage', (): void => {

--- a/packages/backend/src/webhook/service.ts
+++ b/packages/backend/src/webhook/service.ts
@@ -29,6 +29,7 @@ interface GetPageOptions {
   pagination?: Pagination
   filter?: WebhookEventFilter
   sortOrder?: SortOrder
+  tenantId?: string
 }
 
 export interface WebhookService {
@@ -266,9 +267,13 @@ async function getWebhookEventsPage(
   deps: ServiceDependencies,
   options?: GetPageOptions
 ): Promise<WebhookEvent[]> {
-  const { filter, pagination, sortOrder } = options ?? {}
+  const { filter, pagination, sortOrder, tenantId } = options ?? {}
 
   const query = WebhookEvent.query(deps.knex)
+
+  if (tenantId) {
+    query.where('tenantId', tenantId)
+  }
 
   if (filter?.type?.in && filter.type.in.length > 0) {
     query.whereIn('type', filter.type.in)

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -1369,6 +1369,7 @@ export type QueryWebhookEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<SortOrder>;
+  tenantId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Quote = {

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -1369,6 +1369,7 @@ export type QueryWebhookEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<SortOrder>;
+  tenantId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Quote = {

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -1369,6 +1369,7 @@ export type QueryWebhookEventsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<SortOrder>;
+  tenantId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Quote = {


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
After testing the multi-tenancy branch, I found three pagination resolvers that needed a tenantId:
- webhook pagination resolver
- outgoing payments pagination resolver
- combined payments pagination resolver

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3473

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
