### PR TITLE
docs: Remove reference to unused component

### DIFF
--- a/packages/documentation/src/content/docs/integration/playground/overview.mdx
+++ b/packages/documentation/src/content/docs/integration/playground/overview.mdx
@@ -6,7 +6,6 @@ import {
   Mermaid,
   MermaidWrapper,
   LinkOut,
-  Disclosure,
   LargeImg
 } from '@interledger/docs-design-system'
 


### PR DESCRIPTION
**Description of changes**

Removed reference to disclosure component from page

**Required**

- [ ] Used LinkOut component on external links
- [ ] Reviewed Vale errors and made changes where appropriate
- [X] Ran Prettier
- [ ] Previewed updates in Netlify
- [ ] Received SME and/or peer approval if updates are significant
- [ ] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [ ] Included code samples where appropriate
- [ ] Updated related READMEs
