### PR TITLE
docs: add robots.txt to allow all crawlers

### DIFF
--- a/packages/documentation/public/robots.txt
+++ b/packages/documentation/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
**Description of changes**
Adds robots.txt to docs/public so the file is served at rafiki.dev/robots.txt after build and deploy

Currently, the site returns a 404 for /robots.txt. While crawlers interpret a missing robots.txt as "allow everything", having the file in place is a much better practice and resolves the 404 error.

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
