### PR TITLE
fix(backend):  fix webhook resolver filter for OP funded and cancelled events

### DIFF
--- a/packages/backend/src/graphql/resolvers/webhooks.test.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.test.ts
@@ -168,7 +168,8 @@ describe('Webhook Events Query', (): void => {
         variables: {
           filter: {
             type: {
-              in: ['outgoing_payment.funded', 'outgoing_payment.cancelled']
+              in: ['outgoing_payment.funded', 'outgoing_payment.cancelled'],
+              notIn: []
             }
           }
         }

--- a/packages/backend/src/graphql/resolvers/webhooks.test.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.test.ts
@@ -150,7 +150,7 @@ describe('Webhook Events Query', (): void => {
     expect(typesEmpty).not.toContain('outgoing_payment.funded')
     expect(typesEmpty).not.toContain('outgoing_payment.cancelled')
 
-    // When explicitly requested via filter, they should appear
+    // When explicitly requested via filter, they still should not appear
     const withFilter = await appContainer.apolloClient
       .query({
         query: gql`
@@ -177,8 +177,8 @@ describe('Webhook Events Query', (): void => {
       .then((q): WebhookEventsConnection => q.data!.webhookEvents)
 
     const typesWith = withFilter.edges.map((e) => e.node.type)
-    expect(typesWith).toContain('outgoing_payment.funded')
-    expect(typesWith).toContain('outgoing_payment.cancelled')
+    expect(typesWith).toBeUndefined()
+    expect(typesWith).toBeUndefined()
   })
 
   describe('tenant boundaries', (): void => {

--- a/packages/backend/src/graphql/resolvers/webhooks.test.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.test.ts
@@ -177,8 +177,7 @@ describe('Webhook Events Query', (): void => {
       .then((q): WebhookEventsConnection => q.data!.webhookEvents)
 
     const typesWith = withFilter.edges.map((e) => e.node.type)
-    expect(typesWith).toBeUndefined()
-    expect(typesWith).toBeUndefined()
+    expect(typesWith).toStrictEqual([])
   })
 
   describe('tenant boundaries', (): void => {

--- a/packages/backend/src/graphql/resolvers/webhooks.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.ts
@@ -22,9 +22,14 @@ export const getWebhookEvents: QueryResolvers<TenantedApolloContext>['webhookEve
     const { filter, sortOrder, tenantId, ...pagination } = args
     const order = sortOrder === 'ASC' ? SortOrder.Asc : SortOrder.Desc
     const webhookService = await ctx.container.use('webhookService')
-    const filterOrDefaults = filter ?? {
-      type: { notIn: DEFAULT_EXCLUDED_TYPES }
-    }
+    const noFilter =
+      !filter ||
+      (filter?.type?.in &&
+        Array.isArray(filter.type.in) &&
+        filter.type.in.length === 0)
+    const filterOrDefaults = noFilter
+      ? { type: { notIn: DEFAULT_EXCLUDED_TYPES } }
+      : filter
     const getPageFn = (pagination_: Pagination, sortOrder_?: SortOrder) =>
       webhookService.getPage({
         pagination: pagination_,

--- a/packages/backend/src/graphql/resolvers/webhooks.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.ts
@@ -22,14 +22,11 @@ export const getWebhookEvents: QueryResolvers<TenantedApolloContext>['webhookEve
     const { filter, sortOrder, tenantId, ...pagination } = args
     const order = sortOrder === 'ASC' ? SortOrder.Asc : SortOrder.Desc
     const webhookService = await ctx.container.use('webhookService')
-    const noFilter =
-      !filter ||
-      (filter?.type?.in &&
-        Array.isArray(filter.type.in) &&
-        filter.type.in.length === 0)
-    const filterOrDefaults = noFilter
-      ? { type: { notIn: DEFAULT_EXCLUDED_TYPES } }
-      : filter
+    const type = { ...(filter?.type ?? {}) }
+    if (!('notIn' in type)) {
+      type.notIn = DEFAULT_EXCLUDED_TYPES
+    }
+    const filterOrDefaults = { ...filter, type }
     const getPageFn = (pagination_: Pagination, sortOrder_?: SortOrder) =>
       webhookService.getPage({
         pagination: pagination_,

--- a/packages/backend/src/graphql/resolvers/webhooks.ts
+++ b/packages/backend/src/graphql/resolvers/webhooks.ts
@@ -23,7 +23,11 @@ export const getWebhookEvents: QueryResolvers<TenantedApolloContext>['webhookEve
     const order = sortOrder === 'ASC' ? SortOrder.Asc : SortOrder.Desc
     const webhookService = await ctx.container.use('webhookService')
     const type = { ...(filter?.type ?? {}) }
-    if (!('notIn' in type)) {
+    if (
+      !('notIn' in type) ||
+      !Array.isArray(type.notIn) ||
+      type.notIn.length === 0
+    ) {
       type.notIn = DEFAULT_EXCLUDED_TYPES
     }
     const filterOrDefaults = { ...filter, type }


### PR DESCRIPTION
## Changes proposed in this pull request

- This PR fixes resolver filtering for `outgoing_payment.funded` and `outgoing_payment.cancelled` events

## Context

-

## Checklist

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
