### PR TITLE
fix: fix cron job for monthly sync discussion workflow

### DIFF
--- a/.github/workflows/create_monthly_sync.yml
+++ b/.github/workflows/create_monthly_sync.yml
@@ -1,9 +1,9 @@
 name: Create Monthly Sync discussion
 
-# Each Wednesday of every month at 12AM UTC
+# First Wednesday of every month at 12AM UTC
 on:
     schedule:
-      - cron: "0 0 * * 3"
+        - cron: "0 0 1-7 * 3"
 
 jobs:
     create-discussion:
@@ -11,56 +11,57 @@ jobs:
             discussions: write
         runs-on: ubuntu-22.04
         steps:
-          - name: Check if first Wednesday
-            id: check
-            run: |
-              DOM=$(date +%d)
-              if [ "$DOM" -gt 7 ]; then
-                echo "Not the first Wednesday of the month, skipping"
-                exit 0
-              fi
-          - name: Get repository information
-            id: get-repository-info
-            uses: octokit/graphql-action@v2.x
-            env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            with:
-                variables: |
-                    owner: ${{ github.repository_owner }}
-                    name: ${{ github.event.repository.name }}
-                query: |
-                    query GetRepositoryInformation ($name: String!, $owner: String!) {
-                      repository(name: $name, owner: $owner) {
-                        id
-                        discussionCategory(slug: "monthly-sync") {
+            - name: Check if first Wednesday
+              id: check
+              run: |
+                DOM=$(date +%d)
+                if [ "$DOM" -gt 7 ]; then
+                  echo "Not the first Wednesday of the month, skipping"
+                  exit 0
+                fi
+
+            - name: Get repository information
+              id: get-repository-info
+              uses: octokit/graphql-action@v2.x
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  variables: |
+                      owner: ${{ github.repository_owner }}
+                      name: ${{ github.event.repository.name }}
+                  query: |
+                      query GetRepositoryInformation ($name: String!, $owner: String!) {
+                        repository(name: $name, owner: $owner) {
                           id
+                          discussionCategory(slug: "monthly-sync") {
+                            id
+                          }
                         }
                       }
-                    }
 
-          - name: Get current date
-            id: current-date
-            run: echo "date=$(date +'%B %Y')" >> $GITHUB_OUTPUT
+            - name: Get current date
+              id: current-date
+              run: echo "date=$(date +'%B %Y')" >> $GITHUB_OUTPUT
 
-          - name: Create repository discussion
-            id: create-repository-discussion
-            uses: octokit/graphql-action@v2.x
-            env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            with:
-                variables: |
-                    body: "<b>Please add agenda items below and give your monthly update in a comment. Thank you!</b><br/><h2>Agenda</h2>"
-                    title: "Monthly Sync - ${{ steps.current-date.outputs.date }}"
-                    repositoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.id }}
-                    categoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.discussionCategory.id }}
-                query: |
-                    mutation CreateDiscussionMutation ($title: String!, $body: String!, $repositoryId: ID!, $categoryId: ID!) {
-                      createDiscussion(input: { title: $title, body: $body, repositoryId: $repositoryId, categoryId: $categoryId }) {
-                        discussion {
-                          title
+            - name: Create repository discussion
+              id: create-repository-discussion
+              uses: octokit/graphql-action@v2.x
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  variables: |
+                      body: "<b>Please add agenda items below and give your monthly update in a comment. Thank you!</b><br/><h2>Agenda</h2>"
+                      title: "Monthly Sync - ${{ steps.current-date.outputs.date }}"
+                      repositoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.id }}
+                      categoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.discussionCategory.id }}
+                  query: |
+                      mutation CreateDiscussionMutation ($title: String!, $body: String!, $repositoryId: ID!, $categoryId: ID!) {
+                        createDiscussion(input: { title: $title, body: $body, repositoryId: $repositoryId, categoryId: $categoryId }) {
+                          discussion {
+                            title
+                          }
                         }
                       }
-                    }
 
-          - name: Discussion successfully created
-            run: echo "Created discussion '${{ fromJSON(steps.create-repository-discussion.outputs.data).createDiscussion.discussion.title }}'"
+            - name: Discussion successfully created
+              run: echo "Created discussion '${{ fromJSON(steps.create-repository-discussion.outputs.data).createDiscussion.discussion.title }}'"

--- a/.github/workflows/create_monthly_sync.yml
+++ b/.github/workflows/create_monthly_sync.yml
@@ -1,9 +1,9 @@
 name: Create Monthly Sync discussion
 
-# First Wednesday of every month at 12AM UTC
+# Each Wednesday of every month at 12AM UTC
 on:
     schedule:
-        - cron: "0 0 1-7 * 3"
+      - cron: "0 0 * * 3"
 
 jobs:
     create-discussion:
@@ -11,48 +11,56 @@ jobs:
             discussions: write
         runs-on: ubuntu-22.04
         steps:
-            - name: Get repository information
-              id: get-repository-info
-              uses: octokit/graphql-action@v2.x
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  variables: |
-                      owner: ${{ github.repository_owner }}
-                      name: ${{ github.event.repository.name }}
-                  query: |
-                      query GetRepositoryInformation ($name: String!, $owner: String!) {
-                        repository(name: $name, owner: $owner) {
+          - name: Check if first Wednesday
+            id: check
+            run: |
+              DOM=$(date +%d)
+              if [ "$DOM" -gt 7 ]; then
+                echo "Not the first Wednesday of the month, skipping"
+                exit 0
+              fi
+          - name: Get repository information
+            id: get-repository-info
+            uses: octokit/graphql-action@v2.x
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            with:
+                variables: |
+                    owner: ${{ github.repository_owner }}
+                    name: ${{ github.event.repository.name }}
+                query: |
+                    query GetRepositoryInformation ($name: String!, $owner: String!) {
+                      repository(name: $name, owner: $owner) {
+                        id
+                        discussionCategory(slug: "monthly-sync") {
                           id
-                          discussionCategory(slug: "monthly-sync") {
-                            id
-                          }
                         }
                       }
+                    }
 
-            - name: Get current date
-              id: current-date
-              run: echo "date=$(date +'%B %Y')" >> $GITHUB_OUTPUT
+          - name: Get current date
+            id: current-date
+            run: echo "date=$(date +'%B %Y')" >> $GITHUB_OUTPUT
 
-            - name: Create repository discussion
-              id: create-repository-discussion
-              uses: octokit/graphql-action@v2.x
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  variables: |
-                      body: "<b>Please add agenda items below and give your monthly update in a comment. Thank you!</b><br/><h2>Agenda</h2>"
-                      title: "Monthly Sync - ${{ steps.current-date.outputs.date }}"
-                      repositoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.id }}
-                      categoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.discussionCategory.id }}
-                  query: |
-                      mutation CreateDiscussionMutation ($title: String!, $body: String!, $repositoryId: ID!, $categoryId: ID!) {
-                        createDiscussion(input: { title: $title, body: $body, repositoryId: $repositoryId, categoryId: $categoryId }) {
-                          discussion {
-                            title
-                          }
+          - name: Create repository discussion
+            id: create-repository-discussion
+            uses: octokit/graphql-action@v2.x
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            with:
+                variables: |
+                    body: "<b>Please add agenda items below and give your monthly update in a comment. Thank you!</b><br/><h2>Agenda</h2>"
+                    title: "Monthly Sync - ${{ steps.current-date.outputs.date }}"
+                    repositoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.id }}
+                    categoryId: ${{ fromJSON(steps.get-repository-info.outputs.data).repository.discussionCategory.id }}
+                query: |
+                    mutation CreateDiscussionMutation ($title: String!, $body: String!, $repositoryId: ID!, $categoryId: ID!) {
+                      createDiscussion(input: { title: $title, body: $body, repositoryId: $repositoryId, categoryId: $categoryId }) {
+                        discussion {
+                          title
                         }
                       }
+                    }
 
-            - name: Discussion successfully created
-              run: echo "Created discussion '${{ fromJSON(steps.create-repository-discussion.outputs.data).createDiscussion.discussion.title }}'"
+          - name: Discussion successfully created
+            run: echo "Created discussion '${{ fromJSON(steps.create-repository-discussion.outputs.data).createDiscussion.discussion.title }}'"

--- a/.github/workflows/create_monthly_sync.yml
+++ b/.github/workflows/create_monthly_sync.yml
@@ -3,7 +3,7 @@ name: Create Monthly Sync discussion
 # First Wednesday of every month at 12AM UTC
 on:
     schedule:
-        - cron: "0 0 1-7 * 3"
+        - cron: "0 0 * * 3"
 
 jobs:
     create-discussion:


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Run job each Wednesday
- Checking if it's the first Wednesday of the month. If not, we skip creating the disscution.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
As GitHub actions uses an older standard for `cron`, it does not support setting the first Wednesday of every month.
So I set the `cron` to start on every Wednesday, and as a first step of the workflow we check if it's the first Wednesday of that month. If not, we skip the workflow.

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
