### PR TITLE
feat(backend): Raul/raf 1095 augment outgoing payments for card

### DIFF
--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -191,6 +191,13 @@ export type CancelOutgoingPaymentInput = {
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type CardDetailsInput = {
+  /** Expire date */
+  expiry: Scalars['String']['input'];
+  /** Signature */
+  signature: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
   code: Scalars['String']['input'];
@@ -278,6 +285,8 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
   /** Additional metadata associated with the outgoing payment. */
@@ -1006,6 +1015,8 @@ export type MutationWithdrawEventLiquidityArgs = {
 
 export type OutgoingPayment = BasePayment & Model & {
   __typename?: 'OutgoingPayment';
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: Maybe<OutgoingPaymentCardDetails>;
   /** Information about the wallet address of the Open Payments client that created the outgoing payment. */
   client?: Maybe<Scalars['String']['output']>;
   /** The date and time that the outgoing payment was created. */
@@ -1038,6 +1049,16 @@ export type OutgoingPayment = BasePayment & Model & {
   tenantId?: Maybe<Scalars['String']['output']>;
   /** Unique identifier of the wallet address under which the outgoing payment was created. */
   walletAddressId: Scalars['ID']['output'];
+};
+
+export type OutgoingPaymentCardDetails = Model & {
+  __typename?: 'OutgoingPaymentCardDetails';
+  createdAt: Scalars['String']['output'];
+  expiry: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  outgoingPaymentId: Scalars['ID']['output'];
+  signature: Scalars['String']['output'];
+  updatedAt: Scalars['String']['output'];
 };
 
 export type OutgoingPaymentConnection = {
@@ -1898,7 +1919,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
-  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
+  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<OutgoingPaymentCardDetails> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1921,6 +1942,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentInput: ResolverTypeWrapper<Partial<CancelIncomingPaymentInput>>;
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
+  CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1982,6 +2004,7 @@ export type ResolversTypes = {
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
+  OutgoingPaymentCardDetails: ResolverTypeWrapper<Partial<OutgoingPaymentCardDetails>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
   OutgoingPaymentFilter: ResolverTypeWrapper<Partial<OutgoingPaymentFilter>>;
@@ -2065,6 +2088,7 @@ export type ResolversParentTypes = {
   CancelIncomingPaymentInput: Partial<CancelIncomingPaymentInput>;
   CancelIncomingPaymentResponse: Partial<CancelIncomingPaymentResponse>;
   CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
+  CardDetailsInput: Partial<CardDetailsInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -2121,6 +2145,7 @@ export type ResolversParentTypes = {
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
   OutgoingPayment: Partial<OutgoingPayment>;
+  OutgoingPaymentCardDetails: Partial<OutgoingPaymentCardDetails>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
   OutgoingPaymentFilter: Partial<OutgoingPaymentFilter>;
@@ -2392,7 +2417,7 @@ export type LiquidityMutationResponseResolvers<ContextType = any, ParentType ext
 };
 
 export type ModelResolvers<ContextType = any, ParentType extends ResolversParentTypes['Model'] = ResolversParentTypes['Model']> = {
-  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'OutgoingPaymentCardDetails' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 };
@@ -2439,6 +2464,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
+  cardDetails?: Resolver<Maybe<ResolversTypes['OutgoingPaymentCardDetails']>, ParentType, ContextType>;
   client?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -2455,6 +2481,16 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   stateAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   walletAddressId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2792,6 +2828,7 @@ export type Resolvers<ContextType = any> = {
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
+  OutgoingPaymentCardDetails?: OutgoingPaymentCardDetailsResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
   OutgoingPaymentResponse?: OutgoingPaymentResponseResolvers<ContextType>;

--- a/packages/backend/migrations/20250708070748_create_outgoing_payment_card_table.js
+++ b/packages/backend/migrations/20250708070748_create_outgoing_payment_card_table.js
@@ -6,7 +6,7 @@ exports.up = function(knex) {
     return knex.schema.createTable('outgoingPaymentCardDetails', function(table) {
         table.uuid('id').notNullable().primary()
         table.string('signature').notNullable();
-        table.timestamp('expiry').notNullable();
+        table.string('expiry').notNullable();
         table.uuid('outgoingPaymentId').notNullable();
 
         table.foreign('outgoingPaymentId')

--- a/packages/backend/migrations/20250708070748_create_outgoing_payment_card_table.js
+++ b/packages/backend/migrations/20250708070748_create_outgoing_payment_card_table.js
@@ -1,0 +1,28 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+    return knex.schema.createTable('outgoingPaymentCardDetails', function(table) {
+        table.uuid('id').notNullable().primary()
+        table.string('signature').notNullable();
+        table.timestamp('expiry').notNullable();
+        table.uuid('outgoingPaymentId').notNullable();
+
+        table.foreign('outgoingPaymentId')
+            .references('id')
+            .inTable('outgoingPayments')
+            .onDelete('CASCADE');
+
+        table.timestamp('createdAt').defaultTo(knex.fn.now())
+        table.timestamp('updatedAt').defaultTo(knex.fn.now())    
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+    return knex.schema.dropTableIfExists('outgoingPaymentCardDetails');
+};

--- a/packages/backend/migrations/20250708070748_create_outgoing_payment_card_table.js
+++ b/packages/backend/migrations/20250708070748_create_outgoing_payment_card_table.js
@@ -2,27 +2,31 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = function(knex) {
-    return knex.schema.createTable('outgoingPaymentCardDetails', function(table) {
-        table.uuid('id').notNullable().primary()
-        table.string('signature').notNullable();
-        table.string('expiry').notNullable();
-        table.uuid('outgoingPaymentId').notNullable();
+exports.up = function (knex) {
+  return knex.schema.createTable(
+    'outgoingPaymentCardDetails',
+    function (table) {
+      table.uuid('id').notNullable().primary()
+      table.string('signature').notNullable()
+      table.string('expiry').notNullable()
+      table.uuid('outgoingPaymentId').notNullable()
 
-        table.foreign('outgoingPaymentId')
-            .references('id')
-            .inTable('outgoingPayments')
-            .onDelete('CASCADE');
+      table
+        .foreign('outgoingPaymentId')
+        .references('id')
+        .inTable('outgoingPayments')
+        .onDelete('CASCADE')
 
-        table.timestamp('createdAt').defaultTo(knex.fn.now())
-        table.timestamp('updatedAt').defaultTo(knex.fn.now())    
-    });
-};
+      table.timestamp('createdAt').defaultTo(knex.fn.now())
+      table.timestamp('updatedAt').defaultTo(knex.fn.now())
+    }
+  )
+}
 
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.down = function(knex) {
-    return knex.schema.dropTableIfExists('outgoingPaymentCardDetails');
-};
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('outgoingPaymentCardDetails')
+}

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1094,6 +1094,50 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "CardDetailsInput",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "expiry",
+            "description": "Expire date",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "signature",
+            "description": "Signature",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "CreateAssetInput",
         "description": null,
         "isOneOf": false,
@@ -1631,6 +1675,18 @@
         "isOneOf": false,
         "fields": null,
         "inputFields": [
+          {
+            "name": "cardDetails",
+            "description": "Used for the card service to provide the card expiry and signature",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CardDetailsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "idempotencyKey",
             "description": "Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency).",
@@ -4315,6 +4371,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "OutgoingPaymentCardDetails",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Payment",
             "ofType": null
           },
@@ -5558,6 +5619,18 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "cardDetails",
+            "description": "Used for the card service to provide the card expiry and signature",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "OutgoingPaymentCardDetails",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "client",
             "description": "Information about the wallet address of the Open Payments client that created the outgoing payment.",
             "args": [],
@@ -5793,6 +5866,120 @@
             "name": "BasePayment",
             "ofType": null
           },
+          {
+            "kind": "INTERFACE",
+            "name": "Model",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "OutgoingPaymentCardDetails",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expiry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "outgoingPaymentId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "signature",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
           {
             "kind": "INTERFACE",
             "name": "Model",

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -191,6 +191,13 @@ export type CancelOutgoingPaymentInput = {
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type CardDetailsInput = {
+  /** Expire date */
+  expiry: Scalars['String']['input'];
+  /** Signature */
+  signature: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
   code: Scalars['String']['input'];
@@ -278,6 +285,8 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
   /** Additional metadata associated with the outgoing payment. */
@@ -1006,6 +1015,8 @@ export type MutationWithdrawEventLiquidityArgs = {
 
 export type OutgoingPayment = BasePayment & Model & {
   __typename?: 'OutgoingPayment';
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: Maybe<OutgoingPaymentCardDetails>;
   /** Information about the wallet address of the Open Payments client that created the outgoing payment. */
   client?: Maybe<Scalars['String']['output']>;
   /** The date and time that the outgoing payment was created. */
@@ -1038,6 +1049,16 @@ export type OutgoingPayment = BasePayment & Model & {
   tenantId?: Maybe<Scalars['String']['output']>;
   /** Unique identifier of the wallet address under which the outgoing payment was created. */
   walletAddressId: Scalars['ID']['output'];
+};
+
+export type OutgoingPaymentCardDetails = Model & {
+  __typename?: 'OutgoingPaymentCardDetails';
+  createdAt: Scalars['String']['output'];
+  expiry: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  outgoingPaymentId: Scalars['ID']['output'];
+  signature: Scalars['String']['output'];
+  updatedAt: Scalars['String']['output'];
 };
 
 export type OutgoingPaymentConnection = {
@@ -1898,7 +1919,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
-  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
+  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<OutgoingPaymentCardDetails> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1921,6 +1942,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentInput: ResolverTypeWrapper<Partial<CancelIncomingPaymentInput>>;
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
+  CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1982,6 +2004,7 @@ export type ResolversTypes = {
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
+  OutgoingPaymentCardDetails: ResolverTypeWrapper<Partial<OutgoingPaymentCardDetails>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
   OutgoingPaymentFilter: ResolverTypeWrapper<Partial<OutgoingPaymentFilter>>;
@@ -2065,6 +2088,7 @@ export type ResolversParentTypes = {
   CancelIncomingPaymentInput: Partial<CancelIncomingPaymentInput>;
   CancelIncomingPaymentResponse: Partial<CancelIncomingPaymentResponse>;
   CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
+  CardDetailsInput: Partial<CardDetailsInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -2121,6 +2145,7 @@ export type ResolversParentTypes = {
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
   OutgoingPayment: Partial<OutgoingPayment>;
+  OutgoingPaymentCardDetails: Partial<OutgoingPaymentCardDetails>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
   OutgoingPaymentFilter: Partial<OutgoingPaymentFilter>;
@@ -2392,7 +2417,7 @@ export type LiquidityMutationResponseResolvers<ContextType = any, ParentType ext
 };
 
 export type ModelResolvers<ContextType = any, ParentType extends ResolversParentTypes['Model'] = ResolversParentTypes['Model']> = {
-  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'OutgoingPaymentCardDetails' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 };
@@ -2439,6 +2464,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
+  cardDetails?: Resolver<Maybe<ResolversTypes['OutgoingPaymentCardDetails']>, ParentType, ContextType>;
   client?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -2455,6 +2481,16 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   stateAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   walletAddressId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2792,6 +2828,7 @@ export type Resolvers<ContextType = any> = {
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
+  OutgoingPaymentCardDetails?: OutgoingPaymentCardDetailsResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
   OutgoingPaymentResponse?: OutgoingPaymentResponseResolvers<ContextType>;

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -713,6 +713,102 @@ describe('OutgoingPayment Resolvers', (): void => {
       }
       expect(createSpy).toHaveBeenCalledWith({ ...input, tenantId })
     })
+    test('fails because of card expiry', async (): Promise<void> => {
+      const createSpy = jest
+        .spyOn(outgoingPaymentService, 'create')
+        .mockResolvedValueOnce(OutgoingPaymentError.InvalidCardExpiry)
+
+      const input = {
+        walletAddressId: uuid(),
+        quoteId: uuid(),
+        cardDetails: {
+          signature: 'test-signature',
+          expiry: 'NOT-A-VALID-EXPIRY'
+        }
+      }
+
+      expect.assertions(3)
+      try {
+        await appContainer.apolloClient
+          .query({
+            query: gql`
+              mutation CreateOutgoingPayment(
+                $input: CreateOutgoingPaymentInput!
+              ) {
+                createOutgoingPayment(input: $input) {
+                  payment {
+                    id
+                    state
+                  }
+                }
+              }
+            `,
+            variables: { input }
+          })
+          .then(
+            (query): OutgoingPaymentResponse =>
+              query.data?.createOutgoingPayment
+          )
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApolloError)
+        expect((error as ApolloError).graphQLErrors).toContainEqual(
+          expect.objectContaining({
+            message: errorToMessage[OutgoingPaymentError.InvalidCardExpiry],
+            extensions: expect.objectContaining({
+              code: errorToCode[OutgoingPaymentError.InvalidCardExpiry]
+            })
+          })
+        )
+      }
+      expect(createSpy).toHaveBeenCalledWith({ ...input, tenantId })
+    })
+    test('works with card details', async (): Promise<void> => {
+      const { id: walletAddressId } = await createWalletAddress(deps, {
+        tenantId,
+        assetId: asset.id
+      })
+      const payment = await createPayment({
+        tenantId,
+        walletAddressId
+      })
+
+      const createSpy = jest
+        .spyOn(outgoingPaymentService, 'create')
+        .mockResolvedValueOnce(payment)
+
+      const input = {
+        walletAddressId: payment.walletAddressId,
+        quoteId: payment.quote.id,
+        cardDetails: {
+          signature: 'test-signature',
+          expiry: '12/24'
+        }
+      }
+
+      const query = await appContainer.apolloClient
+        .query({
+          query: gql`
+            mutation CreateOutgoingPayment(
+              $input: CreateOutgoingPaymentInput!
+            ) {
+              createOutgoingPayment(input: $input) {
+                payment {
+                  id
+                  state
+                }
+              }
+            }
+          `,
+          variables: { input }
+        })
+        .then(
+          (query): OutgoingPaymentResponse => query.data?.createOutgoingPayment
+        )
+
+      expect(createSpy).toHaveBeenCalledWith({ ...input, tenantId })
+      expect(query.payment?.id).toBe(payment.id)
+      expect(query.payment?.state).toBe(SchemaPaymentState.Funding)
+    })
   })
 
   describe('Mutation.createOutgoingPaymentFromIncomingPayment', (): void => {

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -259,7 +259,7 @@ function cardToGraphql(payment: OutgoingPayment): OutgoingPaymentCardDetails | u
   return {
     id: payment.cardDetails.id,
     outgoingPaymentId: payment.cardDetails.outgoingPaymentId,
-    expiry: new Date(+payment.cardDetails.expiry).toISOString(),
+    expiry: payment.cardDetails.expiry,
     signature: payment.cardDetails.signature,
     updatedAt: new Date(+payment.cardDetails.updatedAt).toISOString(),
     createdAt: new Date(+payment.cardDetails.createdAt).toISOString()

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -253,9 +253,10 @@ export function paymentToGraphql(
     cardDetails: cardToGraphql(payment)
   }
 }
-function cardToGraphql(payment: OutgoingPayment): OutgoingPaymentCardDetails | undefined {
-  if (!payment.cardDetails) 
-    return undefined
+function cardToGraphql(
+  payment: OutgoingPayment
+): OutgoingPaymentCardDetails | undefined {
+  if (!payment.cardDetails) return undefined
   return {
     id: payment.cardDetails.id,
     outgoingPaymentId: payment.cardDetails.outgoingPaymentId,
@@ -265,4 +266,3 @@ function cardToGraphql(payment: OutgoingPayment): OutgoingPaymentCardDetails | u
     createdAt: new Date(+payment.cardDetails.createdAt).toISOString()
   }
 }
-

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -5,7 +5,7 @@ import {
   WalletAddressResolvers,
   QueryResolvers,
   ResolversTypes,
-  OutgoingPaymentCardDetails
+  OutgoingPaymentCardDetails as SchemaOutgoingPaymentCardDetails
 } from '../generated/graphql'
 import {
   isOutgoingPaymentError,
@@ -18,6 +18,7 @@ import { getPageInfo } from '../../shared/pagination'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 import { GraphQLError } from 'graphql'
 import { GraphQLErrorCode } from '../errors'
+import { OutgoingPaymentCardDetails } from '../../open_payments/payment/outgoing/card/model'
 
 export const getOutgoingPayment: QueryResolvers<TenantedApolloContext>['outgoingPayment'] =
   async (parent, args, ctx): Promise<ResolversTypes['OutgoingPayment']> => {
@@ -250,19 +251,19 @@ export function paymentToGraphql(
     quote: quoteToGraphql(payment.quote),
     grantId: payment.grantId,
     tenantId: payment.tenantId,
-    cardDetails: cardToGraphql(payment)
+    cardDetails: cardDetailsToGraphql(payment.cardDetails)
   }
 }
-function cardToGraphql(
-  payment: OutgoingPayment
-): OutgoingPaymentCardDetails | undefined {
-  if (!payment.cardDetails) return undefined
+function cardDetailsToGraphql(
+  cardDetails?: OutgoingPaymentCardDetails
+): SchemaOutgoingPaymentCardDetails | undefined {
+  if (!cardDetails) return undefined
   return {
-    id: payment.cardDetails.id,
-    outgoingPaymentId: payment.cardDetails.outgoingPaymentId,
-    expiry: payment.cardDetails.expiry,
-    signature: payment.cardDetails.signature,
-    updatedAt: new Date(+payment.cardDetails.updatedAt).toISOString(),
-    createdAt: new Date(+payment.cardDetails.createdAt).toISOString()
+    id: cardDetails.id,
+    outgoingPaymentId: cardDetails.outgoingPaymentId,
+    expiry: cardDetails.expiry,
+    signature: cardDetails.signature,
+    createdAt: new Date(+cardDetails.createdAt).toISOString(),
+    updatedAt: new Date(+cardDetails.updatedAt).toISOString()
   }
 }

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -4,7 +4,8 @@ import {
   OutgoingPayment as SchemaOutgoingPayment,
   WalletAddressResolvers,
   QueryResolvers,
-  ResolversTypes
+  ResolversTypes,
+  OutgoingPaymentCardDetails
 } from '../generated/graphql'
 import {
   isOutgoingPaymentError,
@@ -248,6 +249,20 @@ export function paymentToGraphql(
     createdAt: new Date(+payment.createdAt).toISOString(),
     quote: quoteToGraphql(payment.quote),
     grantId: payment.grantId,
-    tenantId: payment.tenantId
+    tenantId: payment.tenantId,
+    cardDetails: cardToGraphql(payment)
   }
 }
+function cardToGraphql(payment: OutgoingPayment): OutgoingPaymentCardDetails | undefined {
+  if (!payment.cardDetails) 
+    return undefined
+  return {
+    id: payment.cardDetails.id,
+    outgoingPaymentId: payment.cardDetails.outgoingPaymentId,
+    expiry: new Date(+payment.cardDetails.expiry).toISOString(),
+    signature: payment.cardDetails.signature,
+    updatedAt: new Date(+payment.cardDetails.updatedAt).toISOString(),
+    createdAt: new Date(+payment.cardDetails.createdAt).toISOString()
+  }
+}
+

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -251,11 +251,13 @@ export function paymentToGraphql(
     quote: quoteToGraphql(payment.quote),
     grantId: payment.grantId,
     tenantId: payment.tenantId,
-    cardDetails: cardDetailsToGraphql(payment.cardDetails)
+    cardDetails: payment.cardDetails
+      ? cardDetailsToGraphql(payment.cardDetails)
+      : undefined
   }
 }
 function cardDetailsToGraphql(
-  cardDetails?: OutgoingPaymentCardDetails
+  cardDetails: OutgoingPaymentCardDetails
 ): SchemaOutgoingPaymentCardDetails | undefined {
   if (!cardDetails) return undefined
   return {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1051,7 +1051,7 @@ type OutgoingPayment implements BasePayment & Model {
   "Unique identifier of the grant under which the outgoing payment was created."
   grantId: String
   "Tenant ID of the outgoing payment."
-  tenantId: String,
+  tenantId: String
   "Used for the card service to provide the card expiry and signature"
   cardDetails: OutgoingPaymentCardDetails
 }
@@ -1063,7 +1063,6 @@ type OutgoingPaymentCardDetails implements Model {
   expiry: String!
   createdAt: String!
   updatedAt: String!
-
 }
 
 enum OutgoingPaymentState {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1051,7 +1051,19 @@ type OutgoingPayment implements BasePayment & Model {
   "Unique identifier of the grant under which the outgoing payment was created."
   grantId: String
   "Tenant ID of the outgoing payment."
-  tenantId: String
+  tenantId: String,
+  "Used for the card service to provide the card expiry and signature"
+  cardDetails: OutgoingPaymentCardDetails
+}
+
+type OutgoingPaymentCardDetails implements Model {
+  id: ID!
+  outgoingPaymentId: ID!
+  signature: String!
+  expiry: String!
+  createdAt: String!
+  updatedAt: String!
+
 }
 
 enum OutgoingPaymentState {
@@ -1229,6 +1241,15 @@ input CreateOutgoingPaymentInput {
   metadata: JSONObject
   "Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency)."
   idempotencyKey: String
+  "Used for the card service to provide the card expiry and signature"
+  cardDetails: CardDetailsInput
+}
+
+input CardDetailsInput {
+  "Signature"
+  signature: String!
+  "Expire date"
+  expiry: String!
 }
 
 input CancelOutgoingPaymentInput {

--- a/packages/backend/src/open_payments/payment/outgoing/card/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/card/model.ts
@@ -1,9 +1,9 @@
 import { BaseModel } from '../../../../shared/baseModel'
 
 type OutgoingPaymentCardDetailsTableName = 'outgoingPaymentCardDetails'
-type OutgoingPaymentId = 'outgoingPaymentId'
+type OutgoingPaymentIdColumnName = 'outgoingPaymentId'
 type OutgoingPaymentIdRelation =
-  `${OutgoingPaymentCardDetailsTableName}.${OutgoingPaymentId}`
+  `${OutgoingPaymentCardDetailsTableName}.${OutgoingPaymentIdColumnName}`
 export const outgoingPaymentCardDetailsRelation: OutgoingPaymentIdRelation =
   'outgoingPaymentCardDetails.outgoingPaymentId'
 
@@ -11,7 +11,7 @@ type OutgoingPaymentCardDetailsType = {
   expiry: string
   signature: string
 } & {
-  [key in OutgoingPaymentId]: string
+  [key in OutgoingPaymentIdColumnName]: string
 }
 
 export class OutgoingPaymentCardDetails

--- a/packages/backend/src/open_payments/payment/outgoing/card/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/card/model.ts
@@ -1,0 +1,20 @@
+import { Pojo } from 'objection'
+import { BaseModel } from '../../../../shared/baseModel'
+
+export class OutgoingPaymentsCardDetails extends BaseModel {
+  public static get tableName(): string {
+    return 'outgoingPaymentCardDetails'
+  }
+
+  public expiry!: Date
+  public readonly outgoingPaymentId!: string
+  public signature!: string
+
+  $formatJson(json: Pojo): Pojo {
+    json = super.$formatJson(json)
+    return {
+      ...json,
+      expiry: json.expiry.toISOString()
+    }
+  }
+}

--- a/packages/backend/src/open_payments/payment/outgoing/card/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/card/model.ts
@@ -6,7 +6,7 @@ export class OutgoingPaymentsCardDetails extends BaseModel {
     return 'outgoingPaymentCardDetails'
   }
 
-  public expiry!: Date
+  public expiry!: string
   public readonly outgoingPaymentId!: string
   public signature!: string
 

--- a/packages/backend/src/open_payments/payment/outgoing/card/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/card/model.ts
@@ -1,20 +1,28 @@
-import { Pojo } from 'objection'
 import { BaseModel } from '../../../../shared/baseModel'
 
-export class OutgoingPaymentsCardDetails extends BaseModel {
-  public static get tableName(): string {
+type OutgoingPaymentCardDetailsTableName = 'outgoingPaymentCardDetails'
+type OutgoingPaymentId = 'outgoingPaymentId'
+type OutgoingPaymentIdRelation =
+  `${OutgoingPaymentCardDetailsTableName}.${OutgoingPaymentId}`
+export const outgoingPaymentCardDetailsRelation: OutgoingPaymentIdRelation =
+  'outgoingPaymentCardDetails.outgoingPaymentId'
+
+type OutgoingPaymentCardDetailsType = {
+  expiry: string
+  signature: string
+} & {
+  [key in OutgoingPaymentId]: string
+}
+
+export class OutgoingPaymentCardDetails
+  extends BaseModel
+  implements OutgoingPaymentCardDetailsType
+{
+  public static get tableName(): OutgoingPaymentCardDetailsTableName {
     return 'outgoingPaymentCardDetails'
   }
 
   public expiry!: string
   public readonly outgoingPaymentId!: string
   public signature!: string
-
-  $formatJson(json: Pojo): Pojo {
-    json = super.$formatJson(json)
-    return {
-      ...json,
-      expiry: json.expiry.toISOString()
-    }
-  }
 }

--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -18,7 +18,8 @@ export enum OutgoingPaymentError {
   InvalidAmount = 'InvalidAmount',
   NegativeReceiveAmount = 'NegativeReceiveAmount',
   InvalidReceiver = 'InvalidReceiver',
-  OnlyOneGrantAmountAllowed = 'OnlyOneGrantAmountAllowed'
+  OnlyOneGrantAmountAllowed = 'OnlyOneGrantAmountAllowed',
+  InvalidCardExpiry = 'InvalidCardExpiry'
 }
 
 export const quoteErrorToOutgoingPaymentError: Record<
@@ -52,7 +53,8 @@ export const errorToHTTPCode: {
   [OutgoingPaymentError.InvalidAmount]: 400,
   [OutgoingPaymentError.NegativeReceiveAmount]: 400,
   [OutgoingPaymentError.InvalidReceiver]: 400,
-  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]: 500
+  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]: 500,
+  [OutgoingPaymentError.InvalidCardExpiry]: 400
 }
 
 export const errorToCode: {
@@ -68,8 +70,8 @@ export const errorToCode: {
   [OutgoingPaymentError.InvalidAmount]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.NegativeReceiveAmount]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.InvalidReceiver]: GraphQLErrorCode.BadUserInput,
-  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]:
-    GraphQLErrorCode.BadUserInput
+  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.InvalidCardExpiry]: GraphQLErrorCode.BadUserInput
 }
 
 export const errorToMessage: {
@@ -85,8 +87,8 @@ export const errorToMessage: {
   [OutgoingPaymentError.InvalidAmount]: 'invalid amount',
   [OutgoingPaymentError.NegativeReceiveAmount]: 'negative receive amount',
   [OutgoingPaymentError.InvalidReceiver]: 'invalid receiver',
-  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]:
-    'only one of receiveAmount or debitAmount allowed'
+  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]: 'only one of receiveAmount or debitAmount allowed',
+  [OutgoingPaymentError.InvalidCardExpiry]: 'expired card format MM/YY'
 }
 
 export const FundingError = { ...OutgoingPaymentError, ...TransferError }

--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -70,7 +70,8 @@ export const errorToCode: {
   [OutgoingPaymentError.InvalidAmount]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.NegativeReceiveAmount]: GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.InvalidReceiver]: GraphQLErrorCode.BadUserInput,
-  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]: GraphQLErrorCode.BadUserInput,
+  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]:
+    GraphQLErrorCode.BadUserInput,
   [OutgoingPaymentError.InvalidCardExpiry]: GraphQLErrorCode.BadUserInput
 }
 
@@ -87,7 +88,8 @@ export const errorToMessage: {
   [OutgoingPaymentError.InvalidAmount]: 'invalid amount',
   [OutgoingPaymentError.NegativeReceiveAmount]: 'negative receive amount',
   [OutgoingPaymentError.InvalidReceiver]: 'invalid receiver',
-  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]: 'only one of receiveAmount or debitAmount allowed',
+  [OutgoingPaymentError.OnlyOneGrantAmountAllowed]:
+    'only one of receiveAmount or debitAmount allowed',
   [OutgoingPaymentError.InvalidCardExpiry]: 'expired card format MM/YY'
 }
 

--- a/packages/backend/src/open_payments/payment/outgoing/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/model.ts
@@ -1,4 +1,4 @@
-import { Model, ModelOptions, Pojo, QueryContext } from 'objection'
+import { Model, ModelOptions, QueryContext } from 'objection'
 import { DbErrors } from 'objection-db-errors'
 
 import { LiquidityAccount } from '../../../accounting/service'

--- a/packages/backend/src/open_payments/payment/outgoing/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/model.ts
@@ -102,7 +102,7 @@ export class OutgoingPayment
 
   public metadata?: Record<string, unknown>
 
-  public cardDetails?: OutgoingPaymentsCardDetails;
+  public cardDetails?: OutgoingPaymentsCardDetails
 
   public quote!: Quote
 
@@ -156,9 +156,8 @@ export class OutgoingPayment
         join: {
           from: 'outgoingPayments.id',
           to: 'outgoingPaymentsCardDetails.outgoingPaymentId'
-
         }
-      },
+      }
     }
   }
 
@@ -329,12 +328,11 @@ export class OutgoingPaymentEvent extends WebhookEvent {
     }
   }
 
-    $formatJson(json: Pojo): Pojo {
-      json = super.$formatJson(json)
-      return {
-        ...json,
-        cardDetails: new OutgoingPaymentsCardDetails().$formatJson(json.card),
-      }
+  $formatJson(json: Pojo): Pojo {
+    json = super.$formatJson(json)
+    return {
+      ...json,
+      cardDetails: new OutgoingPaymentsCardDetails().$formatJson(json.card)
     }
   }
-
+}

--- a/packages/backend/src/open_payments/payment/outgoing/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/model.ts
@@ -16,7 +16,10 @@ import {
   OutgoingPaymentWithSpentAmounts
 } from '@interledger/open-payments'
 import { Tenant } from '../../../tenants/model'
-import { OutgoingPaymentsCardDetails } from './card/model'
+import {
+  OutgoingPaymentCardDetails,
+  outgoingPaymentCardDetailsRelation
+} from './card/model'
 
 export class OutgoingPaymentGrant extends DbErrors(Model) {
   public static get modelPaths(): string[] {
@@ -102,7 +105,7 @@ export class OutgoingPayment
 
   public metadata?: Record<string, unknown>
 
-  public cardDetails?: OutgoingPaymentsCardDetails
+  public cardDetails?: OutgoingPaymentCardDetails
 
   public quote!: Quote
 
@@ -152,10 +155,10 @@ export class OutgoingPayment
       },
       cardDetails: {
         relation: Model.HasOneRelation,
-        modelClass: OutgoingPaymentsCardDetails,
+        modelClass: OutgoingPaymentCardDetails,
         join: {
           from: 'outgoingPayments.id',
-          to: 'outgoingPaymentsCardDetails.outgoingPaymentId'
+          to: outgoingPaymentCardDetailsRelation
         }
       }
     }
@@ -325,14 +328,6 @@ export class OutgoingPaymentEvent extends WebhookEvent {
 
     if (!this.outgoingPaymentId) {
       throw new Error(OutgoingPaymentEventError.OutgoingPaymentIdRequired)
-    }
-  }
-
-  $formatJson(json: Pojo): Pojo {
-    json = super.$formatJson(json)
-    return {
-      ...json,
-      cardDetails: new OutgoingPaymentsCardDetails().$formatJson(json.card)
     }
   }
 }

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -419,7 +419,7 @@ async function createOutgoingPayment(
                 trx
               ).insertAndFetch({
                 outgoingPaymentId: payment.id,
-                expiry: new Date(options.cardDetails?.expiry),
+                expiry: options.cardDetails?.expiry,
                 signature: options.cardDetails?.signature
               })
               payment.cardDetails = card

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -46,7 +46,7 @@ import { IAppConfig } from '../../../config/app'
 import { AssetService } from '../../../asset/service'
 import { Span, trace } from '@opentelemetry/api'
 import { FeeService } from '../../../fee/service'
-import { OutgoingPaymentsCardDetails } from './card/model'
+import { OutgoingPaymentCardDetails } from './card/model'
 
 export interface OutgoingPaymentService
   extends WalletAddressSubresourceService<OutgoingPayment> {
@@ -424,7 +424,7 @@ async function createOutgoingPayment(
             if (!isExpiryFormat(expiry))
               throw OutgoingPaymentError.InvalidCardExpiry
 
-            payment.cardDetails = await OutgoingPaymentsCardDetails.query(
+            payment.cardDetails = await OutgoingPaymentCardDetails.query(
               trx
             ).insertAndFetch({
               outgoingPaymentId: payment.id,

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -223,7 +223,11 @@ export type CreateOutgoingPaymentOptions =
 export function isCreateFromCardPayment(
   options: CreateOutgoingPaymentOptions
 ): options is CreateFromCardPayment {
-  return  'cardDetails' in options && 'expiry' in options.cardDetails && 'signature' in options.cardDetails
+  return (
+    'cardDetails' in options &&
+    'expiry' in options.cardDetails &&
+    'signature' in options.cardDetails
+  )
 }
 
 export function isCreateFromIncomingPayment(
@@ -415,16 +419,18 @@ async function createOutgoingPayment(
           })
 
           if (isCreateFromCardPayment(options)) {
-            const { expiry, signature } = options.cardDetails;
-          
-            if (!isExpiryFormat(expiry)) 
-              throw OutgoingPaymentError.InvalidCardExpiry;
-          
-            payment.cardDetails = await OutgoingPaymentsCardDetails.query(trx).insertAndFetch({
+            const { expiry, signature } = options.cardDetails
+
+            if (!isExpiryFormat(expiry))
+              throw OutgoingPaymentError.InvalidCardExpiry
+
+            payment.cardDetails = await OutgoingPaymentsCardDetails.query(
+              trx
+            ).insertAndFetch({
               outgoingPaymentId: payment.id,
               expiry,
               signature
-            });
+            })
           }
 
           payment.walletAddress = walletAddress
@@ -850,6 +856,4 @@ function validateSentAmount(
 
 function isExpiryFormat(expiry: string): boolean {
   return !!expiry.match(/^(0[1-9]|1[0-2])\/(\d{2})$/)
-
 }
-

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -191,6 +191,13 @@ export type CancelOutgoingPaymentInput = {
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type CardDetailsInput = {
+  /** Expire date */
+  expiry: Scalars['String']['input'];
+  /** Signature */
+  signature: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
   code: Scalars['String']['input'];
@@ -278,6 +285,8 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
   /** Additional metadata associated with the outgoing payment. */
@@ -1006,6 +1015,8 @@ export type MutationWithdrawEventLiquidityArgs = {
 
 export type OutgoingPayment = BasePayment & Model & {
   __typename?: 'OutgoingPayment';
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: Maybe<OutgoingPaymentCardDetails>;
   /** Information about the wallet address of the Open Payments client that created the outgoing payment. */
   client?: Maybe<Scalars['String']['output']>;
   /** The date and time that the outgoing payment was created. */
@@ -1038,6 +1049,16 @@ export type OutgoingPayment = BasePayment & Model & {
   tenantId?: Maybe<Scalars['String']['output']>;
   /** Unique identifier of the wallet address under which the outgoing payment was created. */
   walletAddressId: Scalars['ID']['output'];
+};
+
+export type OutgoingPaymentCardDetails = Model & {
+  __typename?: 'OutgoingPaymentCardDetails';
+  createdAt: Scalars['String']['output'];
+  expiry: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  outgoingPaymentId: Scalars['ID']['output'];
+  signature: Scalars['String']['output'];
+  updatedAt: Scalars['String']['output'];
 };
 
 export type OutgoingPaymentConnection = {
@@ -1898,7 +1919,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
-  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
+  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<OutgoingPaymentCardDetails> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1921,6 +1942,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentInput: ResolverTypeWrapper<Partial<CancelIncomingPaymentInput>>;
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
+  CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1982,6 +2004,7 @@ export type ResolversTypes = {
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
+  OutgoingPaymentCardDetails: ResolverTypeWrapper<Partial<OutgoingPaymentCardDetails>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
   OutgoingPaymentFilter: ResolverTypeWrapper<Partial<OutgoingPaymentFilter>>;
@@ -2065,6 +2088,7 @@ export type ResolversParentTypes = {
   CancelIncomingPaymentInput: Partial<CancelIncomingPaymentInput>;
   CancelIncomingPaymentResponse: Partial<CancelIncomingPaymentResponse>;
   CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
+  CardDetailsInput: Partial<CardDetailsInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -2121,6 +2145,7 @@ export type ResolversParentTypes = {
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
   OutgoingPayment: Partial<OutgoingPayment>;
+  OutgoingPaymentCardDetails: Partial<OutgoingPaymentCardDetails>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
   OutgoingPaymentFilter: Partial<OutgoingPaymentFilter>;
@@ -2392,7 +2417,7 @@ export type LiquidityMutationResponseResolvers<ContextType = any, ParentType ext
 };
 
 export type ModelResolvers<ContextType = any, ParentType extends ResolversParentTypes['Model'] = ResolversParentTypes['Model']> = {
-  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'OutgoingPaymentCardDetails' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 };
@@ -2439,6 +2464,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
+  cardDetails?: Resolver<Maybe<ResolversTypes['OutgoingPaymentCardDetails']>, ParentType, ContextType>;
   client?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -2455,6 +2481,16 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   stateAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   walletAddressId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2792,6 +2828,7 @@ export type Resolvers<ContextType = any> = {
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
+  OutgoingPaymentCardDetails?: OutgoingPaymentCardDetailsResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
   OutgoingPaymentResponse?: OutgoingPaymentResponseResolvers<ContextType>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -191,6 +191,13 @@ export type CancelOutgoingPaymentInput = {
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type CardDetailsInput = {
+  /** Expire date */
+  expiry: Scalars['String']['input'];
+  /** Signature */
+  signature: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
   code: Scalars['String']['input'];
@@ -278,6 +285,8 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
   /** Additional metadata associated with the outgoing payment. */
@@ -1006,6 +1015,8 @@ export type MutationWithdrawEventLiquidityArgs = {
 
 export type OutgoingPayment = BasePayment & Model & {
   __typename?: 'OutgoingPayment';
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: Maybe<OutgoingPaymentCardDetails>;
   /** Information about the wallet address of the Open Payments client that created the outgoing payment. */
   client?: Maybe<Scalars['String']['output']>;
   /** The date and time that the outgoing payment was created. */
@@ -1038,6 +1049,16 @@ export type OutgoingPayment = BasePayment & Model & {
   tenantId?: Maybe<Scalars['String']['output']>;
   /** Unique identifier of the wallet address under which the outgoing payment was created. */
   walletAddressId: Scalars['ID']['output'];
+};
+
+export type OutgoingPaymentCardDetails = Model & {
+  __typename?: 'OutgoingPaymentCardDetails';
+  createdAt: Scalars['String']['output'];
+  expiry: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  outgoingPaymentId: Scalars['ID']['output'];
+  signature: Scalars['String']['output'];
+  updatedAt: Scalars['String']['output'];
 };
 
 export type OutgoingPaymentConnection = {
@@ -1898,7 +1919,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
-  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
+  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<OutgoingPaymentCardDetails> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1921,6 +1942,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentInput: ResolverTypeWrapper<Partial<CancelIncomingPaymentInput>>;
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
+  CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1982,6 +2004,7 @@ export type ResolversTypes = {
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
+  OutgoingPaymentCardDetails: ResolverTypeWrapper<Partial<OutgoingPaymentCardDetails>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
   OutgoingPaymentFilter: ResolverTypeWrapper<Partial<OutgoingPaymentFilter>>;
@@ -2065,6 +2088,7 @@ export type ResolversParentTypes = {
   CancelIncomingPaymentInput: Partial<CancelIncomingPaymentInput>;
   CancelIncomingPaymentResponse: Partial<CancelIncomingPaymentResponse>;
   CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
+  CardDetailsInput: Partial<CardDetailsInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -2121,6 +2145,7 @@ export type ResolversParentTypes = {
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
   OutgoingPayment: Partial<OutgoingPayment>;
+  OutgoingPaymentCardDetails: Partial<OutgoingPaymentCardDetails>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
   OutgoingPaymentFilter: Partial<OutgoingPaymentFilter>;
@@ -2392,7 +2417,7 @@ export type LiquidityMutationResponseResolvers<ContextType = any, ParentType ext
 };
 
 export type ModelResolvers<ContextType = any, ParentType extends ResolversParentTypes['Model'] = ResolversParentTypes['Model']> = {
-  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'OutgoingPaymentCardDetails' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 };
@@ -2439,6 +2464,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
+  cardDetails?: Resolver<Maybe<ResolversTypes['OutgoingPaymentCardDetails']>, ParentType, ContextType>;
   client?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -2455,6 +2481,16 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   stateAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   walletAddressId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2792,6 +2828,7 @@ export type Resolvers<ContextType = any> = {
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
+  OutgoingPaymentCardDetails?: OutgoingPaymentCardDetailsResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
   OutgoingPaymentResponse?: OutgoingPaymentResponseResolvers<ContextType>;

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -191,6 +191,13 @@ export type CancelOutgoingPaymentInput = {
   reason?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type CardDetailsInput = {
+  /** Expire date */
+  expiry: Scalars['String']['input'];
+  /** Signature */
+  signature: Scalars['String']['input'];
+};
+
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
   code: Scalars['String']['input'];
@@ -278,6 +285,8 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
   /** Additional metadata associated with the outgoing payment. */
@@ -1006,6 +1015,8 @@ export type MutationWithdrawEventLiquidityArgs = {
 
 export type OutgoingPayment = BasePayment & Model & {
   __typename?: 'OutgoingPayment';
+  /** Used for the card service to provide the card expiry and signature */
+  cardDetails?: Maybe<OutgoingPaymentCardDetails>;
   /** Information about the wallet address of the Open Payments client that created the outgoing payment. */
   client?: Maybe<Scalars['String']['output']>;
   /** The date and time that the outgoing payment was created. */
@@ -1038,6 +1049,16 @@ export type OutgoingPayment = BasePayment & Model & {
   tenantId?: Maybe<Scalars['String']['output']>;
   /** Unique identifier of the wallet address under which the outgoing payment was created. */
   walletAddressId: Scalars['ID']['output'];
+};
+
+export type OutgoingPaymentCardDetails = Model & {
+  __typename?: 'OutgoingPaymentCardDetails';
+  createdAt: Scalars['String']['output'];
+  expiry: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  outgoingPaymentId: Scalars['ID']['output'];
+  signature: Scalars['String']['output'];
+  updatedAt: Scalars['String']['output'];
 };
 
 export type OutgoingPaymentConnection = {
@@ -1898,7 +1919,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   BasePayment: ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> );
-  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
+  Model: ( Partial<AccountingTransfer> ) | ( Partial<Asset> ) | ( Partial<Fee> ) | ( Partial<IncomingPayment> ) | ( Partial<OutgoingPayment> ) | ( Partial<OutgoingPaymentCardDetails> ) | ( Partial<Payment> ) | ( Partial<Peer> ) | ( Partial<Tenant> ) | ( Partial<WalletAddress> ) | ( Partial<WalletAddressKey> ) | ( Partial<WebhookEvent> );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -1921,6 +1942,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentInput: ResolverTypeWrapper<Partial<CancelIncomingPaymentInput>>;
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
+  CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -1982,6 +2004,7 @@ export type ResolversTypes = {
   Model: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Model']>;
   Mutation: ResolverTypeWrapper<{}>;
   OutgoingPayment: ResolverTypeWrapper<Partial<OutgoingPayment>>;
+  OutgoingPaymentCardDetails: ResolverTypeWrapper<Partial<OutgoingPaymentCardDetails>>;
   OutgoingPaymentConnection: ResolverTypeWrapper<Partial<OutgoingPaymentConnection>>;
   OutgoingPaymentEdge: ResolverTypeWrapper<Partial<OutgoingPaymentEdge>>;
   OutgoingPaymentFilter: ResolverTypeWrapper<Partial<OutgoingPaymentFilter>>;
@@ -2065,6 +2088,7 @@ export type ResolversParentTypes = {
   CancelIncomingPaymentInput: Partial<CancelIncomingPaymentInput>;
   CancelIncomingPaymentResponse: Partial<CancelIncomingPaymentResponse>;
   CancelOutgoingPaymentInput: Partial<CancelOutgoingPaymentInput>;
+  CardDetailsInput: Partial<CardDetailsInput>;
   CreateAssetInput: Partial<CreateAssetInput>;
   CreateAssetLiquidityWithdrawalInput: Partial<CreateAssetLiquidityWithdrawalInput>;
   CreateIncomingPaymentInput: Partial<CreateIncomingPaymentInput>;
@@ -2121,6 +2145,7 @@ export type ResolversParentTypes = {
   Model: ResolversInterfaceTypes<ResolversParentTypes>['Model'];
   Mutation: {};
   OutgoingPayment: Partial<OutgoingPayment>;
+  OutgoingPaymentCardDetails: Partial<OutgoingPaymentCardDetails>;
   OutgoingPaymentConnection: Partial<OutgoingPaymentConnection>;
   OutgoingPaymentEdge: Partial<OutgoingPaymentEdge>;
   OutgoingPaymentFilter: Partial<OutgoingPaymentFilter>;
@@ -2392,7 +2417,7 @@ export type LiquidityMutationResponseResolvers<ContextType = any, ParentType ext
 };
 
 export type ModelResolvers<ContextType = any, ParentType extends ResolversParentTypes['Model'] = ResolversParentTypes['Model']> = {
-  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AccountingTransfer' | 'Asset' | 'Fee' | 'IncomingPayment' | 'OutgoingPayment' | 'OutgoingPaymentCardDetails' | 'Payment' | 'Peer' | 'Tenant' | 'WalletAddress' | 'WalletAddressKey' | 'WebhookEvent', ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 };
@@ -2439,6 +2464,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 };
 
 export type OutgoingPaymentResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPayment'] = ResolversParentTypes['OutgoingPayment']> = {
+  cardDetails?: Resolver<Maybe<ResolversTypes['OutgoingPaymentCardDetails']>, ParentType, ContextType>;
   client?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   debitAmount?: Resolver<ResolversTypes['Amount'], ParentType, ContextType>;
@@ -2455,6 +2481,16 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
   stateAttempts?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   tenantId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   walletAddressId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2792,6 +2828,7 @@ export type Resolvers<ContextType = any> = {
   Model?: ModelResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   OutgoingPayment?: OutgoingPaymentResolvers<ContextType>;
+  OutgoingPaymentCardDetails?: OutgoingPaymentCardDetailsResolvers<ContextType>;
   OutgoingPaymentConnection?: OutgoingPaymentConnectionResolvers<ContextType>;
   OutgoingPaymentEdge?: OutgoingPaymentEdgeResolvers<ContextType>;
   OutgoingPaymentResponse?: OutgoingPaymentResponseResolvers<ContextType>;


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request

Update Outgoing Payment GraphQl request to take in the expiry and the signature of a card to be passed along to the webhook

## Context
In the POS - Card Service relationship the Card Service need to pass along the outgoing payment request toughener with the card details to the ASE
[raf-1095
](https://linear.app/interledger/issue/RAF-1095/card-service-createcardpaymentbackend-api)
## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [x] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
