### PR TITLE
fix: updates to make e2e payment flow work

### DIFF
--- a/localenv/cloud-nine-wallet/docker-compose.yml
+++ b/localenv/cloud-nine-wallet/docker-compose.yml
@@ -156,6 +156,7 @@ services:
       KEY_ID: 7097F83B-CB84-469E-96C6-2141C72E22C0
       OPERATOR_TENANT_ID: 438fa74a-fa7d-4317-9ced-dde32ece1787
       CARD_SERVICE_URL: 'http://cloud-nine-wallet-card-service:3007'
+      CARD_WEBHOOK_SERVICE_URL: 'http://cloud-nine-wallet-card-service:3007/payment-event'
     depends_on:
       - shared-database
       - shared-redis

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -264,7 +264,7 @@ async function cancelOutgoingPayment(
             : {})
         }
       })
-      .withGraphFetched('[quote, cardDetails')
+      .withGraphFetched('[quote, cardDetails]')
     const asset = await deps.assetService.get(payment.quote.assetId)
     if (asset) payment.quote.asset = asset
 

--- a/packages/backend/src/open_payments/payment/outgoing/service.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/service.ts
@@ -264,7 +264,7 @@ async function cancelOutgoingPayment(
             : {})
         }
       })
-      .withGraphFetched('quote')
+      .withGraphFetched('[quote, cardDetails')
     const asset = await deps.assetService.get(payment.quote.assetId)
     if (asset) payment.quote.asset = asset
 
@@ -719,7 +719,7 @@ async function fundPayment(
         tenantId
       })
       .forUpdate()
-      .withGraphFetched('quote')
+      .withGraphFetched('[quote, cardDetails]')
     if (!payment) return FundingError.UnknownPayment
 
     const asset = await deps.assetService.get(payment.quote.assetId)

--- a/packages/card-service/src/app.ts
+++ b/packages/card-service/src/app.ts
@@ -9,10 +9,12 @@ import cors from '@koa/cors'
 import { createValidatorMiddleware, HttpMethod } from '@interledger/openapi'
 import { PaymentContext } from './payment/types'
 import { PaymentEventContext } from './payment/types'
+import { PaymentRoutes } from './payment/routes'
 
 export interface AppServices {
   logger: Promise<Logger>
   config: Promise<IAppConfig>
+  paymentRoutes: Promise<PaymentRoutes>
 }
 
 export type AppContainer = IocContract<AppServices>

--- a/packages/point-of-sale/src/card-service-client/client.ts
+++ b/packages/point-of-sale/src/card-service-client/client.ts
@@ -37,13 +37,14 @@ interface ServiceDependencies extends BaseService {
 
 export enum Result {
   APPROVED = 'approved',
-  CARD_EXPIRED = 'card_expired',
   INVALID_SIGNATURE = 'invalid_signature'
 }
 
 export type PaymentResponse = {
   requestId: string
-  result: Result
+  result: {
+    code: Result
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
@@ -97,14 +98,14 @@ async function sendPayment(
         HttpStatusCode.NotFound
       )
     }
-    return payment.result
+    return payment.result.code
   } catch (error) {
     deps.logger.debug(error)
     if (error instanceof CardServiceClientError) throw error
 
     if (error instanceof AxiosError) {
       if (isPaymentResponse(error.response?.data)) {
-        return error.response.data.result
+        return error.response.data.result.code
       }
       throw new CardServiceClientError(
         error.response?.data ?? 'Unknown Axios error',

--- a/packages/point-of-sale/src/payments/routes.test.ts
+++ b/packages/point-of-sale/src/payments/routes.test.ts
@@ -69,18 +69,6 @@ describe('Payment Routes', () => {
       expect(webhookWaitMap.get('incoming-payment-url')).toBeUndefined()
     })
 
-    test('returns 401 with result card_expired or invalid_signature', async () => {
-      const ctx = createPaymentContext()
-      mockPaymentService()
-      jest
-        .spyOn(cardServiceClient, 'sendPayment')
-        .mockResolvedValueOnce(Result.CARD_EXPIRED)
-
-      await paymentRoutes.payment(ctx)
-      expect(ctx.response.body).toBe(Result.CARD_EXPIRED)
-      expect(ctx.status).toBe(401)
-    })
-
     test('returns cardService error code when thrown', async () => {
       const ctx = createPaymentContext()
       mockPaymentService()


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Fetch cardDetails during outgoing payment funded and cancelled events, so it gets stored in the webhook data to send
- Add `CARD_WEBHOOK_SERVICE_URL` to cloud nine backend docker compose file
- Handle card service payment request data properly in POS service


## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Related to #3654 | RAF-1168

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
