### PR TITLE
feat(backend): tenant id filter tests for gql pagination

### DIFF
--- a/packages/backend/src/graphql/resolvers/asset.test.ts
+++ b/packages/backend/src/graphql/resolvers/asset.test.ts
@@ -1,4 +1,9 @@
-import { ApolloError, gql } from '@apollo/client'
+import {
+  ApolloClient,
+  ApolloError,
+  gql,
+  NormalizedCacheObject
+} from '@apollo/client'
 import assert from 'assert'
 import { v4 as uuid } from 'uuid'
 
@@ -659,6 +664,158 @@ describe('Asset Resolvers', (): void => {
             fixed: fee.fixedFee.toString()
           })
         })
+      })
+    })
+
+    describe('tenant boundaries', (): void => {
+      let operatorAsset: AssetModel
+      let tenantAsset: AssetModel
+      let secondTenantAsset: AssetModel
+      let tenantedApolloClient: ApolloClient<NormalizedCacheObject>
+
+      const pageQuery = gql`
+        query Assets($tenantId: String) {
+          assets(tenantId: $tenantId) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      `
+      beforeEach(async (): Promise<void> => {
+        operatorAsset = await createAsset(deps)
+
+        const tenant = await createTenant(deps)
+        tenantedApolloClient = await createApolloClient(
+          appContainer.container,
+          appContainer.app,
+          tenant.id
+        )
+        tenantAsset = await createAsset(deps, { tenantId: tenant.id })
+        secondTenantAsset = await createAsset(deps, { tenantId: tenant.id })
+      })
+      test('operator can get assets across all tenants', async (): Promise<void> => {
+        const query = await appContainer.apolloClient
+          .query({
+            query: pageQuery
+          })
+          .then((query): AssetsConnection => {
+            if (query.data) {
+              return query.data.assets
+            } else {
+              throw new Error('Data was empty')
+            }
+          })
+        expect(query.edges).toHaveLength(3)
+        expect(query.edges).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: operatorAsset.id
+              })
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: tenantAsset.id
+              })
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: secondTenantAsset.id
+              })
+            })
+          ])
+        )
+      })
+
+      test('tenant cannot get assets across all tenants', async (): Promise<void> => {
+        const query = await tenantedApolloClient
+          .query({
+            query: pageQuery
+          })
+          .then((query): AssetsConnection => {
+            if (query.data) {
+              return query.data.assets
+            } else {
+              throw new Error('Data was empty')
+            }
+          })
+        expect(query.edges).toHaveLength(2)
+        expect(query.edges).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: tenantAsset.id
+              })
+            })
+          ])
+        )
+      })
+
+      test('operator can specify filter assets across all tenants', async (): Promise<void> => {
+        const query = await appContainer.apolloClient
+          .query({
+            query: pageQuery,
+            variables: {
+              tenantId: tenantAsset.tenantId
+            }
+          })
+          .then((query): AssetsConnection => {
+            if (query.data) {
+              return query.data.assets
+            } else {
+              throw new Error('Data was empty')
+            }
+          })
+        expect(query.edges).toHaveLength(2)
+        expect(query.edges).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: tenantAsset.id
+              })
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: secondTenantAsset.id
+              })
+            })
+          ])
+        )
+      })
+
+      test('tenant cannot filter assets across all tenants', async (): Promise<void> => {
+        const query = await tenantedApolloClient
+          .query({
+            query: pageQuery,
+            variables: {
+              tenantId: Config.operatorTenantId
+            }
+          })
+          .then((query): AssetsConnection => {
+            if (query.data) {
+              return query.data.assets
+            } else {
+              throw new Error('Data was empty')
+            }
+          })
+        expect(query.edges).toHaveLength(2)
+        expect(query.edges).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: tenantAsset.id
+              })
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: secondTenantAsset.id
+              })
+            })
+          ])
+        )
       })
     })
   })

--- a/packages/backend/src/graphql/resolvers/asset.test.ts
+++ b/packages/backend/src/graphql/resolvers/asset.test.ts
@@ -749,6 +749,11 @@ describe('Asset Resolvers', (): void => {
               node: expect.objectContaining({
                 id: tenantAsset.id
               })
+            }),
+            expect.objectContaining({
+              node: expect.objectContaining({
+                id: secondTenantAsset.id
+              })
             })
           ])
         )

--- a/packages/backend/src/tests/combinedPayment.ts
+++ b/packages/backend/src/tests/combinedPayment.ts
@@ -30,22 +30,25 @@ export function toCombinedPayment(
   })
 }
 
+interface TestCombinedPaymentsOptions {
+  tenantId?: string
+}
+
 /**
  * Creates a random payment (incoming or outgoing) and returns a combined payment object that represents it.
  * @param deps - the app service dependency container.
  * @returns A CombinedPayment object that represents the created payment.
  */
 export async function createCombinedPayment(
-  deps: IocContract<AppServices>
+  deps: IocContract<AppServices>,
+  options?: TestCombinedPaymentsOptions
 ): Promise<CombinedPayment> {
-  const sendAsset = await createAsset(deps)
-  const receiveAsset = await createAsset(deps)
-  const sendWalletAddressId = (
-    await createWalletAddress(deps, {
-      assetId: sendAsset.id,
-      tenantId: sendAsset.tenantId
-    })
-  ).id
+  const sendAsset = await createAsset(deps, options)
+  const receiveAsset = await createAsset(deps, options)
+  const sendWalletAddress = await createWalletAddress(deps, {
+    assetId: sendAsset.id,
+    tenantId: sendAsset.tenantId
+  })
   const receiveWalletAddress = await createWalletAddress(deps, {
     assetId: receiveAsset.id,
     tenantId: sendAsset.tenantId
@@ -59,8 +62,8 @@ export async function createCombinedPayment(
           tenantId: receiveWalletAddress.tenantId
         })
       : await createOutgoingPayment(deps, {
-          tenantId: Config.operatorTenantId,
-          walletAddressId: sendWalletAddressId,
+          tenantId: sendWalletAddress.tenantId,
+          walletAddressId: sendWalletAddress.id,
           method: 'ilp',
           receiver: `${Config.openPaymentsUrl}/${uuid()}`,
           validDestination: false

--- a/packages/backend/src/tests/peer.ts
+++ b/packages/backend/src/tests/peer.ts
@@ -15,7 +15,9 @@ export async function createPeer(
   } = {}
 ): Promise<Peer> {
   const peerOptions: CreateOptions = {
-    assetId: options.assetId || (await createAsset(deps)).id,
+    assetId:
+      options.assetId ||
+      (await createAsset(deps, { tenantId: options.tenantId })).id,
     http: {
       outgoing: options.http?.outgoing || {
         authToken: faker.string.sample(32),

--- a/packages/backend/src/tests/webhook.ts
+++ b/packages/backend/src/tests/webhook.ts
@@ -8,7 +8,9 @@ import { EventPayload } from '../webhook/service'
 import { createAsset } from './asset'
 
 export const webhookEventTypes = ['event1', 'event2', 'event3'] as const
-type WebhookEventPayload = EventPayload & { assetId: string }
+type WebhookEventPayload = EventPayload & { assetId: string } & {
+  tenantId: string
+}
 
 export async function createWebhookEvent(
   deps: IocContract<AppServices>,


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Adds tests for the resolvers of several resources on the Rafiki Backend that test the following:
  - The ability for an operator to paginate across all tenants for a given resource
  - That a tenant does not paginate across all tenants for a given resource
  - The ability for an operator to filter pagination results by any tenant
  - That a tenant cannot filter pagination results by another tenant id

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes RAF-1080. Fixes #3476.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
