### PR TITLE
docs: replace emojis for better dark mode visibility

### DIFF
--- a/packages/documentation/src/content/docs/resources/get-involved.mdx
+++ b/packages/documentation/src/content/docs/resources/get-involved.mdx
@@ -38,7 +38,7 @@ Before claiming an issue, ensure you have:
 - Understood the expected deliverables
 - Confirmed the issue hasn't been resolved in a recent pull request
 
-## 💻 Coding
+## 👨‍💻 Coding
 
 - <LinkOut href='https://github.com/interledger/rafiki'>Contribute</LinkOut> to Rafiki
   coding or testing.


### PR DESCRIPTION
**Description of changes**

On https://rafiki.dev/resources/get-involved/  the coding emoji 💻 was hard to see in dark mode, so I replaced it with 👨‍💻

**Required**

- [ ] Used LinkOut component on external links
- [ ] Reviewed Vale errors and made changes where appropriate
- [ ] Ran Prettier
- [ ] Previewed updates in Netlify
- [ ] Received SME and/or peer approval if updates are significant
- [ ] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [ ] Included code samples where appropriate
- [ ] Updated related READMEs
