### PR TITLE
fix: fix Create Quote Bruno pre-request script

### DIFF
--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Quote.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Quote.bru
@@ -51,25 +51,34 @@ body:graphql:vars {
 
 script:pre-request {
   // Create an additional wallet address to represent the account that will be sending money
-  
+
   const fetch = require('node-fetch');
   const scripts = require('./scripts');
-  
+
   const randomInt = Math.floor(Math.random() * (1001));
-  
-  const initialRequest = bru.getEnvVar("initialWalletAddressRequest");
-  const postRequestBody = {
-      query: initialRequest.body.query,
-      variables: {
-        "input": {
-          "assetId": bru.getEnvVar("assetId"),
-          "url": "https://" + bru.getEnvVar("OpenPaymentsHost") + "/simon/" + randomInt,
-          "publicName": "Simon"
-      }
+
+  const createWalletAddressQuery = `
+    mutation CreateWalletAddress($input: CreateWalletAddressInput!) {
+      createWalletAddress(input: $input) {
+        walletAddress {
+          id
+        }
       }
     }
-  
-  const signature = scripts.generateBackendApiSignature(postRequestBody)
+  `;
+
+  const postRequestBody = {
+    query: createWalletAddressQuery,
+    variables: {
+      input: {
+        assetId: bru.getEnvVar("assetId"),
+        url: "https://" + bru.getEnvVar("OpenPaymentsHost") + "/simon/" + randomInt,
+        publicName: "Simon"
+      }
+    }
+  };
+
+  const signature = scripts.generateBackendApiSignature(postRequestBody);
   const postRequest = {
     method: 'post',
     headers: {
@@ -79,11 +88,12 @@ script:pre-request {
     },
     body: JSON.stringify(postRequestBody)
   };
-  
-  const response = await fetch(`${initialRequest.url}`, postRequest);
+
+  const graphqlUrl = bru.getEnvVar("RafikiGraphqlHost") + "/graphql";
+  const response = await fetch(graphqlUrl, postRequest);
   const body = await response.json();
   bru.setEnvVar("secondWalletAddressId", body.data.createWalletAddress.walletAddress.id);
-  
+
   scripts.addApiSignatureHeader();
 }
 

--- a/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
+++ b/bruno/collections/Rafiki/Rafiki Admin APIs/Create Wallet Address.bru
@@ -65,7 +65,6 @@ script:post-response {
   if (body?.data) {
     bru.setEnvVar("walletAddressId", body.data.createWalletAddress.walletAddress.id);
     bru.setEnvVar("walletAddressUrl", body.data.createWalletAddress.walletAddress.url);
-    bru.setEnvVar('initialWalletAddressRequest',req)
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the broken "Create Quote" pre-request script in the Bruno API collection.

**Root cause:** The `Create Wallet Address` post-response script stored the Bruno `req` object as an environment variable via `bru.setEnvVar('initialWalletAddressRequest', req)`. However, Bruno environment variables are serialized as strings, so when `Create Quote` retrieved it with `bru.getEnvVar("initialWalletAddressRequest")`, the object's properties (`.body.query`, `.url`) were `undefined`, causing the script to fail.

**Fix:**
- Inline the `CreateWalletAddress` GraphQL mutation directly in the Create Quote pre-request script
- Use `bru.getEnvVar("RafikiGraphqlHost")` for the URL instead of the stored request object
- Remove the non-functional `setEnvVar('initialWalletAddressRequest', req)` from Create Wallet Address

## Changes

| File | Change |
|------|--------|
| `bruno/.../Create Quote.bru` | Inline mutation query, use env var for URL |
| `bruno/.../Create Wallet Address.bru` | Remove non-functional `setEnvVar` for request object |

Closes #3573