### PR TITLE
feat(backend): additional webhook events for outgoing payments

### DIFF
--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/backend/migrations/20250917082624_add_request_id_to_outgoing_payment_card_details.js
+++ b/packages/backend/migrations/20250917082624_add_request_id_to_outgoing_payment_card_details.js
@@ -1,0 +1,37 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const hasColumn = await knex.schema.hasColumn(
+    'outgoingPaymentCardDetails',
+    'requestId'
+  )
+  if (!hasColumn) {
+    await knex.schema.alterTable(
+      'outgoingPaymentCardDetails',
+      function (table) {
+        table.string('requestId').nullable()
+      }
+    )
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  const hasColumn = await knex.schema.hasColumn(
+    'outgoingPaymentCardDetails',
+    'requestId'
+  )
+  if (hasColumn) {
+    await knex.schema.alterTable(
+      'outgoingPaymentCardDetails',
+      function (table) {
+        table.dropColumn('requestId')
+      }
+    )
+  }
+}

--- a/packages/backend/migrations/20250917082746_add_initiated_by_to_outgoing_payment.js
+++ b/packages/backend/migrations/20250917082746_add_initiated_by_to_outgoing_payment.js
@@ -1,0 +1,35 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable('outgoingPayments', function (table) {
+      table.enum('initiatedBy', ['CARD', 'OPEN_PAYMENTS', 'ADMIN'])
+    })
+    .then(() => {
+      return Promise.all([
+        knex.raw(
+          `UPDATE "outgoingPayments" SET "initiatedBy" = 'OPEN_PAYMENTS' WHERE "grantId" IS NOT NULL`
+        ),
+        knex.raw(
+          `UPDATE "outgoingPayments" SET "initiatedBy" = 'ADMIN' WHERE "grantId" IS NULL`
+        )
+      ])
+    })
+    .then(() => {
+      return knex.raw(
+        `ALTER TABLE "outgoingPayments" ALTER COLUMN "initiatedBy" SET NOT NULL`
+      )
+    })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('outgoingPayments', function (table) {
+    table.dropColumn('initiatedBy')
+  })
+}

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1060,6 +1060,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "cardPaymentFailureReason",
+            "description": "If card flow, optional machine-readable failure reason",
+            "type": {
+              "kind": "ENUM",
+              "name": "CardPaymentFailureReason",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": "Unique identifier of the outgoing payment to cancel.",
             "type": {
@@ -1116,6 +1128,18 @@
             "deprecationReason": null
           },
           {
+            "name": "requestId",
+            "description": "Unique card request identifier from POS/Card Service",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "signature",
             "description": "Signature",
             "type": {
@@ -1134,6 +1158,24 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CardPaymentFailureReason",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "invalid_signature",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -3409,21 +3451,37 @@
         "inputFields": [
           {
             "name": "in",
-            "description": "Array of strings to filter by.",
+            "description": "Array of strings to include.",
             "type": {
-              "kind": "NON_NULL",
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notIn",
+            "description": "Array of strings to exclude.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
               }
             },
@@ -5983,6 +6041,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requestId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/backend/src/graphql/resolvers/liquidity.test.ts
+++ b/packages/backend/src/graphql/resolvers/liquidity.test.ts
@@ -3474,28 +3474,116 @@ describe('Liquidity Resolvers', (): void => {
     })
 
     describe('depositOutgoingPaymentLiquidity', (): void => {
-      describe.each(Object.values(DepositEventType).map((type) => [type]))(
-        '%s',
-        (type): void => {
-          let eventId: string
+      describe(DepositEventType.PaymentCreated, (): void => {
+        let eventId: string
 
-          beforeEach(async (): Promise<void> => {
-            eventId = uuid()
-            await OutgoingPaymentEvent.query(knex).insertAndFetch({
-              id: eventId,
-              outgoingPaymentId: outgoingPayment.id,
-              type,
-              data: outgoingPayment.toData({
-                amountSent: BigInt(0),
-                balance: BigInt(0)
-              }),
-              tenantId: Config.operatorTenantId
-            })
+        beforeEach(async (): Promise<void> => {
+          eventId = uuid()
+          await OutgoingPaymentEvent.query(knex).insertAndFetch({
+            id: eventId,
+            outgoingPaymentId: outgoingPayment.id,
+            type: DepositEventType.PaymentCreated,
+            data: outgoingPayment.toData({
+              amountSent: BigInt(0),
+              balance: BigInt(0)
+            }),
+            tenantId: Config.operatorTenantId
           })
+        })
 
-          test('Can deposit account liquidity', async (): Promise<void> => {
-            const depositSpy = jest.spyOn(accountingService, 'createDeposit')
-            const response = await appContainer.apolloClient
+        test('Can deposit account liquidity', async (): Promise<void> => {
+          const depositSpy = jest.spyOn(accountingService, 'createDeposit')
+          const response = await appContainer.apolloClient
+            .mutate({
+              mutation: gql`
+                mutation DepositLiquidity(
+                  $input: DepositOutgoingPaymentLiquidityInput!
+                ) {
+                  depositOutgoingPaymentLiquidity(input: $input) {
+                    success
+                  }
+                }
+              `,
+              variables: {
+                input: {
+                  outgoingPaymentId: outgoingPayment.id,
+                  idempotencyKey: uuid()
+                }
+              }
+            })
+            .then((query): LiquidityMutationResponse => {
+              if (query.data) {
+                return query.data.depositOutgoingPaymentLiquidity
+              } else {
+                throw new Error('Data was empty')
+              }
+            })
+
+          expect(response.success).toBe(true)
+          assert.ok(outgoingPayment.debitAmount)
+          await expect(depositSpy).toHaveBeenCalledWith({
+            id: eventId,
+            account: expect.any(OutgoingPayment),
+            amount: outgoingPayment.debitAmount.value
+          })
+          await expect(
+            accountingService.getBalance(outgoingPayment.id)
+          ).resolves.toEqual(outgoingPayment.debitAmount.value)
+        })
+
+        test("Can't deposit for non-existent outgoing payment id", async (): Promise<void> => {
+          let error
+          try {
+            await appContainer.apolloClient
+              .mutate({
+                mutation: gql`
+                  mutation DepositLiquidity(
+                    $input: DepositOutgoingPaymentLiquidityInput!
+                  ) {
+                    depositOutgoingPaymentLiquidity(input: $input) {
+                      success
+                    }
+                  }
+                `,
+                variables: {
+                  input: {
+                    outgoingPaymentId: uuid(),
+                    idempotencyKey: uuid()
+                  }
+                }
+              })
+              .then((query): LiquidityMutationResponse => {
+                if (query.data) {
+                  return query.data.depositOutgoingPaymentLiquidity
+                } else {
+                  throw new Error('Data was empty')
+                }
+              })
+          } catch (err) {
+            error = err
+          }
+          expect(error).toBeInstanceOf(ApolloError)
+          expect((error as ApolloError).graphQLErrors).toContainEqual(
+            expect.objectContaining({
+              message: 'Invalid transfer id',
+              extensions: expect.objectContaining({
+                code: GraphQLErrorCode.BadUserInput
+              })
+            })
+          )
+        })
+
+        test('Returns an error for existing transfer', async (): Promise<void> => {
+          await expect(
+            accountingService.createDeposit({
+              id: eventId,
+              account: incomingPayment,
+              amount: BigInt(100)
+            })
+          ).resolves.toBeUndefined()
+          let error
+          try {
+            await appContainer.apolloClient
               .mutate({
                 mutation: gql`
                   mutation DepositLiquidity(
@@ -3520,111 +3608,20 @@ describe('Liquidity Resolvers', (): void => {
                   throw new Error('Data was empty')
                 }
               })
-
-            expect(response.success).toBe(true)
-            assert.ok(outgoingPayment.debitAmount)
-            await expect(depositSpy).toHaveBeenCalledWith({
-              id: eventId,
-              account: expect.any(OutgoingPayment),
-              amount: outgoingPayment.debitAmount.value
+          } catch (err) {
+            error = err
+          }
+          expect(error).toBeInstanceOf(ApolloError)
+          expect((error as ApolloError).graphQLErrors).toContainEqual(
+            expect.objectContaining({
+              message: 'Transfer already exists',
+              extensions: expect.objectContaining({
+                code: GraphQLErrorCode.Duplicate
+              })
             })
-            await expect(
-              accountingService.getBalance(outgoingPayment.id)
-            ).resolves.toEqual(outgoingPayment.debitAmount.value)
-          })
-
-          test("Can't deposit for non-existent outgoing payment id", async (): Promise<void> => {
-            let error
-            try {
-              await appContainer.apolloClient
-                .mutate({
-                  mutation: gql`
-                    mutation DepositLiquidity(
-                      $input: DepositOutgoingPaymentLiquidityInput!
-                    ) {
-                      depositOutgoingPaymentLiquidity(input: $input) {
-                        success
-                      }
-                    }
-                  `,
-                  variables: {
-                    input: {
-                      outgoingPaymentId: uuid(),
-                      idempotencyKey: uuid()
-                    }
-                  }
-                })
-                .then((query): LiquidityMutationResponse => {
-                  if (query.data) {
-                    return query.data.depositOutgoingPaymentLiquidity
-                  } else {
-                    throw new Error('Data was empty')
-                  }
-                })
-            } catch (err) {
-              error = err
-            }
-            expect(error).toBeInstanceOf(ApolloError)
-            expect((error as ApolloError).graphQLErrors).toContainEqual(
-              expect.objectContaining({
-                message: 'Invalid transfer id',
-                extensions: expect.objectContaining({
-                  code: GraphQLErrorCode.BadUserInput
-                })
-              })
-            )
-          })
-
-          test('Returns an error for existing transfer', async (): Promise<void> => {
-            await expect(
-              accountingService.createDeposit({
-                id: eventId,
-                account: incomingPayment,
-                amount: BigInt(100)
-              })
-            ).resolves.toBeUndefined()
-            let error
-            try {
-              await appContainer.apolloClient
-                .mutate({
-                  mutation: gql`
-                    mutation DepositLiquidity(
-                      $input: DepositOutgoingPaymentLiquidityInput!
-                    ) {
-                      depositOutgoingPaymentLiquidity(input: $input) {
-                        success
-                      }
-                    }
-                  `,
-                  variables: {
-                    input: {
-                      outgoingPaymentId: outgoingPayment.id,
-                      idempotencyKey: uuid()
-                    }
-                  }
-                })
-                .then((query): LiquidityMutationResponse => {
-                  if (query.data) {
-                    return query.data.depositOutgoingPaymentLiquidity
-                  } else {
-                    throw new Error('Data was empty')
-                  }
-                })
-            } catch (err) {
-              error = err
-            }
-            expect(error).toBeInstanceOf(ApolloError)
-            expect((error as ApolloError).graphQLErrors).toContainEqual(
-              expect.objectContaining({
-                message: 'Transfer already exists',
-                extensions: expect.objectContaining({
-                  code: GraphQLErrorCode.Duplicate
-                })
-              })
-            )
-          })
-        }
-      )
+          )
+        })
+      })
     })
   })
 })

--- a/packages/backend/src/graphql/resolvers/webhooks.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.ts
@@ -8,6 +8,11 @@ import { getPageInfo } from '../../shared/pagination'
 import { WebhookEvent } from '../../webhook/event/model'
 import { Pagination, SortOrder } from '../../shared/baseModel'
 
+const DEFAULT_EXCLUDED_TYPES = [
+  'outgoing_payment.funded',
+  'outgoing_payment.cancelled'
+]
+
 export const getWebhookEvents: QueryResolvers<TenantedApolloContext>['webhookEvents'] =
   async (
     parent,
@@ -17,10 +22,13 @@ export const getWebhookEvents: QueryResolvers<TenantedApolloContext>['webhookEve
     const { filter, sortOrder, tenantId, ...pagination } = args
     const order = sortOrder === 'ASC' ? SortOrder.Asc : SortOrder.Desc
     const webhookService = await ctx.container.use('webhookService')
+    const filterOrDefaults = filter ?? {
+      type: { notIn: DEFAULT_EXCLUDED_TYPES }
+    }
     const getPageFn = (pagination_: Pagination, sortOrder_?: SortOrder) =>
       webhookService.getPage({
         pagination: pagination_,
-        filter,
+        filter: filterOrDefaults,
         sortOrder: sortOrder_,
         tenantId: ctx.isOperator ? tenantId : ctx.tenant.id
       })

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1065,6 +1065,7 @@ type OutgoingPaymentCardDetails implements Model {
   outgoingPaymentId: ID!
   signature: String!
   expiry: String!
+  requestId: String
   createdAt: String!
   updatedAt: String!
 }
@@ -1253,6 +1254,8 @@ input CardDetailsInput {
   signature: String!
   "Expire date"
   expiry: String!
+  "Unique card request identifier from POS/Card Service"
+  requestId: String
 }
 
 input CancelOutgoingPaymentInput {
@@ -1260,6 +1263,12 @@ input CancelOutgoingPaymentInput {
   id: ID!
   "Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments."
   reason: String
+  "If card flow, optional machine-readable failure reason"
+  cardPaymentFailureReason: CardPaymentFailureReason
+}
+
+enum CardPaymentFailureReason {
+  invalid_signature
 }
 
 input CreateOutgoingPaymentFromIncomingPaymentInput {
@@ -1508,8 +1517,10 @@ input WebhookEventFilter {
 }
 
 input FilterString {
-  "Array of strings to filter by."
-  in: [String!]!
+  "Array of strings to include."
+  in: [String!]
+  "Array of strings to exclude."
+  notIn: [String!]
 }
 
 interface Model {

--- a/packages/backend/src/open_payments/payment/outgoing/card/model.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/card/model.ts
@@ -10,6 +10,7 @@ export const outgoingPaymentCardDetailsRelation: OutgoingPaymentIdRelation =
 type OutgoingPaymentCardDetailsType = {
   expiry: string
   signature: string
+  requestId?: string
 } & {
   [key in OutgoingPaymentIdColumnName]: string
 }
@@ -25,4 +26,5 @@ export class OutgoingPaymentCardDetails
   public expiry!: string
   public readonly outgoingPaymentId!: string
   public signature!: string
+  public requestId?: string
 }

--- a/packages/backend/src/open_payments/payment/outgoing/service.test.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.test.ts
@@ -112,10 +112,10 @@ describe('OutgoingPaymentService', (): void => {
     [key in OutgoingPaymentState]: OutgoingPaymentEventType | undefined
   } = {
     [OutgoingPaymentState.Funding]: OutgoingPaymentEventType.PaymentCreated,
-    [OutgoingPaymentState.Sending]: undefined,
+    [OutgoingPaymentState.Sending]: OutgoingPaymentEventType.PaymentFunded,
     [OutgoingPaymentState.Failed]: OutgoingPaymentEventType.PaymentFailed,
     [OutgoingPaymentState.Completed]: OutgoingPaymentEventType.PaymentCompleted,
-    [OutgoingPaymentState.Cancelled]: undefined
+    [OutgoingPaymentState.Cancelled]: OutgoingPaymentEventType.PaymentCancelled
   }
 
   async function processNext(
@@ -131,7 +131,7 @@ describe('OutgoingPaymentService', (): void => {
     if (expectState) expect(payment.state).toBe(expectState)
     expect(payment.error).toEqual(expectedError || null)
     const type = webhookTypes[payment.state]
-    if (type) {
+    if (type && type !== OutgoingPaymentEventType.PaymentFunded) {
       await expect(
         OutgoingPaymentEvent.query(knex).where({
           type
@@ -1526,6 +1526,44 @@ describe('OutgoingPaymentService', (): void => {
       expect(isOutgoingPaymentError(payment)).toBeTruthy()
       expect(payment).toBe(OutgoingPaymentError.InvalidCardExpiry)
     })
+
+    test('persists requestId in cardDetails and includes in webhook data', async () => {
+      const paymentMethods: OpenPaymentsPaymentMethod[] = [
+        {
+          type: 'ilp',
+          ilpAddress: 'test.ilp' as IlpAddress,
+          sharedSecret: ''
+        }
+      ]
+      const debitAmount = {
+        value: BigInt(123),
+        assetCode: receiverWalletAddress.asset.code,
+        assetScale: receiverWalletAddress.asset.scale
+      }
+      const requestId = 'req-123'
+      const options: CreateFromCardPayment = {
+        walletAddressId: receiverWalletAddress.id,
+        debitAmount,
+        incomingPayment: incomingPayment.toOpenPaymentsTypeWithMethods(
+          config.openPaymentsUrl,
+          receiverWalletAddress,
+          paymentMethods
+        ).id,
+        tenantId,
+        cardDetails: {
+          expiry: '12/30',
+          signature: 'sig',
+          requestId
+        }
+      }
+      const created = await outgoingPaymentService.create(options)
+      assert.ok(!isOutgoingPaymentError(created))
+      const fetched = await OutgoingPayment.query(knex)
+        .findById(created.id)
+        .withGraphFetched('cardDetails')
+      assert.ok(fetched?.cardDetails)
+      expect(fetched.cardDetails.requestId).toBe(requestId)
+    })
   })
 
   describe('processNext', (): void => {
@@ -2058,6 +2096,110 @@ describe('OutgoingPaymentService', (): void => {
         OutgoingPaymentState.Failed,
         LifecycleError.QuoteExpired
       )
+    })
+  })
+
+  describe('webhook events for funded/cancelled (card vs non-card)', (): void => {
+    test('emits funded only for card flows', async (): Promise<void> => {
+      // Create card flow outgoing payment
+      const cardIncomingPayment = await createIncomingPayment(deps, {
+        walletAddressId: receiverWalletAddress.id,
+        tenantId: Config.operatorTenantId,
+        initiationReason: IncomingPaymentInitiationReason.Card
+      })
+      const cardOptions: CreateFromCardPayment = {
+        walletAddressId,
+        debitAmount,
+        incomingPayment: cardIncomingPayment.getUrl(config.openPaymentsUrl),
+        tenantId,
+        cardDetails: { expiry: '12/30', signature: 'sig', requestId: 'req-1' }
+      }
+      const cardOutgoingPayment =
+        await outgoingPaymentService.create(cardOptions)
+      assert.ok(!isOutgoingPaymentError(cardOutgoingPayment))
+      await outgoingPaymentService.fund({
+        id: cardOutgoingPayment.id,
+        tenantId,
+        amount: debitAmount.value,
+        transferId: uuid()
+      })
+      await expect(
+        OutgoingPaymentEvent.query(knex).where({
+          outgoingPaymentId: cardOutgoingPayment.id,
+          type: OutgoingPaymentEventType.PaymentFunded
+        })
+      ).resolves.not.toHaveLength(0)
+
+      // Create non-card outgoing payment
+      const nonCard = await createOutgoingPayment(deps, {
+        tenantId,
+        walletAddressId,
+        client,
+        receiver,
+        debitAmount,
+        validDestination: true,
+        method: 'ilp'
+      })
+      await outgoingPaymentService.fund({
+        id: nonCard.id,
+        tenantId,
+        amount: debitAmount.value,
+        transferId: uuid()
+      })
+      await expect(
+        OutgoingPaymentEvent.query(knex).where({
+          outgoingPaymentId: nonCard.id,
+          type: OutgoingPaymentEventType.PaymentFunded
+        })
+      ).resolves.toHaveLength(0)
+    })
+
+    test('emits cancelled only for card flows', async (): Promise<void> => {
+      // Create card flow outgoing payment and cancel
+      const cardIncomingPayment = await createIncomingPayment(deps, {
+        walletAddressId: receiverWalletAddress.id,
+        tenantId: Config.operatorTenantId,
+        initiationReason: IncomingPaymentInitiationReason.Card
+      })
+      const cardOptions: CreateFromCardPayment = {
+        walletAddressId,
+        debitAmount,
+        incomingPayment: cardIncomingPayment.getUrl(config.openPaymentsUrl),
+        tenantId,
+        cardDetails: { expiry: '12/30', signature: 'sig', requestId: 'req-2' }
+      }
+      const cardOutgoingPayment =
+        await outgoingPaymentService.create(cardOptions)
+      assert.ok(!isOutgoingPaymentError(cardOutgoingPayment))
+
+      await outgoingPaymentService.cancel({
+        id: cardOutgoingPayment.id,
+        tenantId
+      })
+      await expect(
+        OutgoingPaymentEvent.query(knex).where({
+          outgoingPaymentId: cardOutgoingPayment.id,
+          type: OutgoingPaymentEventType.PaymentCancelled
+        })
+      ).resolves.not.toHaveLength(0)
+
+      // Create non-card outgoing payment and cancel
+      const nonCard = await createOutgoingPayment(deps, {
+        tenantId,
+        walletAddressId,
+        client,
+        receiver,
+        debitAmount,
+        validDestination: true,
+        method: 'ilp'
+      })
+      await outgoingPaymentService.cancel({ id: nonCard.id, tenantId })
+      await expect(
+        OutgoingPaymentEvent.query(knex).where({
+          outgoingPaymentId: nonCard.id,
+          type: OutgoingPaymentEventType.PaymentCancelled
+        })
+      ).resolves.toHaveLength(0)
     })
   })
 

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -18,6 +18,7 @@ import {
   OutgoingPaymentState,
   OutgoingPaymentEventType
 } from './model'
+import { OutgoingPaymentInitiationReason } from './types'
 import { Grant } from '../../auth/middleware'
 import {
   AccountingService,
@@ -204,6 +205,7 @@ export interface CreateFromCardPayment extends CreateFromIncomingPayment {
   cardDetails: {
     expiry: string
     signature: string
+    requestId?: string
   }
 }
 
@@ -211,6 +213,7 @@ export type CancelOutgoingPaymentOptions = {
   id: string
   tenantId: string
   reason?: string
+  cardPaymentFailureReason?: 'invalid_signature'
 }
 
 export type CreateOutgoingPaymentOptions =
@@ -259,7 +262,10 @@ async function cancelOutgoingPayment(
         state: OutgoingPaymentState.Cancelled,
         metadata: {
           ...payment.metadata,
-          ...(options.reason ? { cancellationReason: options.reason } : {})
+          ...(options.reason ? { cancellationReason: options.reason } : {}),
+          ...(options.cardPaymentFailureReason
+            ? { cardPaymentFailureReason: options.cardPaymentFailureReason }
+            : {})
         }
       })
       .withGraphFetched('quote')
@@ -269,6 +275,15 @@ async function cancelOutgoingPayment(
     payment.walletAddress = await deps.walletAddressService.get(
       payment.walletAddressId
     )
+
+    if (payment.initiatedBy === OutgoingPaymentInitiationReason.Card) {
+      await sendWebhookEvent(
+        deps,
+        payment,
+        OutgoingPaymentEventType.PaymentCancelled,
+        trx
+      )
+    }
 
     return addSentAmount(deps, payment)
   })
@@ -388,6 +403,15 @@ async function createOutgoingPayment(
             }
           )
 
+          let initiatedBy: OutgoingPaymentInitiationReason
+          if (isCreateFromCardPayment(options)) {
+            initiatedBy = OutgoingPaymentInitiationReason.Card
+          } else if (options.grant) {
+            initiatedBy = OutgoingPaymentInitiationReason.OpenPayments
+          } else {
+            initiatedBy = OutgoingPaymentInitiationReason.Admin
+          }
+
           const payment = await OutgoingPayment.query(trx).insertAndFetch({
             id: quoteId,
             tenantId,
@@ -395,11 +419,12 @@ async function createOutgoingPayment(
             client: options.client,
             metadata: options.metadata,
             state: OutgoingPaymentState.Funding,
-            grantId
+            grantId,
+            initiatedBy
           })
 
           if (isCreateFromCardPayment(options)) {
-            const { expiry, signature } = options.cardDetails
+            const { expiry, signature, requestId } = options.cardDetails
 
             if (!isExpiryFormat(expiry))
               throw OutgoingPaymentError.InvalidCardExpiry
@@ -409,7 +434,8 @@ async function createOutgoingPayment(
             ).insertAndFetch({
               outgoingPaymentId: payment.id,
               expiry,
-              signature
+              signature,
+              requestId
             })
           }
 
@@ -738,6 +764,15 @@ async function fundPayment(
       return error
     }
     await payment.$query(trx).patch({ state: OutgoingPaymentState.Sending })
+
+    if (payment.initiatedBy === OutgoingPaymentInitiationReason.Card) {
+      await sendWebhookEvent(
+        deps,
+        payment,
+        OutgoingPaymentEventType.PaymentFunded,
+        trx
+      )
+    }
     return await addSentAmount(deps, payment)
   })
 }

--- a/packages/backend/src/open_payments/payment/outgoing/types.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/types.ts
@@ -1,0 +1,8 @@
+export enum OutgoingPaymentInitiationReason {
+  // The outgoing payment was initiated by a card payment.
+  Card = 'CARD',
+  // The outgoing payment was initiated through Open Payments.
+  OpenPayments = 'OPEN_PAYMENTS',
+  // The outgoing payment was initiated by the Admin API.
+  Admin = 'ADMIN'
+}

--- a/packages/backend/src/openapi/specs/webhooks.yaml
+++ b/packages/backend/src/openapi/specs/webhooks.yaml
@@ -74,6 +74,28 @@ webhooks:
       responses:
         '200':
           description: Data was received successfully
+  outgoingPaymentFunded:
+    post:
+      requestBody:
+        description: Notifies the card service that an outgoing payment has been funded by the ASE.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/outgoingPaymentEvent'
+      responses:
+        '200':
+          description: Data was received successfully
+  outgoingPaymentCancelled:
+    post:
+      requestBody:
+        description: Notifies the card service that an outgoing payment has been cancelled by the ASE.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/outgoingPaymentEvent'
+      responses:
+        '200':
+          description: Data was received successfully
   walletAddressNotFound:
     post:
       requestBody:
@@ -186,6 +208,8 @@ components:
             - outgoing_payment.created
             - outgoing_payment.completed
             - outgoing_payment.failed
+            - outgoing_payment.funded
+            - outgoing_payment.cancelled
         data:
           type: object
           required:

--- a/packages/backend/src/shared/filters.ts
+++ b/packages/backend/src/shared/filters.ts
@@ -1,3 +1,4 @@
 export interface FilterString {
   in?: string[]
+  notIn?: string[]
 }

--- a/packages/card-service/src/graphql/generated/graphql.ts
+++ b/packages/card-service/src/graphql/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/point-of-sale/src/graphql/generated/graphql.ts
+++ b/packages/point-of-sale/src/graphql/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -185,6 +185,8 @@ export type CancelIncomingPaymentResponse = {
 };
 
 export type CancelOutgoingPaymentInput = {
+  /** If card flow, optional machine-readable failure reason */
+  cardPaymentFailureReason?: InputMaybe<CardPaymentFailureReason>;
   /** Unique identifier of the outgoing payment to cancel. */
   id: Scalars['ID']['input'];
   /** Reason why this outgoing payment has been canceled. This value will be publicly visible in the metadata field if this outgoing payment is requested through Open Payments. */
@@ -194,9 +196,15 @@ export type CancelOutgoingPaymentInput = {
 export type CardDetailsInput = {
   /** Expire date */
   expiry: Scalars['String']['input'];
+  /** Unique card request identifier from POS/Card Service */
+  requestId?: InputMaybe<Scalars['String']['input']>;
   /** Signature */
   signature: Scalars['String']['input'];
 };
+
+export enum CardPaymentFailureReason {
+  InvalidSignature = 'invalid_signature'
+}
 
 export type CreateAssetInput = {
   /** Should be an ISO 4217 currency code whenever possible, e.g. `USD`. For more information, refer to [assets](https://rafiki.dev/overview/concepts/accounting/#assets). */
@@ -574,8 +582,10 @@ export type FeesConnection = {
 };
 
 export type FilterString = {
-  /** Array of strings to filter by. */
-  in: Array<Scalars['String']['input']>;
+  /** Array of strings to include. */
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** Array of strings to exclude. */
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type Http = {
@@ -1065,6 +1075,7 @@ export type OutgoingPaymentCardDetails = Model & {
   expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
+  requestId?: Maybe<Scalars['String']['output']>;
   signature: Scalars['String']['output'];
   updatedAt: Scalars['String']['output'];
 };
@@ -1960,6 +1971,7 @@ export type ResolversTypes = {
   CancelIncomingPaymentResponse: ResolverTypeWrapper<Partial<CancelIncomingPaymentResponse>>;
   CancelOutgoingPaymentInput: ResolverTypeWrapper<Partial<CancelOutgoingPaymentInput>>;
   CardDetailsInput: ResolverTypeWrapper<Partial<CardDetailsInput>>;
+  CardPaymentFailureReason: ResolverTypeWrapper<Partial<CardPaymentFailureReason>>;
   CreateAssetInput: ResolverTypeWrapper<Partial<CreateAssetInput>>;
   CreateAssetLiquidityWithdrawalInput: ResolverTypeWrapper<Partial<CreateAssetLiquidityWithdrawalInput>>;
   CreateIncomingPaymentInput: ResolverTypeWrapper<Partial<CreateIncomingPaymentInput>>;
@@ -2508,6 +2520,7 @@ export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType ex
   expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds new webhook events for outgoing payments.
In order not to have the POS service waiting until the incoming payment expires, we have to reply to the POS service request with the ASEs decision on the outgoing payment. This is done by having backend send new webhooks to the card service: `outgoing_payment.funded` and `outgoing_payment.cancelled`.

## Context

Closes RAF-1156

## Checklist

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
