### PR TITLE
feat(backend): add custom webhook URL for POS

### DIFF
--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -204,7 +204,8 @@ export const Config = {
     false
   ),
   cardServiceUrl: optional(envString, 'CARD_SERVICE_URL'),
-  posServiceUrl: optional(envString, 'POS_SERVICE_URL')
+  posServiceUrl: optional(envString, 'POS_SERVICE_URL'),
+  posWebhookServiceUrl: optional(envString, 'POS_WEBHOOK_SERVICE_URL')
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -896,7 +896,7 @@ describe('Incoming Payment Service', (): void => {
           'Creates webhook event for POS service if card payment',
           withConfigOverride(
             () => config,
-            { posServiceUrl: faker.internet.url() },
+            { posWebhookServiceUrl: faker.internet.url() },
             async (): Promise<void> => {
               await expect(
                 IncomingPaymentEvent.query(knex).where({

--- a/packages/backend/src/webhook/service.test.ts
+++ b/packages/backend/src/webhook/service.test.ts
@@ -699,7 +699,7 @@ describe('Webhook Service', (): void => {
       'adds webhooks for POS service if event was for a card payment',
       withConfigOverride(
         () => config,
-        { posServiceUrl: faker.internet.url() },
+        { posWebhookServiceUrl: faker.internet.url() },
         async (): Promise<void> => {
           const tenantId = crypto.randomUUID()
           expect(

--- a/packages/backend/src/webhook/service.ts
+++ b/packages/backend/src/webhook/service.ts
@@ -168,7 +168,11 @@ async function processNextWebhook(
 
       if (webhook.metadata?.sendToPosService) {
         await sendWebhook(deps, webhook, {
-          webhookUrl: `${deps.config.posServiceUrl}/webhook`
+          webhookUrl:
+            deps.config.posWebhookServiceUrl ??
+            (deps.config.posServiceUrl
+              ? `${deps.config.posServiceUrl}/webhook`
+              : undefined)
         })
       } else {
         const settings = await deps_.tenantSettingService.get({
@@ -316,7 +320,7 @@ export function finalizeWebhookRecipients(
 
   if (
     initiationReason === IncomingPaymentInitiationReason.Card &&
-    config.posServiceUrl
+    (config.posWebhookServiceUrl || config.posServiceUrl)
   ) {
     recipients = recipients.concat([
       {
@@ -328,6 +332,7 @@ export function finalizeWebhookRecipients(
     ])
   } else if (
     initiationReason === IncomingPaymentInitiationReason.Card &&
+    !config.posWebhookServiceUrl &&
     !config.posServiceUrl
   ) {
     logger?.warn('Could not create webhook recipient for point of sale service')

--- a/packages/backend/src/webhook/service.ts
+++ b/packages/backend/src/webhook/service.ts
@@ -168,11 +168,7 @@ async function processNextWebhook(
 
       if (webhook.metadata?.sendToPosService) {
         await sendWebhook(deps, webhook, {
-          webhookUrl:
-            deps.config.posWebhookServiceUrl ??
-            (deps.config.posServiceUrl
-              ? `${deps.config.posServiceUrl}/webhook`
-              : undefined)
+          webhookUrl: deps.config.posWebhookServiceUrl
         })
       } else {
         const settings = await deps_.tenantSettingService.get({
@@ -320,7 +316,7 @@ export function finalizeWebhookRecipients(
 
   if (
     initiationReason === IncomingPaymentInitiationReason.Card &&
-    (config.posWebhookServiceUrl || config.posServiceUrl)
+    config.posWebhookServiceUrl
   ) {
     recipients = recipients.concat([
       {
@@ -332,8 +328,7 @@ export function finalizeWebhookRecipients(
     ])
   } else if (
     initiationReason === IncomingPaymentInitiationReason.Card &&
-    !config.posWebhookServiceUrl &&
-    !config.posServiceUrl
+    !config.posWebhookServiceUrl
   ) {
     logger?.warn('Could not create webhook recipient for point of sale service')
   }


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds `POS_WEBHOOK_SERVICE_URL` env var and uses it when creating webhooks for incoming payment completions that were for card payments.

## Context

Closes RAF-1145

## Checklist

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
