### PR TITLE
fix(frontend): update Peer page maxPacketAmount description and link

### DIFF
--- a/packages/frontend/app/routes/peers.$peerId.tsx
+++ b/packages/frontend/app/routes/peers.$peerId.tsx
@@ -165,12 +165,13 @@ export default function ViewPeerPage() {
                     error={response?.errors.general.fieldErrors.maxPacketAmount}
                     description={
                       <>
-                        The maximum amount of value that can be sent in a single{' '}
+                        The maximum amount of value that you are willing to
+                        accept from the peer in a single{' '}
                         <a
                           className='default-link'
-                          href='https://interledger.org/developers/rfcs/stream-protocol/#35-packets-and-frames'
+                          href='https://rafiki.dev/admin/admin-user-guide/'
                         >
-                          Interledger STREAM Packet
+                          Interledger packet
                         </a>
                         .
                       </>

--- a/packages/frontend/app/routes/peers.create.tsx
+++ b/packages/frontend/app/routes/peers.create.tsx
@@ -136,13 +136,13 @@ export default function CreatePeerPage() {
                       error={response?.errors?.fieldErrors?.maxPacketAmount}
                       description={
                         <>
-                          The maximum amount of value that can be sent in a
-                          single{' '}
+                          The maximum amount of value that you are willing to
+                          accept from the peer in a single{' '}
                           <a
                             className='default-link'
-                            href='https://interledger.org/developers/rfcs/stream-protocol/#35-packets-and-frames'
+                            href='https://rafiki.dev/admin/admin-user-guide/'
                           >
-                            Interledger STREAM Packet
+                            Interledger packet
                           </a>
                           .
                         </>


### PR DESCRIPTION
## Summary

Updates the `maxPacketAmount` field description on the Create Peer and Edit Peer Admin UI pages per the TODOs in #3178:

- **Description updated:** Changed from "The maximum amount of value that can be sent in a single Interledger STREAM Packet" to "The maximum amount of value that you are willing to accept from the peer in a single Interledger packet"
- **Link updated:** Changed from `interledger.org/developers/rfcs/stream-protocol/` to `rafiki.dev/admin/admin-user-guide/` (more stable, less likely to move)

Both the Create Peer (`peers.create.tsx`) and Edit Peer (`peers.$peerId.tsx`) pages are updated.

## Changes

| File | Change |
|------|--------|
| `packages/frontend/app/routes/peers.create.tsx` | Update maxPacketAmount description and link |
| `packages/frontend/app/routes/peers.$peerId.tsx` | Update maxPacketAmount description and link |

Closes #3178