### PR TITLE
docs: update w/ user feedback

### DIFF
--- a/packages/documentation/src/content/docs/integration/requirements/webhook-events.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/webhook-events.mdx
@@ -162,7 +162,7 @@ To recreate the signed payload string, concatenate the following.
 - A period (.) character
 - The actual JSON payload from the request body, containing the `id`, `type`, and `data` attributes
 
-This string format is essential for accurate signature validation.
+This string format is essential for accurate signature validation. The webhook body must be JSON canonicalized before HMAC computation.
 
 ### Generate the expected signature
 


### PR DESCRIPTION
**Description of changes**

Received user feedback re: JSON canonicalization in webhook signature. Updated doc. No fixed #, no related Linear issue.

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
