### PR TITLE
chore(backend): remove tenant id from card service path in WA response 

### DIFF
--- a/packages/backend/src/open_payments/wallet_address/routes.test.ts
+++ b/packages/backend/src/open_payments/wallet_address/routes.test.ts
@@ -123,7 +123,7 @@ describe('Wallet Address Routes', (): void => {
         // Ensure the tenant id is returned for auth and resource server:
         authServer: `${config.authServerGrantUrl}/${config.operatorTenantId}`,
         resourceServer: `${config.openPaymentsUrl}/${config.operatorTenantId}`,
-        cardService: `${config.cardServiceUrl}/${config.operatorTenantId}`,
+        cardService: `${config.cardServiceUrl}/`,
         additionalProperties: {
           [addProp.fieldKey]: addProp.fieldValue
         }
@@ -168,7 +168,7 @@ describe('Wallet Address Routes', (): void => {
         // Ensure the tenant id is returned for auth and resource server:
         authServer: `${config.authServerGrantUrl}/${walletAddress.tenantId}`,
         resourceServer: `${config.openPaymentsUrl}/${walletAddress.tenantId}`,
-        cardService: `${config.cardServiceUrl}/${walletAddress.tenantId}`
+        cardService: `${config.cardServiceUrl}/`
       })
     })
   })

--- a/packages/backend/src/open_payments/wallet_address/routes.ts
+++ b/packages/backend/src/open_payments/wallet_address/routes.ts
@@ -64,7 +64,7 @@ export async function getWalletAddress(
     authServer: `${ensureTrailingSlash(deps.config.authServerGrantUrl)}${walletAddress.tenantId}`,
     resourceServer: `${ensureTrailingSlash(deps.config.openPaymentsUrl)}${walletAddress.tenantId}`,
     ...(deps.config.cardServiceUrl && {
-      cardService: `${ensureTrailingSlash(deps.config.cardServiceUrl)}${walletAddress.tenantId}`
+      cardService: `${ensureTrailingSlash(deps.config.cardServiceUrl)}`
     })
   })
 }


### PR DESCRIPTION
## Changes proposed in this pull request

- This PR removes tenant id from card service path in WA response since we are not processing it anywhere.

## Context

Closes RAF-1152

## Checklist

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
