### PR TITLE
fix: match payment bodies for pos and card service

### DIFF
--- a/bruno/collections/Rafiki/POS Service APIs/Initiate Payment.bru
+++ b/bruno/collections/Rafiki/POS Service APIs/Initiate Payment.bru
@@ -13,12 +13,10 @@ post {
 body:json {
   {
     "card": {
-      "walletAddress": "http://cloud-nine-wallet-backend/accounts/gfranklin",
-      "trasactionCounter": 1,
-      "expiry": "2025-09-13T13:00:00Z"
+      "walletAddress": "https://cloud-nine-wallet-backend/accounts/gfranklin",
+       "signature": "signature"
     },
-    "signature": "signature",
     "value": 1,
-    "merchantWalletAddress": "http://happy-life-bank-backend/accounts/pfry"
+    "merchantWalletAddress": "https://happy-life-bank-backend/accounts/pfry"
   }
 }

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1100,22 +1100,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "expiry",
-            "description": "Expire date",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "signature",
             "description": "Signature",
             "type": {
@@ -1697,7 +1681,7 @@
         "inputFields": [
           {
             "name": "cardDetails",
-            "description": "Used for the card service to provide the card expiry and signature",
+            "description": "Used for the card service to provide the card signature",
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "CardDetailsInput",
@@ -5925,22 +5909,6 @@
         "fields": [
           {
             "name": "createdAt",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "expiry",
             "description": null,
             "args": [],
             "type": {

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.test.ts
@@ -897,55 +897,7 @@ describe('OutgoingPayment Resolvers', (): void => {
       }
       expect(createSpy).toHaveBeenCalledWith({ ...input, tenantId })
     })
-    test('fails because of card expiry', async (): Promise<void> => {
-      const createSpy = jest
-        .spyOn(outgoingPaymentService, 'create')
-        .mockResolvedValueOnce(OutgoingPaymentError.InvalidCardExpiry)
 
-      const input = {
-        walletAddressId: uuid(),
-        quoteId: uuid(),
-        cardDetails: {
-          signature: 'test-signature',
-          expiry: 'NOT-A-VALID-EXPIRY'
-        }
-      }
-
-      expect.assertions(3)
-      try {
-        await appContainer.apolloClient
-          .query({
-            query: gql`
-              mutation CreateOutgoingPayment(
-                $input: CreateOutgoingPaymentInput!
-              ) {
-                createOutgoingPayment(input: $input) {
-                  payment {
-                    id
-                    state
-                  }
-                }
-              }
-            `,
-            variables: { input }
-          })
-          .then(
-            (query): OutgoingPaymentResponse =>
-              query.data?.createOutgoingPayment
-          )
-      } catch (error) {
-        expect(error).toBeInstanceOf(ApolloError)
-        expect((error as ApolloError).graphQLErrors).toContainEqual(
-          expect.objectContaining({
-            message: errorToMessage[OutgoingPaymentError.InvalidCardExpiry],
-            extensions: expect.objectContaining({
-              code: errorToCode[OutgoingPaymentError.InvalidCardExpiry]
-            })
-          })
-        )
-      }
-      expect(createSpy).toHaveBeenCalledWith({ ...input, tenantId })
-    })
     test('works with card details', async (): Promise<void> => {
       const { id: walletAddressId } = await createWalletAddress(deps, {
         tenantId,
@@ -964,8 +916,7 @@ describe('OutgoingPayment Resolvers', (): void => {
         walletAddressId: payment.walletAddressId,
         quoteId: payment.quote.id,
         cardDetails: {
-          signature: 'test-signature',
-          expiry: '12/24'
+          signature: 'test-signature'
         }
       }
 

--- a/packages/backend/src/graphql/resolvers/outgoing_payment.ts
+++ b/packages/backend/src/graphql/resolvers/outgoing_payment.ts
@@ -263,7 +263,6 @@ function cardDetailsToGraphql(
   return {
     id: cardDetails.id,
     outgoingPaymentId: cardDetails.outgoingPaymentId,
-    expiry: cardDetails.expiry,
     signature: cardDetails.signature,
     createdAt: new Date(+cardDetails.createdAt).toISOString(),
     updatedAt: new Date(+cardDetails.updatedAt).toISOString()

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1064,7 +1064,6 @@ type OutgoingPaymentCardDetails implements Model {
   id: ID!
   outgoingPaymentId: ID!
   signature: String!
-  expiry: String!
   createdAt: String!
   updatedAt: String!
 }
@@ -1244,15 +1243,13 @@ input CreateOutgoingPaymentInput {
   metadata: JSONObject
   "Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency)."
   idempotencyKey: String
-  "Used for the card service to provide the card expiry and signature"
+  "Used for the card service to provide the card signature"
   cardDetails: CardDetailsInput
 }
 
 input CardDetailsInput {
   "Signature"
   signature: String!
-  "Expire date"
-  expiry: String!
 }
 
 input CancelOutgoingPaymentInput {

--- a/packages/card-service/src/graphql/generated/graphql.ts
+++ b/packages/card-service/src/graphql/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/card-service/src/openapi/specs/card-server.yaml
+++ b/packages/card-service/src/openapi/specs/card-server.yaml
@@ -19,9 +19,7 @@ paths:
                 - merchantWalletAddress
                 - incomingPaymentUrl
                 - date
-                - signature
                 #                - terminalCert
-                - terminalId
               properties:
                 requestId:
                   type: string
@@ -30,19 +28,14 @@ paths:
                   type: object
                   required:
                     - walletAddress
-                    - transactionCounter
-                    - expiry
+                    - signature
                   properties:
                     walletAddress:
                       type: string
                       format: uri
-                    transactionCounter:
-                      type: integer
-                    expiry:
+                    signature:
                       type: string
-                      pattern: '^(0[1-9]|1[0-2])\/\d{2,4}$'
-                      example: '12/25'
-                      description: 'Card expiry in MM/YY or MM/YYYY format'
+
                 merchantWalletAddress:
                   type: string
                   format: uri
@@ -52,13 +45,11 @@ paths:
                 date:
                   type: string
                   format: date-time
-                signature:
-                  type: string
                 #                terminalCert:
                 #                  type: string
-                terminalId:
-                  type: string
-                  format: uuid
+                # terminalId:
+                #   type: string
+                #   format: uuid
       responses:
         '201':
           description: Payment request accepted

--- a/packages/card-service/src/payment/routes.test.ts
+++ b/packages/card-service/src/payment/routes.test.ts
@@ -32,14 +32,16 @@ describe('PaymentRoutes', () => {
     requestId: uuid,
     card: {
       walletAddress: uri,
-      transactionCounter: 1,
-      expiry: '12/25'
+      signature: 'sig'
     },
     merchantWalletAddress: uri,
     incomingPaymentUrl: uri,
     date: dateTime,
-    signature: 'sig',
-    terminalId: uuid
+    incomingAmount: {
+      assetCode: 'USD',
+      assetScale: 0,
+      value: '100'
+    }
   }
 
   const paymentEventFixture: PaymentEventBody = {

--- a/packages/card-service/src/payment/service.test.ts
+++ b/packages/card-service/src/payment/service.test.ts
@@ -109,10 +109,12 @@ describe('PaymentService', () => {
       expect(mutationSpy).toHaveBeenCalledWith({
         mutation: CREATE_OUTGOING_PAYMENT_FROM_INCOMING,
         variables: {
-          walletAddressId: expect.any(String),
-          incomingPayment: paymentFixture.incomingPaymentUrl,
-          cardDetails: {
-            signature: paymentFixture.card.signature
+          input: {
+            walletAddressId: expect.any(String),
+            incomingPayment: paymentFixture.incomingPaymentUrl,
+            cardDetails: {
+              signature: paymentFixture.card.signature
+            }
           }
         }
       })

--- a/packages/card-service/src/payment/service.test.ts
+++ b/packages/card-service/src/payment/service.test.ts
@@ -30,14 +30,11 @@ describe('PaymentService', () => {
     requestId: uuid,
     card: {
       walletAddress: uri,
-      transactionCounter: 1,
-      expiry: '12/25'
+      signature: 'sig'
     },
     merchantWalletAddress: uri,
     incomingPaymentUrl: uri,
     date: dateTime,
-    signature: 'sig',
-    terminalId: uuid,
     incomingAmount: {
       assetCode: 'USD',
       assetScale: 2,
@@ -56,10 +53,12 @@ describe('PaymentService', () => {
     querySpy = jest.spyOn(apolloClient, 'query')
     querySpy.mockResolvedValue({
       data: {
-        id: v4(),
-        asset: {
-          code: 'USD',
-          scale: 2
+        walletAddressByUrl: {
+          id: v4(),
+          asset: {
+            code: 'USD',
+            scale: 2
+          }
         }
       }
     })
@@ -113,8 +112,7 @@ describe('PaymentService', () => {
           walletAddressId: expect.any(String),
           incomingPayment: paymentFixture.incomingPaymentUrl,
           cardDetails: {
-            signature: paymentFixture.signature,
-            expiry: paymentFixture.card.expiry
+            signature: paymentFixture.card.signature
           }
         }
       })
@@ -122,7 +120,7 @@ describe('PaymentService', () => {
 
     test('throws if wallet address is invalid', async (): Promise<void> => {
       querySpy.mockClear()
-      querySpy.mockResolvedValue(undefined)
+      querySpy.mockResolvedValue({ data: { walletAddressByUrl: undefined } })
       await expect(service.create(paymentFixture)).rejects.toThrow(
         UnknownWalletAddressError
       )

--- a/packages/card-service/src/payment/service.ts
+++ b/packages/card-service/src/payment/service.ts
@@ -11,9 +11,6 @@ import {
 } from './errors'
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import {
-  CreateOutgoingPaymentFromIncoming,
-  CreateOutgoingPaymentFromIncomingPaymentInput,
-  GetWalletAddressByUrl,
   Mutation,
   MutationCreateOutgoingPaymentFromIncomingPaymentArgs,
   Query,

--- a/packages/card-service/src/payment/service.ts
+++ b/packages/card-service/src/payment/service.ts
@@ -11,9 +11,9 @@ import {
 } from './errors'
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client'
 import {
-  Mutation,
+  CreateOutgoingPaymentFromIncoming,
+  GetWalletAddressByUrl,
   MutationCreateOutgoingPaymentFromIncomingPaymentArgs,
-  Query,
   QueryWalletAddressByUrlArgs
 } from '../graphql/generated/graphql'
 import { CREATE_OUTGOING_PAYMENT_FROM_INCOMING } from '../graphql/mutations/createOutgoingPayment'
@@ -55,7 +55,7 @@ async function handleCreatePayment(
     const deferred = new Deferred<PaymentEventBody>()
     paymentWaitMap.set(requestId, deferred)
     const { data } = await deps.apolloClient.query<
-      Query,
+      GetWalletAddressByUrl,
       QueryWalletAddressByUrlArgs
     >({
       query: GET_WALLET_ADDRESS_BY_URL,
@@ -70,7 +70,7 @@ async function handleCreatePayment(
     const walletAddressId = data.walletAddressByUrl.id
 
     const outgoingPaymentFromIncomingPayment = await deps.apolloClient.mutate<
-      Mutation,
+      CreateOutgoingPaymentFromIncoming,
       MutationCreateOutgoingPaymentFromIncomingPaymentArgs
     >({
       mutation: CREATE_OUTGOING_PAYMENT_FROM_INCOMING,

--- a/packages/card-service/src/payment/types.ts
+++ b/packages/card-service/src/payment/types.ts
@@ -1,8 +1,7 @@
 import { AppContext } from '../app'
 export interface CardDetails {
   walletAddress: string
-  transactionCounter: number
-  expiry: string
+  signature: string
 }
 
 export interface PaymentBody {
@@ -11,9 +10,7 @@ export interface PaymentBody {
   merchantWalletAddress: string
   incomingPaymentUrl: string
   date: string
-  signature: string
   //  terminalCert: string
-  terminalId: string
   incomingAmount: {
     assetCode: string
     assetScale: number

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/point-of-sale/src/card-service-client/client.test.ts
+++ b/packages/point-of-sale/src/card-service-client/client.test.ts
@@ -37,11 +37,9 @@ describe('CardServiceClient', () => {
     incomingPaymentUrl: 'incomingPaymentUrl',
     merchantWalletAddress: '',
     date: new Date(),
-    signature: '',
     card: {
       walletAddress: faker.internet.url(),
-      trasactionCounter: 1,
-      expiry: new Date(new Date().getDate() + 1)
+      signature: ''
     },
     incomingAmount: {
       assetCode: 'USD',

--- a/packages/point-of-sale/src/card-service-client/client.ts
+++ b/packages/point-of-sale/src/card-service-client/client.ts
@@ -8,17 +8,15 @@ import { CardServiceClientError } from './errors'
 import { v4 as uuid } from 'uuid'
 import { BaseService } from '../shared/baseService'
 
-interface Card {
-  trasactionCounter: number
-  expiry: Date
+export interface Card {
+  signature: string
   walletAddress: string
 }
 
 export interface PaymentOptions {
   merchantWalletAddress: string
   incomingPaymentUrl: string
-  date: Date
-  signature: string
+  date: string
   card: Card
   incomingAmount: {
     assetCode: string

--- a/packages/point-of-sale/src/graphql/generated/graphql.ts
+++ b/packages/point-of-sale/src/graphql/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -192,8 +192,6 @@ export type CancelOutgoingPaymentInput = {
 };
 
 export type CardDetailsInput = {
-  /** Expire date */
-  expiry: Scalars['String']['input'];
   /** Signature */
   signature: Scalars['String']['input'];
 };
@@ -289,7 +287,7 @@ export type CreateOutgoingPaymentFromIncomingPaymentInput = {
 };
 
 export type CreateOutgoingPaymentInput = {
-  /** Used for the card service to provide the card expiry and signature */
+  /** Used for the card service to provide the card signature */
   cardDetails?: InputMaybe<CardDetailsInput>;
   /** Unique key to ensure duplicate or retried requests are processed only once. For more information, refer to [idempotency](https://rafiki.dev/apis/graphql/admin-api-overview/#idempotency). */
   idempotencyKey?: InputMaybe<Scalars['String']['input']>;
@@ -1062,7 +1060,6 @@ export type OutgoingPayment = BasePayment & Model & {
 export type OutgoingPaymentCardDetails = Model & {
   __typename?: 'OutgoingPaymentCardDetails';
   createdAt: Scalars['String']['output'];
-  expiry: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   outgoingPaymentId: Scalars['ID']['output'];
   signature: Scalars['String']['output'];
@@ -2505,7 +2502,6 @@ export type OutgoingPaymentResolvers<ContextType = any, ParentType extends Resol
 
 export type OutgoingPaymentCardDetailsResolvers<ContextType = any, ParentType extends ResolversParentTypes['OutgoingPaymentCardDetails'] = ResolversParentTypes['OutgoingPaymentCardDetails']> = {
   createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  expiry?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   outgoingPaymentId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   signature?: Resolver<ResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Matched `POST /payment` bodies for `point-of-sale` and `card-service` (removed unnecessary fields)
- Fixed some GraphQL calls
- Updated OpenAPI spec for 'card-service'

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes #3622 
Linear [#1153](https://linear.app/interledger/issue/RAF-1153/pos-servicecard-service-reconcile-request-bodies-for-post-payment)

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [x] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [x] OpenAPI specs updated (if necessary)
