### PR TITLE
feat(card-service): handle payment cancelled & funded events

### DIFF
--- a/localenv/cloud-nine-wallet/docker-compose.yml
+++ b/localenv/cloud-nine-wallet/docker-compose.yml
@@ -156,6 +156,7 @@ services:
       KEY_ID: 7097F83B-CB84-469E-96C6-2141C72E22C0
       OPERATOR_TENANT_ID: 438fa74a-fa7d-4317-9ced-dde32ece1787
       CARD_SERVICE_URL: 'http://cloud-nine-wallet-card-service:3007'
+      CARD_WEBHOOK_SERVICE_URL: 'http://cloud-nine-wallet-card-service:3007/payment-event'
     depends_on:
       - shared-database
       - shared-redis

--- a/localenv/mock-account-servicing-entity/generated/graphql.ts
+++ b/localenv/mock-account-servicing-entity/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 

--- a/packages/backend/src/graphql/generated/graphql.schema.json
+++ b/packages/backend/src/graphql/generated/graphql.schema.json
@@ -1174,6 +1174,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "invalid_request",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "invalid_signature",
             "description": null,
             "isDeprecated": false,

--- a/packages/backend/src/graphql/generated/graphql.ts
+++ b/packages/backend/src/graphql/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -1252,6 +1252,7 @@ input CancelOutgoingPaymentInput {
 
 enum CardPaymentFailureReason {
   invalid_signature
+  invalid_request
 }
 
 input CreateOutgoingPaymentFromIncomingPaymentInput {

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -264,7 +264,7 @@ async function cancelOutgoingPayment(
             : {})
         }
       })
-      .withGraphFetched('quote')
+      .withGraphFetched('[quote, cardDetails]')
     const asset = await deps.assetService.get(payment.quote.assetId)
     if (asset) payment.quote.asset = asset
 
@@ -719,7 +719,7 @@ async function fundPayment(
         tenantId
       })
       .forUpdate()
-      .withGraphFetched('quote')
+      .withGraphFetched('[quote, cardDetails]')
     if (!payment) return FundingError.UnknownPayment
 
     const asset = await deps.assetService.get(payment.quote.assetId)

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -213,7 +213,7 @@ export type CancelOutgoingPaymentOptions = {
   id: string
   tenantId: string
   reason?: string
-  cardPaymentFailureReason?: 'invalid_signature'
+  cardPaymentFailureReason?: 'invalid_signature' | 'invalid_request'
 }
 
 export type CreateOutgoingPaymentOptions =

--- a/packages/card-service/src/app.ts
+++ b/packages/card-service/src/app.ts
@@ -9,10 +9,12 @@ import cors from '@koa/cors'
 import { createValidatorMiddleware, HttpMethod } from '@interledger/openapi'
 import { PaymentContext } from './payment/types'
 import { PaymentEventContext } from './payment/types'
+import { PaymentRoutes } from './payment/routes'
 
 export interface AppServices {
   logger: Promise<Logger>
   config: Promise<IAppConfig>
+  paymentRoutes: Promise<PaymentRoutes>
 }
 
 export type AppContainer = IocContract<AppServices>

--- a/packages/card-service/src/graphql/generated/graphql.ts
+++ b/packages/card-service/src/graphql/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 

--- a/packages/card-service/src/openapi/specs/card-server.yaml
+++ b/packages/card-service/src/openapi/specs/card-server.yaml
@@ -54,17 +54,46 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - requestId
+                  - result
                 properties:
                   requestId:
                     type: string
+                    format: uuid
                   result:
-                    type: string
-                    enum:
-                      - approved
+                    type: object
+                    required:
+                      - code
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - approved
+                          - invalid_signature
+                      description:
+                        type: string
         '400':
           description: Invalid request
-        '401':
-          description: Card expired or invalid signature
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                properties:
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - description
+                    properties:
+                      code:
+                        type: string
+                        enum:
+                          - invalid_request
+                      description:
+                        type: string
         '500':
           description: Internal server error
   /payment-event:
@@ -78,31 +107,54 @@ paths:
             schema:
               type: object
               required:
-                - requestId
-                - outgoingPaymentId
-                - result
+                - id
+                - type
+                - data
               properties:
-                requestId:
+                id:
                   type: string
                   format: uuid
-                outgoingPaymentId:
+                type:
                   type: string
-                  format: uuid
-                result:
+                  enum:
+                    - outgoing_payment.funded
+                    - outgoing_payment.cancelled
+                data:
                   type: object
                   required:
-                    - code
+                    - id
+                    - cardDetails
                   properties:
-                    code:
+                    id:
                       type: string
-                      enum:
-                        - completed
-                        - card_expired
-                        - invalid_signature
+                      format: uuid
+                    cardDetails:
+                      type: object
+                      required:
+                        - requestId
+                      properties:
+                        requestId:
+                          type: string
+                          format: uuid
+                        initiatedAt:
+                          type: string
+                          format: date-time
+                        data:
+                          type: object
+                          additionalProperties: true
+                      additionalProperties: true
+                    metadata:
+                      type: object
+                      properties:
+                        cardPaymentFailureReason:
+                          type: string
+                          enum:
+                            - invalid_signature
+                            - invalid_request
+                      additionalProperties: true
+                  additionalProperties: true
       responses:
-        '202':
-          description: Payment event accepted and forwarded
+        '200':
+          description: Payment event accepted
         '400':
           description: Malformed request body
-        '404':
-          description: Request not found

--- a/packages/card-service/src/payment/routes.test.ts
+++ b/packages/card-service/src/payment/routes.test.ts
@@ -3,10 +3,13 @@ import { Deferred } from '../utils/deferred'
 import {
   PaymentEventBody,
   PaymentBody,
-  PaymentEventResultEnum,
+  PaymentEventType,
+  PaymentCancellationReason,
   PaymentContext,
   PaymentEventContext,
-  PaymentResultEnum
+  PaymentResult,
+  PaymentResultCode,
+  PaymentErrorCode
 } from './types'
 import { initIocContainer } from '../index'
 import { createTestApp, TestContainer } from '../tests/app'
@@ -41,15 +44,25 @@ describe('PaymentRoutes', () => {
   }
 
   const paymentEventFixture: PaymentEventBody = {
-    requestId,
-    outgoingPaymentId: crypto.randomUUID(),
-    result: { code: PaymentEventResultEnum.Completed }
+    id: crypto.randomUUID(),
+    type: PaymentEventType.Funded,
+    data: {
+      id: crypto.randomUUID(),
+      cardDetails: {
+        requestId
+      },
+      metadata: {}
+    }
   }
 
   beforeAll(async () => {
     deps = initIocContainer(Config)
     appContainer = await createTestApp(deps)
     routes = await deps.use('paymentRoutes')
+  })
+
+  afterEach(() => {
+    paymentWaitMap.clear()
   })
 
   afterAll(async () => {
@@ -68,12 +81,16 @@ describe('PaymentRoutes', () => {
       ctx.request.body = paymentFixture
 
       const paymentService = await deps.use('paymentService')
-      jest
-        .spyOn(paymentService, 'create')
-        .mockResolvedValue(paymentEventFixture)
+      jest.spyOn(paymentService, 'create').mockResolvedValue({
+        requestId,
+        result: { code: PaymentResultCode.Approved }
+      })
       await expect(routes.create(ctx)).resolves.toBeUndefined()
       expect(ctx.status).toBe(201)
-      expect(ctx.body).toEqual({ result: PaymentResultEnum.Approved })
+      expect(ctx.body).toEqual({
+        requestId,
+        result: { code: PaymentResultCode.Approved }
+      })
     })
 
     test('returns 504 on PaymentTimeoutError', async () => {
@@ -112,7 +129,7 @@ describe('PaymentRoutes', () => {
       })
     })
 
-    test('returns 401 and error on card expired', async () => {
+    test('returns 200 and invalid signature result when webhook reports invalid signature', async () => {
       const ctx: PaymentContext = createContext<PaymentContext>(
         { method, url },
         {},
@@ -122,17 +139,25 @@ describe('PaymentRoutes', () => {
 
       const paymentService = await deps.use('paymentService')
       jest.spyOn(paymentService, 'create').mockResolvedValue({
-        ...paymentEventFixture,
-        result: { code: PaymentEventResultEnum.CardExpired }
+        requestId,
+        result: {
+          code: PaymentResultCode.InvalidSignature,
+          description: 'Invalid card signature'
+        }
       })
 
-      await expect(routes.create(ctx)).rejects.toMatchObject({
-        status: 401,
-        message: 'Card expired'
+      await expect(routes.create(ctx)).resolves.toBeUndefined()
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toEqual({
+        requestId,
+        result: {
+          code: PaymentResultCode.InvalidSignature,
+          description: 'Invalid card signature'
+        }
       })
     })
 
-    test('returns 401 and error on invalid signature', async () => {
+    test('returns 400 with invalid_request error when service reports request issue', async () => {
       const ctx: PaymentContext = createContext<PaymentContext>(
         { method, url },
         {},
@@ -142,13 +167,19 @@ describe('PaymentRoutes', () => {
 
       const paymentService = await deps.use('paymentService')
       jest.spyOn(paymentService, 'create').mockResolvedValue({
-        ...paymentEventFixture,
-        result: { code: PaymentEventResultEnum.InvalidSignature }
+        error: {
+          code: PaymentErrorCode.InvalidRequest,
+          description: 'Unsupported payment event type'
+        }
       })
 
-      await expect(routes.create(ctx)).rejects.toMatchObject({
-        status: 401,
-        message: 'Invalid signature'
+      await expect(routes.create(ctx)).resolves.toBeUndefined()
+      expect(ctx.status).toBe(400)
+      expect(ctx.body).toEqual({
+        error: {
+          code: PaymentErrorCode.InvalidRequest,
+          description: 'Unsupported payment event type'
+        }
       })
     })
   })
@@ -156,7 +187,7 @@ describe('PaymentRoutes', () => {
   describe('POST /payment-event', () => {
     const url = '/payment-event'
 
-    test('returns 202 on paymentEvent with known requestId', async () => {
+    test('returns 200 on paymentEvent with known requestId', async () => {
       const ctx: PaymentEventContext = createContext<PaymentEventContext>(
         { method, url },
         {},
@@ -164,15 +195,18 @@ describe('PaymentRoutes', () => {
       )
       ctx.request.body = paymentEventFixture
 
-      const deferred = new Deferred<PaymentEventBody>()
+      const deferred = new Deferred<PaymentResult>()
       const resolveSpy = jest.spyOn(deferred, 'resolve')
       paymentWaitMap.set(requestId, deferred)
       await expect(routes.handlePaymentEvent(ctx)).resolves.toBeUndefined()
-      expect(resolveSpy).toHaveBeenCalledWith(ctx.request.body)
-      expect(ctx.status).toBe(202)
+      expect(resolveSpy).toHaveBeenCalledWith({
+        requestId,
+        result: { code: PaymentResultCode.Approved }
+      })
+      expect(ctx.status).toBe(200)
     })
 
-    test('returns 404 on paymentEvent with unknown requestId', async () => {
+    test('resolves invalid signature result on cancelled payment with invalid signature reason', async () => {
       const ctx: PaymentEventContext = createContext<PaymentEventContext>(
         { method, url },
         {},
@@ -180,13 +214,81 @@ describe('PaymentRoutes', () => {
       )
       ctx.request.body = {
         ...paymentEventFixture,
-        requestId: 'bar-uuid-0000-0000-0000-000000000000'
+        type: PaymentEventType.Cancelled,
+        data: {
+          ...paymentEventFixture.data,
+          metadata: {
+            ...paymentEventFixture.data.metadata,
+            cardPaymentFailureReason: PaymentCancellationReason.InvalidSignature
+          }
+        }
       }
 
-      await expect(routes.handlePaymentEvent(ctx)).rejects.toMatchObject({
-        status: 404,
-        message: 'No ongoing payment for this requestId'
+      const deferred = new Deferred<PaymentResult>()
+      const resolveSpy = jest.spyOn(deferred, 'resolve')
+      paymentWaitMap.set(requestId, deferred)
+      await expect(routes.handlePaymentEvent(ctx)).resolves.toBeUndefined()
+      expect(resolveSpy).toHaveBeenCalledWith({
+        requestId,
+        result: {
+          code: PaymentResultCode.InvalidSignature,
+          description: 'Invalid card signature'
+        }
       })
+      expect(ctx.status).toBe(200)
+    })
+
+    test('resolves invalid_request error on cancelled payment with unsupported reason', async () => {
+      const ctx: PaymentEventContext = createContext<PaymentEventContext>(
+        { method, url },
+        {},
+        deps
+      )
+      ctx.request.body = {
+        ...paymentEventFixture,
+        type: PaymentEventType.Cancelled,
+        data: {
+          ...paymentEventFixture.data,
+          metadata: {
+            ...paymentEventFixture.data.metadata,
+            cardPaymentFailureReason: 'mismatched_hash'
+          }
+        }
+      }
+
+      const deferred = new Deferred<PaymentResult>()
+      const resolveSpy = jest.spyOn(deferred, 'resolve')
+      paymentWaitMap.set(requestId, deferred)
+      await expect(routes.handlePaymentEvent(ctx)).resolves.toBeUndefined()
+      expect(resolveSpy).toHaveBeenCalledWith({
+        error: {
+          code: PaymentErrorCode.InvalidRequest,
+          description: expect.stringContaining('mismatched_hash')
+        }
+      })
+      expect(ctx.status).toBe(200)
+    })
+
+    test('returns 200 without resolving when requestId is unknown', async () => {
+      const ctx: PaymentEventContext = createContext<PaymentEventContext>(
+        { method, url },
+        {},
+        deps
+      )
+      ctx.request.body = {
+        ...paymentEventFixture,
+        data: {
+          ...paymentEventFixture.data,
+          cardDetails: {
+            ...paymentEventFixture.data.cardDetails,
+            requestId
+          }
+        }
+      }
+
+      await expect(routes.handlePaymentEvent(ctx)).resolves.toBeUndefined()
+      expect(ctx.status).toBe(200)
+      expect(paymentWaitMap.size).toBe(0)
     })
   })
 })

--- a/packages/card-service/src/payment/routes.ts
+++ b/packages/card-service/src/payment/routes.ts
@@ -6,7 +6,6 @@ import {
   PaymentCancellationReason,
   PaymentErrorCode,
   PaymentErrorResult,
-  PaymentResolution,
   PaymentResult,
   PaymentResultCode
 } from './types'
@@ -106,7 +105,7 @@ function toPaymentResolution(
   deps: ServiceDependencies,
   body: PaymentEventBody,
   identifiers: PaymentIdentifiers
-): PaymentResolution {
+): PaymentResult {
   const { requestId, outgoingPaymentId } = identifiers
   const cardPaymentFailureReason = body.data.metadata?.cardPaymentFailureReason
 

--- a/packages/card-service/src/payment/service.test.ts
+++ b/packages/card-service/src/payment/service.test.ts
@@ -1,6 +1,6 @@
 import { createPaymentService } from './service'
 import { paymentWaitMap } from './wait-map'
-import { PaymentEventResultEnum, PaymentBody } from './types'
+import { PaymentBody, PaymentResultCode } from './types'
 import { initIocContainer } from '../index'
 import { createTestApp, TestContainer } from '../tests/app'
 import { Config } from '../config/app'
@@ -81,21 +81,19 @@ describe('PaymentService', () => {
   })
 
   describe('create', () => {
-    test('resolves when paymentEvent is received', async () => {
+    test('resolves when payment event result is received', async () => {
       setTimeout(() => {
         const d = paymentWaitMap.get(requestId)
         d?.resolve({
-          requestId: requestId,
-          outgoingPaymentId: requestId,
-          result: { code: PaymentEventResultEnum.Completed }
+          requestId,
+          result: { code: PaymentResultCode.Approved }
         })
       }, 10)
 
       const result = await service.create(paymentFixture)
       expect(result).toEqual({
-        requestId: requestId,
-        outgoingPaymentId: requestId,
-        result: { code: PaymentEventResultEnum.Completed }
+        requestId,
+        result: { code: PaymentResultCode.Approved }
       })
 
       expect(querySpy).toHaveBeenCalledWith({

--- a/packages/card-service/src/payment/service.ts
+++ b/packages/card-service/src/payment/service.ts
@@ -1,4 +1,4 @@
-import { PaymentBody, PaymentEventBody } from './types'
+import { PaymentBody, PaymentResult } from './types'
 import { IAppConfig } from '../config/app'
 import { Deferred } from '../utils/deferred'
 import { paymentWaitMap } from './wait-map'
@@ -25,7 +25,7 @@ interface ServiceDependencies extends BaseService {
 }
 
 export interface PaymentService {
-  create(payment: PaymentBody): Promise<PaymentEventBody>
+  create(payment: PaymentBody): Promise<PaymentResult>
 }
 
 export async function createPaymentService({
@@ -49,10 +49,10 @@ export async function createPaymentService({
 async function handleCreatePayment(
   deps: ServiceDependencies,
   payment: PaymentBody
-): Promise<PaymentEventBody> {
+): Promise<PaymentResult> {
   const { requestId } = payment
   try {
-    const deferred = new Deferred<PaymentEventBody>()
+    const deferred = new Deferred<PaymentResult>()
     paymentWaitMap.set(requestId, deferred)
     const { data } = await deps.apolloClient.query<
       GetWalletAddressByUrl,
@@ -114,8 +114,8 @@ async function handleCreatePayment(
 
 async function waitForPaymentEvent(
   config: IAppConfig,
-  deferred: Deferred<PaymentEventBody>
-): Promise<PaymentEventBody | void> {
+  deferred: Deferred<PaymentResult>
+): Promise<PaymentResult> {
   return Promise.race([
     deferred.promise,
     new Promise<void>((_, reject) =>

--- a/packages/card-service/src/payment/service.ts
+++ b/packages/card-service/src/payment/service.ts
@@ -118,7 +118,7 @@ async function waitForPaymentEvent(
 ): Promise<PaymentResult> {
   return Promise.race([
     deferred.promise,
-    new Promise<void>((_, reject) =>
+    new Promise<never>((_, reject) =>
       setTimeout(
         () => reject(new PaymentTimeoutError()),
         config.cardPaymentTimeoutMS

--- a/packages/card-service/src/payment/types.ts
+++ b/packages/card-service/src/payment/types.ts
@@ -82,7 +82,6 @@ export interface PaymentErrorResult {
   }
 }
 
-
 export interface PaymentEventParams {}
 
 export type PaymentEventContext = Omit<AppContext, 'request'> & {

--- a/packages/card-service/src/payment/types.ts
+++ b/packages/card-service/src/payment/types.ts
@@ -82,7 +82,6 @@ export interface PaymentErrorResult {
   }
 }
 
-export type PaymentResolution = PaymentSuccessResult | PaymentErrorResult
 
 export interface PaymentEventParams {}
 
@@ -93,4 +92,4 @@ export type PaymentEventContext = Omit<AppContext, 'request'> & {
   }
 }
 
-export type PaymentResult = PaymentResolution | void
+export type PaymentResult = PaymentSuccessResult | PaymentErrorResult

--- a/packages/card-service/src/payment/types.ts
+++ b/packages/card-service/src/payment/types.ts
@@ -26,23 +26,63 @@ export type PaymentContext = Omit<AppContext, 'request'> & {
   }
 }
 
-export enum PaymentResultEnum {
-  Approved = 'approved'
-}
-
-export enum PaymentEventResultEnum {
-  Completed = 'completed',
-  CardExpired = 'card_expired',
+export enum PaymentResultCode {
+  Approved = 'approved',
   InvalidSignature = 'invalid_signature'
 }
 
+export enum PaymentErrorCode {
+  InvalidRequest = 'invalid_request'
+}
+
+export enum PaymentEventType {
+  Funded = 'outgoing_payment.funded',
+  Cancelled = 'outgoing_payment.cancelled'
+}
+
+export enum PaymentCancellationReason {
+  InvalidSignature = 'invalid_signature',
+  InvalidRequest = 'invalid_request'
+}
+
+export interface PaymentEventCardDetails {
+  requestId?: string
+  initiatedAt?: string
+  data?: Record<string, unknown>
+}
+
+export interface PaymentEventMetadata extends Record<string, unknown> {
+  cardPaymentFailureReason?: PaymentCancellationReason | string
+}
+
+export interface PaymentEventData {
+  id: string
+  cardDetails?: PaymentEventCardDetails
+  metadata?: PaymentEventMetadata
+}
+
 export interface PaymentEventBody {
+  id: string
+  type: PaymentEventType | string
+  data: PaymentEventData
+}
+
+export interface PaymentSuccessResult {
   requestId: string
-  outgoingPaymentId: string
   result: {
-    code: PaymentEventResultEnum
+    code: PaymentResultCode
+    description?: string
   }
 }
+
+export interface PaymentErrorResult {
+  error: {
+    code: PaymentErrorCode
+    description: string
+  }
+}
+
+export type PaymentResolution = PaymentSuccessResult | PaymentErrorResult
 
 export interface PaymentEventParams {}
 
@@ -53,4 +93,4 @@ export type PaymentEventContext = Omit<AppContext, 'request'> & {
   }
 }
 
-export type PaymentResult = PaymentEventBody | void
+export type PaymentResult = PaymentResolution | void

--- a/packages/card-service/src/payment/wait-map.test.ts
+++ b/packages/card-service/src/payment/wait-map.test.ts
@@ -1,10 +1,10 @@
 import { paymentWaitMap } from './wait-map'
 import { Deferred } from '../utils/deferred'
-import { PaymentEventBody } from './types'
+import { PaymentResult } from './types'
 
 describe('paymentWaitMap', () => {
   test('stores and retrieves Deferreds by key', () => {
-    const d = new Deferred<PaymentEventBody>()
+    const d = new Deferred<PaymentResult>()
     paymentWaitMap.set('abc', d)
     expect(paymentWaitMap.get('abc')).toBe(d)
     paymentWaitMap.delete('abc')

--- a/packages/card-service/src/payment/wait-map.ts
+++ b/packages/card-service/src/payment/wait-map.ts
@@ -1,4 +1,4 @@
 import { Deferred } from '../utils/deferred'
-import { PaymentEventBody } from './types'
+import { PaymentResult } from './types'
 
-export const paymentWaitMap = new Map<string, Deferred<PaymentEventBody>>()
+export const paymentWaitMap = new Map<string, Deferred<PaymentResult>>()

--- a/packages/frontend/app/generated/graphql.ts
+++ b/packages/frontend/app/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 

--- a/packages/mock-account-service-lib/src/generated/graphql.ts
+++ b/packages/mock-account-service-lib/src/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 

--- a/packages/point-of-sale/src/card-service-client/client.ts
+++ b/packages/point-of-sale/src/card-service-client/client.ts
@@ -37,13 +37,14 @@ interface ServiceDependencies extends BaseService {
 
 export enum Result {
   APPROVED = 'approved',
-  CARD_EXPIRED = 'card_expired',
   INVALID_SIGNATURE = 'invalid_signature'
 }
 
 export type PaymentResponse = {
   requestId: string
-  result: Result
+  result: {
+    code: Result
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
@@ -97,14 +98,14 @@ async function sendPayment(
         HttpStatusCode.NotFound
       )
     }
-    return payment.result
+    return payment.result.code
   } catch (error) {
     deps.logger.debug(error)
     if (error instanceof CardServiceClientError) throw error
 
     if (error instanceof AxiosError) {
       if (isPaymentResponse(error.response?.data)) {
-        return error.response.data.result
+        return error.response.data.result.code
       }
       throw new CardServiceClientError(
         error.response?.data ?? 'Unknown Axios error',

--- a/packages/point-of-sale/src/graphql/generated/graphql.ts
+++ b/packages/point-of-sale/src/graphql/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 

--- a/packages/point-of-sale/src/payments/routes.test.ts
+++ b/packages/point-of-sale/src/payments/routes.test.ts
@@ -69,18 +69,6 @@ describe('Payment Routes', () => {
       expect(webhookWaitMap.get('incoming-payment-url')).toBeUndefined()
     })
 
-    test('returns 401 with result card_expired or invalid_signature', async () => {
-      const ctx = createPaymentContext()
-      mockPaymentService()
-      jest
-        .spyOn(cardServiceClient, 'sendPayment')
-        .mockResolvedValueOnce(Result.CARD_EXPIRED)
-
-      await paymentRoutes.payment(ctx)
-      expect(ctx.response.body).toBe(Result.CARD_EXPIRED)
-      expect(ctx.status).toBe(401)
-    })
-
     test('returns cardService error code when thrown', async () => {
       const ctx = createPaymentContext()
       mockPaymentService()

--- a/test/test-lib/src/generated/graphql.ts
+++ b/test/test-lib/src/generated/graphql.ts
@@ -200,6 +200,7 @@ export type CardDetailsInput = {
 };
 
 export enum CardPaymentFailureReason {
+  InvalidRequest = 'invalid_request',
   InvalidSignature = 'invalid_signature'
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request
This PR handles the `outgoing_payment.funded` and `outgoing_payment.cancelled` events that we are sending from the backend to the card service ([RAF-1156](https://linear.app/interledger/issue/RAF-1156/backend-add-additional-webhook-events-for-outgoing-payments))

## Context

Closes [RAF-1168](https://linear.app/interledger/issue/RAF-1168/card-service-handle-payment-cancelled-and-funded-events)

## Checklist

- [x] Related issues linked using `fixes #number`
- [x] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
