### PR TITLE
feat(ci): add setup-qemu-action to node build job

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -413,10 +413,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: false
           platforms: ${{ matrix.platform.arch }}


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Explicitly add "Set up QEMU" step to the node-build job when building docker images
- Update `docker/build-push-action` 

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Given that we are encountering
```
#11 6.752 Importing packages to virtual store
#11 23.01 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```
during these build failures for arm platform, this may be a result of QEMU emulator not being set up/utilized properly. This PR adds the  "Set up QEMU" step as [recommended](https://docs.docker.com/build/ci/github-actions/multi-platform/) in the Docker Docs for multi-platform image builds.



Fixes RAF-1203 | #3730 

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [x] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
