### PR TITLE
feat(backend): soft delete expired incoming payments with no funds

### DIFF
--- a/packages/backend/migrations/20260609123924_add_deleted_at_to_incoming_payment.js
+++ b/packages/backend/migrations/20260609123924_add_deleted_at_to_incoming_payment.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('incomingPayments', function (table) {
+    table.timestamp('deletedAt').nullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('incomingPayments', function (table) {
+    table.dropColumn('deletedAt')
+  })
+}

--- a/packages/backend/src/open_payments/payment/incoming/model.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.ts
@@ -104,6 +104,7 @@ export class IncomingPayment
   public processAt!: Date | null
   public approvedAt?: Date | null
   public cancelledAt?: Date | null
+  public deletedAt?: Date | null
   public initiatedBy!: IncomingPaymentInitiationReason
 
   public readonly assetId!: string

--- a/packages/backend/src/open_payments/payment/incoming/model.ts
+++ b/packages/backend/src/open_payments/payment/incoming/model.ts
@@ -48,6 +48,7 @@ export interface IncomingPaymentResponse {
   metadata?: Record<string, unknown>
   approvedAt?: string
   cancelledAt?: string
+  deletedAt?: string
 }
 
 export type IncomingPaymentData = IncomingPaymentResponse &
@@ -218,6 +219,9 @@ export class IncomingPayment
     }
     if (this.cancelledAt) {
       data.cancelledAt = new Date(this.cancelledAt).toISOString()
+    }
+    if (this.deletedAt) {
+      data.deletedAt = new Date(this.deletedAt).toISOString()
     }
 
     return data

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -815,6 +815,21 @@ describe('Incoming Payment Service', (): void => {
         ).resolves.toBeUndefined()
 
         await expect(
+          incomingPaymentService.update({
+            id: incomingPayment.id,
+            tenantId: Config.operatorTenantId,
+            metadata: {}
+          })
+        ).resolves.toBe(IncomingPaymentError.UnknownPayment)
+
+        await expect(
+          incomingPaymentService.complete(
+            incomingPayment.id,
+            Config.operatorTenantId
+          )
+        ).resolves.toBe(IncomingPaymentError.UnknownPayment)
+
+        await expect(
           incomingPaymentService.getPage({
             walletAddressId
           })

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -818,9 +818,9 @@ describe('Incoming Payment Service', (): void => {
           knex
         ).findById(incomingPayment.id)
         expect(softDeletedIncomingPayment).toBeDefined()
-        expect(softDeletedIncomingPayment?.deletedAt).toBeLessThanOrEqual(
-          Date.now()
-        )
+        expect(softDeletedIncomingPayment).toMatchObject({
+          deletedAt: expect.any(Date)
+        })
       })
     })
 

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -785,7 +785,7 @@ describe('Incoming Payment Service', (): void => {
         })
       })
 
-      test('Deletes an expired incoming payment (and account) with no money', async (): Promise<void> => {
+      test('Soft deletes an expired incoming payment with no money', async (): Promise<void> => {
         const incomingPayment = await createIncomingPayment(deps, {
           walletAddressId,
           incomingAmount: {
@@ -806,11 +806,21 @@ describe('Incoming Payment Service', (): void => {
         await expect(incomingPaymentService.processNext()).resolves.toBe(
           incomingPayment.id
         )
-        expect(
-          await incomingPaymentService.get({
+
+        // soft-deteleted records should not appear via normal service lookup
+        await expect(
+          incomingPaymentService.get({
             id: incomingPayment.id
           })
-        ).toBeUndefined()
+        ).resolves.toBeUndefined()
+
+        const softDeletedIncomingPayment = await IncomingPayment.query(
+          knex
+        ).findById(incomingPayment.id)
+        expect(softDeletedIncomingPayment).toBeDefined()
+        expect(softDeletedIncomingPayment?.deletedAt).toBeLessThanOrEqual(
+          Date.now()
+        )
       })
     })
 

--- a/packages/backend/src/open_payments/payment/incoming/service.test.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.test.ts
@@ -814,6 +814,13 @@ describe('Incoming Payment Service', (): void => {
           })
         ).resolves.toBeUndefined()
 
+        await expect(
+          incomingPaymentService.getPage({
+            walletAddressId
+          })
+        ).resolves.toHaveLength(0)
+
+        // confirm the row still exists with deletedAt set
         const softDeletedIncomingPayment = await IncomingPayment.query(
           knex
         ).findById(incomingPayment.id)

--- a/packages/backend/src/open_payments/payment/incoming/service.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.ts
@@ -155,9 +155,9 @@ async function updateIncomingPayment(
   deps: ServiceDependencies,
   options: UpdateOptions
 ): Promise<IncomingPayment | IncomingPaymentError> {
-  const incomingPayment = await IncomingPayment.query(
-    deps.knex
-  ).patchAndFetchById(options.id, options)
+  const incomingPayment = await IncomingPayment.query(deps.knex)
+    .patchAndFetchById(options.id, options)
+    .whereNull('deletedAt')
   if (incomingPayment) {
     const asset = await deps.assetService.get(incomingPayment.assetId)
     if (asset) incomingPayment.asset = asset
@@ -372,7 +372,10 @@ async function handleExpired(
       processAt: new Date()
     })
   } else {
-    deps.logger.debug({ amountReceived }, 'deleting expired incoming payment')
+    deps.logger.debug(
+      { amountReceived },
+      'soft deleting expired incoming payment'
+    )
     await incomingPayment.$query(deps.knex).patch({
       state: IncomingPaymentState.Expired,
       deletedAt: new Date(),
@@ -534,6 +537,7 @@ async function completeIncomingPayment(
   return deps.knex.transaction(async (trx) => {
     const payment = await IncomingPayment.query(trx)
       .findOne({ id, ...(tenantId && { tenantId }) })
+      .whereNull('deletedAt')
       .forUpdate()
     if (!payment) return IncomingPaymentError.UnknownPayment
 

--- a/packages/backend/src/open_payments/payment/incoming/service.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.ts
@@ -375,7 +375,8 @@ async function handleExpired(
     deps.logger.debug({ amountReceived }, 'deleting expired incoming payment')
     await incomingPayment.$query(deps.knex).patch({
       state: IncomingPaymentState.Expired,
-      deletedAt: new Date()
+      deletedAt: new Date(),
+      processAt: null
     })
   }
 }
@@ -750,7 +751,7 @@ async function getPage(
 ): Promise<IncomingPayment[]> {
   const { filter, pagination, sortOrder, tenantId, walletAddressId, client } =
     options ?? {}
-  const query = IncomingPayment.query(deps.knex)
+  const query = IncomingPayment.query(deps.knex).whereNull('deletedAt')
 
   if (tenantId) {
     query.where('tenantId', tenantId)

--- a/packages/backend/src/open_payments/payment/incoming/service.ts
+++ b/packages/backend/src/open_payments/payment/incoming/service.ts
@@ -134,7 +134,9 @@ async function getIncomingPayment(
   deps: ServiceDependencies,
   options: GetOptions
 ): Promise<IncomingPayment | undefined> {
-  const incomingPayment = await IncomingPayment.query(deps.knex).get(options)
+  const incomingPayment = await IncomingPayment.query(deps.knex)
+    .get(options)
+    .whereNull('deletedAt')
   if (!incomingPayment) {
     return
   }
@@ -371,7 +373,10 @@ async function handleExpired(
     })
   } else {
     deps.logger.debug({ amountReceived }, 'deleting expired incoming payment')
-    await incomingPayment.$query(deps.knex).delete()
+    await incomingPayment.$query(deps.knex).patch({
+      state: IncomingPaymentState.Expired,
+      deletedAt: new Date()
+    })
   }
 }
 


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Add deletedAt to the incoming payments model
- In the IncomingPaymentService.handleExpired method, set deletedAt field instead of deleting the record and set the state to expired and processAt to null so that it is not processed by another worker.
- Updated IncomingPaymentData type so that IncomingPaymentEvents have all metadata for WebHook

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Fixes RAF-1224

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
