### PR TITLE
docs: mi/3527/native-code-blocks

### DIFF
--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -60,7 +60,6 @@ Refer to the Starlight documentation on [authoring content](https://starlight.as
 
 We have extracted some commonly repeated patterns within the documentation pages into custom docs components that can be reused. There are components which are shared across all our Starlight documentation sites and those which are specific to this project only. This will determine what the import path is.
 
-- CodeBlock (Shared)
 - Hidden (Shared)
 - LargeImg (Shared)
 - LinkOut (Shared)
@@ -68,10 +67,10 @@ We have extracted some commonly repeated patterns within the documentation pages
 - StylishHeader (Shared)
 - Tooltip (Shared)
 
-For the shared components, if you are using both `CodeBlock` and `LinkOut` on the same page, you can import them both like so:
+For the shared components, if you are using both `LinkOut` and `MermaidWrapper` on the same page, you can import them both like so:
 
 ```jsx
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut, MermaidWrapper } from '@interledger/docs-design-system'
 ```
 
 For more information about importing things in Javascript, please refer to [import on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import).

--- a/packages/documentation/src/content/docs/admin/liquidity/asset-liquidity.mdx
+++ b/packages/documentation/src/content/docs/admin/liquidity/asset-liquidity.mdx
@@ -5,7 +5,7 @@ tableOfContents:
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 import IdempotencyNote from '/src/partials/liquidity-idempotency.mdx'
 
 Asset liquidity is the amount of value, denominated in a given asset, that Rafiki has available to handle cross-currency (foreign exchange) transactions between you and your peer. Whenever an outgoing payment/incoming payment is in a different asset than the peering relationship, the liquidity of asset accounts change depending on the FX direction.

--- a/packages/documentation/src/content/docs/admin/liquidity/payment-liquidity.mdx
+++ b/packages/documentation/src/content/docs/admin/liquidity/payment-liquidity.mdx
@@ -5,7 +5,7 @@ tableOfContents:
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 import IdempotencyNote from '/src/partials/liquidity-idempotency.mdx'
 
 Payment liquidity represents:

--- a/packages/documentation/src/content/docs/admin/liquidity/peer-liquidity.mdx
+++ b/packages/documentation/src/content/docs/admin/liquidity/peer-liquidity.mdx
@@ -5,7 +5,6 @@ tableOfContents:
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
 import IdempotencyNote from '/src/partials/liquidity-idempotency.mdx'
 
 Peer liquidity is the line of credit you extend to a peer, denominated in your agreed upon asset. A peer's liquidity account balance represents the amount of credit the peer still has available to them.

--- a/packages/documentation/src/content/docs/admin/liquidity/two-phase-transfers.mdx
+++ b/packages/documentation/src/content/docs/admin/liquidity/two-phase-transfers.mdx
@@ -3,7 +3,6 @@ title: Two-phase transfers
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
 import IdempotencyNote from '/src/partials/liquidity-idempotency.mdx'
 
 Rafiki allows for two-phase transfers, which moves funds in two stages.

--- a/packages/documentation/src/content/docs/es/overview/concepts/accounting.mdx
+++ b/packages/documentation/src/content/docs/es/overview/concepts/accounting.mdx
@@ -4,12 +4,7 @@ tableOfContents:
   maxHeadingLevel: 3
 ---
 
-import {
-  LinkOut,
-  CodeBlock,
-  Mermaid,
-  StylishHeader
-} from '@interledger/docs-design-system'
+import { Mermaid, StylishHeader } from '@interledger/docs-design-system'
 import { Steps } from '@astrojs/starlight/components'
 
 Rafiki uses <LinkOut href="https://en.wikipedia.org/wiki/Double-entry_bookkeeping">double-entry accounting</LinkOut> to record financial transactions. In this method of bookkeeping, a transaction recorded to one account results in an equal and opposite entry to another account. For example, a \$50 credit to one account results in a \$50 debit from another account.

--- a/packages/documentation/src/content/docs/integration/deployment/services/frontend-service.mdx
+++ b/packages/documentation/src/content/docs/integration/deployment/services/frontend-service.mdx
@@ -15,7 +15,7 @@ The following are required when using the `frontend` service:
 - A Rafiki [`backend`](/integration/deployment/services/backend-service) service up and running to access the Backend Admin API.
 - An identity provider for authentication and user management. Out of the box, the Rafiki Admin application uses <LinkOut href="https://www.ory.sh/docs/kratos/ory-kratos-intro">Ory Kratos</LinkOut>, a secure and fully open-source identity management solution.
 
-<KratosWarn />>
+<KratosWarn />
 
 You must also set the environment variables for the `frontend` service.
 

--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -5,7 +5,6 @@ title: Overview
 import {
   Mermaid,
   MermaidWrapper,
-  CodeBlock,
   LinkOut,
   Disclosure,
   LargeImg
@@ -61,25 +60,17 @@ This option enables the primary instance (Cloud Nine Wallet) to utilize TigerBee
 
 To run the local environment with TigerBeetle, execute the following command from the root of the project:
 
-<CodeBlock title="Using TigerBeetle">
-
-```
+```bash title="Using TigerBeetle"
 pnpm localenv:compose up
 ```
-
-</CodeBlock>
 
 #### Using Postgres
 
 If you want the primary instance (Cloud Nine Wallet) to use Postgres as the accounting database instead of TigerBeetle, you must use the `psql` variant of the `localenv:compose` command as follows:
 
-<CodeBlock title="Using Postgres">
-
-```
+```bash title="Using Postgres"
 pnpm localenv:compose:psql up
 ```
-
-</CodeBlock>
 
 The local environment consists of a primary and secondary Rafiki instance, each with its docker-compose file (<LinkOut href='https://github.com/interledger/rafiki/blob/main/localenv/cloud-nine-wallet/docker-compose.yml'>Cloud Nine Wallet</LinkOut>, <LinkOut href='https://github.com/interledger/rafiki/blob/main/localenv/cloud-nine-wallet/docker-compose.yml'>Happy Life Bank</LinkOut>). The primary Cloud Nine Wallet docker-compose file (`./cloud-nine-wallet/docker-compose.yml`) includes the primary Rafiki `backend` and `auth` services, as well as the required data stores, which include TigerBeetle (if enabled), Redis, and Postgres. The primary instance contains all of the necessary components so that it can run independently.
 

--- a/packages/documentation/src/content/docs/integration/requirements/assets.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/assets.mdx
@@ -6,7 +6,7 @@ tableOfContents:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 import { Badge } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 
 An asset represents an item of value that can be transferred via the Interledger Protocol. Assets in Rafiki can be added through the Backend Admin API or the [Rafiki Admin](/admin/admin-user-guide/#assets) application.
 

--- a/packages/documentation/src/content/docs/integration/requirements/exchange-rates.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/exchange-rates.mdx
@@ -3,7 +3,7 @@ title: Exchange rates
 ---
 
 import { Badge } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 
 If you plan to support cross-currency transactions, you must specify from where your Rafiki instance will fetch current exchange rates.
 
@@ -15,27 +15,17 @@ Often, it's the receiving ASE that provides the exchange rates for each ILP pack
 
 Rafiki fetches exchange rates from your exchange rates endpoint. Set your endpoint via the `backend` service's `EXCHAGE_RATES_URL` variable. An <LinkOut href="https://github.com/interledger/rafiki/blob/main/packages/backend/src/openapi/specs/exchange-rates.yaml">OpenAPI specification</LinkOut> for the endpoint is available.
 
-<CodeBlock title='Example'>
-
-```
+```bash title='Example'
 EXCHANGE_RATES_URL: http://cloud-nine-wallet/rates
 ```
 
-</CodeBlock>
-
 The endpoint must accept <Badge text="GET" variant="note" size="medium"/> requests and respond as follows.
 
-<CodeBlock title='Example API request'>
-
-```
+```bash title="Example API request"
 GET https://cloud-nine-wallet/rates
 ```
 
-</CodeBlock>
-
-<CodeBlock title='Example API response'>
-
-```
+```bash title='Example API response'
 {
     "base": "USD",
     "rates": {
@@ -43,8 +33,6 @@ GET https://cloud-nine-wallet/rates
     }
 }
 ```
-
-</CodeBlock>
 
 ### Response objects
 
@@ -70,13 +58,9 @@ As exchange rates and fees charged by connectors fluctuate, there will likely be
 
 Set your allowed slippage rate to a value between 0 and 1 via the `backend` service's `SLIPPAGE` variable or use the default setting of `0.01` (1%).
 
-<CodeBlock title='Example'>
-
-```
+```bash title='Example'
 SLIPPAGE: 0.05
 ```
-
-</CodeBlock>
 
 ### Example
 

--- a/packages/documentation/src/content/docs/integration/requirements/open-payments/grants-revoking.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/open-payments/grants-revoking.mdx
@@ -3,7 +3,7 @@ title: Viewing and revoking grants
 ---
 
 import { Badge, Tabs, TabItem } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 
 Grants are the mechanism in Open Payments by which your account holders give permission to a client application to access their accounts and send payments on their behalf. Providing your account holders the ability to view and revoke grants is not required to implement and operate Rafiki, but allowing them to do so is critical to providing an optimal user experience.
 

--- a/packages/documentation/src/content/docs/integration/requirements/open-payments/idp.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/open-payments/idp.mdx
@@ -3,7 +3,7 @@ title: Identity provider (IdP)
 ---
 
 import { Badge, Steps } from '@astrojs/starlight/components'
-import { LinkOut, CodeBlock } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 
 An identity provider (IdP) is a system or service that stores and manages user identity information, authentication, and consent. Examples of IdPs include OpenID Connect and Okta.
 

--- a/packages/documentation/src/content/docs/integration/requirements/open-payments/wallet-keys.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/open-payments/wallet-keys.mdx
@@ -3,7 +3,6 @@ title: Wallet address keys
 ---
 
 import { LinkOut } from '@interledger/docs-design-system'
-import { CodeBlock } from '@interledger/docs-design-system'
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Creating a public-private key pair for each wallet address is not required when integrating with Rafiki.

--- a/packages/documentation/src/content/docs/integration/requirements/peers.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/peers.mdx
@@ -5,7 +5,7 @@ tableOfContents:
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 import { Badge } from '@astrojs/starlight/components'
 
 To join the Interledger network and be able to send and receive payments, you must add one or more peers to your Rafiki instance. Peering establishes the connections needed for your Rafiki instance to interact with another account servicing entity (ASE). The purpose of this guide is to help you set up and manage peers.

--- a/packages/documentation/src/content/docs/integration/requirements/sending-fees.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/sending-fees.mdx
@@ -6,7 +6,7 @@ tableOfContents:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 import { Badge } from '@astrojs/starlight/components'
-import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 
 You have the option to charge sending fees, on top of any estimated network fees, for facilitating transfers. Each asset you support can have a different fee structure and you can specify both fixed and variable fees per asset. The fee amount is added on top of the quote that is generated after the ILP rate probe completes. You can define sending fees through the Backend Admin API or the [Rafiki Admin](/admin/admin-user-guide/#edit-asset) application.
 

--- a/packages/documentation/src/content/docs/integration/requirements/wallet-addresses.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/wallet-addresses.mdx
@@ -6,7 +6,6 @@ tableOfContents:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 import { LinkOut } from '@interledger/docs-design-system'
-import { CodeBlock } from '@interledger/docs-design-system'
 
 Each payment account belonging to your users (for example, your customers) must have at least one associated wallet address for the account to be able to send and receive payments over Interledger and Open Payments. A wallet address serves as a publicly shareable standardized ID for a payment account.
 

--- a/packages/documentation/src/content/docs/integration/requirements/webhook-events.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/webhook-events.mdx
@@ -5,7 +5,7 @@ tableOfContents:
 ---
 
 import { Badge, Tabs, TabItem, Steps } from '@astrojs/starlight/components'
-import { Mermaid, CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { Mermaid, LinkOut } from '@interledger/docs-design-system'
 
 The main communication channel between you and your Rafiki instance is composed of the Backend Admin API and a set of webhook events.
 
@@ -145,13 +145,9 @@ Each webhook request includes a `Rafiki-Signature` header with a timestamp, vers
 
 The `Rafiki-Signature` header in each webhook request has the following format:
 
-<CodeBlock title="Rafiki-Signature header">
-
-```
+```bash title="Rafiki-Signature header"
 Rafiki-Signature: t=<timestamp>, v<version>=<signature_digest>
 ```
-
-</CodeBlock>
 
 - `t=<timestamp>`: The UNIX timestamp (in seconds) when the signature was generated.
 - `v<version>=<digest>`: The versioned HMAC SHA-256 signature digest. The default version is `v1`.
@@ -178,9 +174,7 @@ Finally, compare the signature in the header to the expected signature you gener
 
 Below is an example in JavaScript to verify Rafiki's webhook signature:
 
-<CodeBlock title="Verify webhook signature example">
-
-```js
+```js title="Verify webhook signature example"
 function verifyWebhookSignature(request: Request): boolean {
   const signatureParts = request.headers['Rafiki-Signature'].split(', ')
   const timestamp = signatureParts[0].split('=')[1]
@@ -197,8 +191,6 @@ function verifyWebhookSignature(request: Request): boolean {
   return digest === signatureDigest
 }
 ```
-
-</CodeBlock>
 
 ## Event handling
 

--- a/packages/documentation/src/content/docs/overview/concepts/accounting.mdx
+++ b/packages/documentation/src/content/docs/overview/concepts/accounting.mdx
@@ -6,7 +6,6 @@ tableOfContents:
 
 import {
   LinkOut,
-  CodeBlock,
   Mermaid,
   StylishHeader
 } from '@interledger/docs-design-system'

--- a/packages/documentation/src/content/docs/resources/environment-variables.mdx
+++ b/packages/documentation/src/content/docs/resources/environment-variables.mdx
@@ -2,7 +2,7 @@
 title: Environment variables
 ---
 
-import { LinkOut, CodeBlock } from '@interledger/docs-design-system'
+import { LinkOut } from '@interledger/docs-design-system'
 import BackEnv from '/src/partials/backend-variables.mdx'
 import AuthEnv from '/src/partials/auth-variables.mdx'
 import FrontEnv from '/src/partials/frontend-variables.mdx'
@@ -12,13 +12,9 @@ Environment variables are key value pairs used to configure how your Rafiki inst
 
 Each environment variable name is uppercase, followed by an equal sign and the value of the variable.
 
-<CodeBlock title='Environment variable example'>
-
-```
+```bash title='Environment variable example'
 WEBHOOKS_URL=http://my-business/webhooks
 ```
-
-</CodeBlock>
 
 The environment variable in the preceding example specifies the HTTP endpoint at which you want your Rafiki instance to send you notifications of webhook events.
 

--- a/packages/documentation/src/content/docs/resources/glossary.mdx
+++ b/packages/documentation/src/content/docs/resources/glossary.mdx
@@ -4,8 +4,6 @@ title: Glossary
 
 import { LinkOut } from '@interledger/docs-design-system'
 
-import { CodeBlock } from '@interledger/docs-design-system'
-
 ## Account servicing entity (ASE)
 
 An entity that provides and maintains a payment account for a payer and/or payee. An ASE is a regulated entity within the country or countries it operates. Examples include digital wallets, banks, and mobile money providers. Non-regulated entities should not use Rafiki in production environments due to the potential legal and compliance risks involved.


### PR DESCRIPTION
Fixes issue #3527 

- Replaced custom component with native code block support

- Removed CodeBlock imports from doc files and references from Readme

- Removed > after aside on frontend service page

