### PR TITLE
feat: updated the weekly sync to monthly sync

### DIFF
--- a/.github/workflows/create_monthly_sync.yml
+++ b/.github/workflows/create_monthly_sync.yml
@@ -1,9 +1,9 @@
-name: Create Weekly Sync discussion
+name: Create Monthly Sync discussion
 
-# Every Wednesday at 12AM UTC
+# First Wednesday of every month at 12AM UTC
 on:
     schedule:
-        - cron: "0 0 * * 3"
+        - cron: "0 0 1-7 * 3"
 
 jobs:
     create-discussion:
@@ -24,7 +24,7 @@ jobs:
                       query GetRepositoryInformation ($name: String!, $owner: String!) {
                         repository(name: $name, owner: $owner) {
                           id
-                          discussionCategory(slug: "weekly-sync") {
+                          discussionCategory(slug: "monthly-sync") {
                             id
                           }
                         }
@@ -32,7 +32,7 @@ jobs:
 
             - name: Get current date
               id: current-date
-              run: echo "date=$(date -d "next Tue" +'%d %B %Y')" >> $GITHUB_OUTPUT
+              run: echo "date=$(date +'%B %Y')" >> $GITHUB_OUTPUT
 
             - name: Create repository discussion
               id: create-repository-discussion
@@ -41,8 +41,8 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
                   variables: |
-                      body: "<b>Please add agenda items below and give your weekly update in a comment. Thank you!</b><br/><h2>Agenda</h2>"
-                      title: "Weekly Sync - ${{ steps.current-date.outputs.date }}"
+                      body: "<b>Please add agenda items below and give your monthly update in a comment. Thank you!</b><br/><h2>Agenda</h2>"
+                      title: "Monthly Sync - ${{ steps.current-date.outputs.date }}"
                       repositoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.id }}
                       categoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.discussionCategory.id }}
                   query: |


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request

- Renamed file from `create_weekly_sync.yml` to `create_monthly_sync.yml`
- Changed cron expression from `"0 0 * * 3"` (every Wednesday) to `"0 0 1-7 * 3"` (first Wednesday of every month)
- Updated GraphQL query to use "monthly-sync" category instead of "weekly-sync"
- Changed discussion title from "Weekly Sync - [date]" to "Monthly Sync - [Month Year]"
- Simplified date logic from `date -d "next Tue" +'%d %B %Y'` to `date +'%B %Y'`
<!--
Provide a succinct description of what this pull request entails.
-->

## Context

Since the team has moved from weekly to monthly sync meetings. This PR updates the automated GitHub workflow that creates discussion threads for team syncs to reflect this change.
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using  fixes #3393 
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)


