### PR TITLE
chore(point-of-sale): update pos service response structure

### DIFF
--- a/packages/point-of-sale/src/payments/routes.ts
+++ b/packages/point-of-sale/src/payments/routes.ts
@@ -2,15 +2,13 @@ import { AppContext } from '../app'
 import { CardServiceClient, Result } from '../card-service-client/client'
 import { BaseService } from '../shared/baseService'
 import { PaymentService } from './service'
-import { CardServiceClientError } from '../card-service-client/errors'
 import { Deferred } from '../utils/deferred'
 import { webhookWaitMap } from '../webhook-handlers/request-map'
 import { WebhookBody } from '../webhook-handlers/routes'
 import { IAppConfig } from '../config/app'
 import {
   IncomingPaymentEventTimeoutError,
-  InvalidCardPaymentError,
-  PaymentRouteError
+  InvalidCardPaymentError
 } from './errors'
 
 interface ServiceDependencies extends BaseService {
@@ -101,12 +99,19 @@ async function payment(
       }
     )
 
+    if (result === Result.INVALID_SIGNATURE) {
+      webhookWaitMap.delete(incomingPayment.id)
+      ctx.body = { result: { code: Result.INVALID_SIGNATURE } }
+      ctx.status = 200
+      return
+    }
+
     if (result !== Result.APPROVED) throw new InvalidCardPaymentError(result)
     const event = await waitForIncomingPaymentEvent(deps.config, deferred)
     webhookWaitMap.delete(incomingPayment.id)
     if (!event || !event.data.completed)
       throw new IncomingPaymentEventTimeoutError(incomingPayment.id)
-    ctx.body = result
+    ctx.body = { result: { code: Result.APPROVED } }
     ctx.status = 200
   } catch (err) {
     deps.logger.debug(err)
@@ -130,15 +135,6 @@ async function waitForIncomingPaymentEvent(
   ])
 }
 
-function handlePaymentError(err: unknown) {
-  if (err instanceof CardServiceClientError) {
-    return { body: err.message, status: err.status }
-  }
-  if (err instanceof PaymentRouteError) {
-    return { body: err.message, status: err.status }
-  }
-  if (err instanceof Error) {
-    return { body: err.message, status: 400 }
-  }
-  return { body: err, status: 500 }
+function handlePaymentError(_err: unknown) {
+  return { body: { error: { code: 'invalid_request' } }, status: 400 }
 }

--- a/packages/point-of-sale/src/webhook-handlers/routes.test.ts
+++ b/packages/point-of-sale/src/webhook-handlers/routes.test.ts
@@ -51,7 +51,7 @@ describe('Webhook Handler Routes Tests', (): void => {
     )
 
     await webhookHandlerRoutes.handleWebhook(ctx)
-    expect(ctx.status).toEqual(202)
+    expect(ctx.status).toEqual(200)
     expect(deferredSpy).toHaveBeenCalledWith(ctx.request.body)
   })
 

--- a/packages/point-of-sale/src/webhook-handlers/routes.ts
+++ b/packages/point-of-sale/src/webhook-handlers/routes.ts
@@ -53,7 +53,7 @@ async function handleWebhook(
   const deferred = webhookWaitMap.get(id)
   if (deferred) {
     deferred.resolve(ctx.request.body)
-    ctx.status = 202
+    ctx.status = 200
   } else {
     ctx.throw(404, 'Not awaiting webhook for incoming payment id')
   }


### PR DESCRIPTION
## Changes proposed in this pull request

- This PR updates the response structure we return to the POS via `POST /payment`

## Context

Closes #RAF-1175

## Checklist

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
