### PR TITLE
Add healthz to forbidden wallet address paths

### DIFF
--- a/packages/backend/src/open_payments/wallet_address/service.ts
+++ b/packages/backend/src/open_payments/wallet_address/service.ts
@@ -136,6 +136,7 @@ export async function createWalletAddressService({
 }
 
 export const FORBIDDEN_PATHS = [
+  '/healthz',
   '/incoming-payments',
   '/outgoing-payments',
   '/quotes'


### PR DESCRIPTION
## Summary
- Add /healthz to the wallet address forbidden path list
- Prevent health check endpoints from being used as wallet addresses

## Testing
- Not run locally: this environment does not have pnpm/corepack available, though the existing FORBIDDEN_PATHS parameterized service test covers the new path.

Fixes #3640