### PR TITLE
fix: resolve i18n-related issues for docs header

### DIFF
--- a/packages/documentation/src/components/Header.astro
+++ b/packages/documentation/src/components/Header.astro
@@ -7,7 +7,7 @@ import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
 import RafikiLogo from "../components/RafikiLogo.astro";
 ---
 <div class="header sl-flex">
-  <a href={getRelativeLocaleUrl("es")} class="site-logo">
+  <a href={getRelativeLocaleUrl(Astro.currentLocale ?? 'en', '/')} class="site-logo">
     <RafikiLogo />
   </a>
   <div class="secondary-wrap">
@@ -15,8 +15,8 @@ import RafikiLogo from "../components/RafikiLogo.astro";
     <SocialIcons />
     <div class="sl-hidden md:sl-flex">
       <ThemeSelect />
-      <LanguageSelect />
     </div>
+    <LanguageSelect />
   </div>
 </div>
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- This PR fixes the header of the docs sites, where the home link now detects the current active locale, and shows the language selector on the landing page

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
