### PR TITLE
fix(backend): isolate tenant auth on per-request GraphQL context

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -107,11 +107,12 @@ import { LocalPaymentService } from './payment-method/local/service'
 import { GrantService } from './open_payments/grant/service'
 import { AuthServerService } from './open_payments/authServer/service'
 import { Tenant } from './tenants/model'
-import {
-  getTenantFromApiSignature,
-  TenantApiSignatureResult
-} from './shared/utils'
 import { TenantService } from './tenants/service'
+import {
+  authenticatedTenantMiddleware,
+  createTenantedApolloContext,
+  unauthenticatedTenantMiddleware
+} from './tenants/middleware'
 import { AuthServiceClient } from './auth-service-client/client'
 import { TenantSettingService } from './tenants/settings/service'
 import { StreamCredentialsService } from './payment-method/ilp/stream-credentials/service'
@@ -233,6 +234,14 @@ type ContextType<T> = T extends (
   : never
 
 const WALLET_ADDRESS_PATH = '/:walletAddressPath+'
+
+export interface TenantedAppContext extends AppContext {
+  // Unset when a test request carries no tenant-id header
+  tenantApiSignatureResult?: {
+    tenant: Tenant
+    isOperator: boolean
+  }
+}
 
 export interface TenantedApolloContext extends ApolloContext {
   tenant: Tenant
@@ -428,62 +437,21 @@ export class App {
       }
     )
 
-    let tenantApiSignatureResult: TenantApiSignatureResult
-    const tenantSignatureMiddleware = async (
-      ctx: AppContext,
-      next: Koa.Next
-    ): Promise<void> => {
-      const result = await getTenantFromApiSignature(ctx, this.config)
-      if (!result) {
-        ctx.throw(401, 'Unauthorized')
-      } else {
-        tenantApiSignatureResult = {
-          tenant: result.tenant,
-          isOperator: result.isOperator ? true : false
-        }
-      }
-      return next()
-    }
-
-    const testTenantSignatureMiddleware = async (
-      ctx: AppContext,
-      next: Koa.Next
-    ): Promise<void> => {
-      if (ctx.headers['tenant-id']) {
-        const tenantService = await ctx.container.use('tenantService')
-        const tenant = await tenantService.get(
-          ctx.headers['tenant-id'] as string
-        )
-
-        if (tenant) {
-          tenantApiSignatureResult = {
-            tenant,
-            isOperator: tenant.apiSecret === this.config.adminApiSecret
-          }
-        } else {
-          ctx.throw(401, 'Unauthorized')
-        }
-      }
-      return next()
-    }
-
     // For tests, we still need to get the tenant in the middleware, but
     // we don't need to verify the signature nor prevent replay attacks
     koa.use(
       this.config.env !== 'test'
-        ? tenantSignatureMiddleware
-        : testTenantSignatureMiddleware
+        ? authenticatedTenantMiddleware
+        : unauthenticatedTenantMiddleware
     )
 
     koa.use(
       koaMiddleware(this.apolloServer, {
-        context: async (): Promise<TenantedApolloContext> => {
-          return {
-            ...tenantApiSignatureResult,
-            container: this.container,
-            logger: await this.container.use('logger')
-          }
-        }
+        context: async ({
+          ctx
+        }: {
+          ctx: TenantedAppContext
+        }): Promise<TenantedApolloContext> => createTenantedApolloContext(ctx)
       })
     )
 

--- a/packages/backend/src/graphql/errors/index.ts
+++ b/packages/backend/src/graphql/errors/index.ts
@@ -6,5 +6,6 @@ export enum GraphQLErrorCode {
   InternalServerError = 'INTERNAL_SERVER_ERROR',
   NotFound = 'NOT_FOUND',
   Conflict = 'CONFLICT',
-  Timeout = 'TIMEOUT'
+  Timeout = 'TIMEOUT',
+  Unauthenticated = 'UNAUTHENTICATED'
 }

--- a/packages/backend/src/tenants/middleware.test.ts
+++ b/packages/backend/src/tenants/middleware.test.ts
@@ -1,0 +1,352 @@
+import crypto from 'node:crypto'
+import { IocContract } from '@adonisjs/fold'
+import { faker } from '@faker-js/faker'
+import { GraphQLError } from 'graphql'
+import { Redis } from 'ioredis'
+import { Logger } from 'pino'
+import { v4 as uuid } from 'uuid'
+
+import { initIocContainer } from '..'
+import { AppServices, TenantedAppContext } from '../app'
+import { Config } from '../config/app'
+import { GraphQLErrorCode } from '../graphql/errors'
+import { generateApiSignature } from '../tests/apiSignature'
+import { TestContainer, createTestApp } from '../tests/app'
+import { createContext } from '../tests/context'
+import { truncateTables } from '../tests/tableManager'
+import { Tenant } from './model'
+import { TenantService } from './service'
+import {
+  authenticatedTenantMiddleware,
+  createTenantedApolloContext,
+  unauthenticatedTenantMiddleware
+} from './middleware'
+
+describe('Tenant signature middleware', (): void => {
+  let deps: IocContract<AppServices>
+  let appContainer: TestContainer
+  let tenantService: TenantService
+  let logger: Logger
+  let redis: Redis
+  let tenant: Tenant
+  let operator: Tenant
+
+  const operatorApiSecret = crypto.randomBytes(8).toString('base64')
+  const requestBody = { test: 'value' }
+
+  const createTenantedContext = (
+    headers: Record<string, string>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any = requestBody
+  ): TenantedAppContext => {
+    const ctx = createContext<TenantedAppContext>(
+      {
+        headers: { Accept: 'application/json', ...headers },
+        url: '/graphql'
+      },
+      {},
+      appContainer.container
+    )
+    // createKoaServer sets this on every request ctx
+    ctx.logger = logger
+    ctx.request.body = body
+    return ctx
+  }
+
+  const createTenant = async (apiSecret: string): Promise<Tenant> =>
+    Tenant.query(appContainer.knex).insertAndFetch({
+      email: faker.internet.email(),
+      publicName: faker.company.name(),
+      apiSecret,
+      idpConsentUrl: faker.internet.url(),
+      idpSecret: 'test-idp-secret'
+    })
+
+  beforeAll(async (): Promise<void> => {
+    deps = initIocContainer({
+      ...Config,
+      adminApiSecret: operatorApiSecret
+    })
+    appContainer = await createTestApp(deps)
+    tenantService = await deps.use('tenantService')
+    logger = await deps.use('logger')
+    redis = await deps.use('redis')
+  })
+
+  beforeEach(async (): Promise<void> => {
+    tenant = await createTenant(crypto.randomBytes(8).toString('base64'))
+    operator = await createTenant(operatorApiSecret)
+  })
+
+  afterEach(async (): Promise<void> => {
+    await redis.flushall()
+    await truncateTables(deps)
+  })
+
+  afterAll(async (): Promise<void> => {
+    await appContainer.shutdown()
+  })
+
+  describe('authenticatedTenantMiddleware', (): void => {
+    test.each`
+      isOperator | description
+      ${false}   | ${'tenanted non-operator'}
+      ${true}    | ${'tenanted operator'}
+    `(
+      'stores the tenant on the request context for a $description request',
+      async ({ isOperator }): Promise<void> => {
+        const expectedTenant = isOperator ? operator : tenant
+        const ctx = createTenantedContext({
+          signature: generateApiSignature(
+            expectedTenant.apiSecret,
+            Config.adminApiSignatureVersion,
+            requestBody
+          ),
+          'tenant-id': expectedTenant.id
+        })
+
+        const next = jest.fn()
+
+        await expect(
+          authenticatedTenantMiddleware(ctx, next)
+        ).resolves.toBeUndefined()
+
+        expect(ctx.tenantApiSignatureResult).toEqual({
+          tenant: expectedTenant,
+          isOperator
+        })
+        expect(next).toHaveBeenCalled()
+      }
+    )
+
+    test("throws 401 when the signature isn't signed with the tenant secret", async (): Promise<void> => {
+      const ctx = createTenantedContext({
+        signature: generateApiSignature(
+          'wrongsecret',
+          Config.adminApiSignatureVersion,
+          requestBody
+        ),
+        'tenant-id': tenant.id
+      })
+
+      const next = jest.fn()
+      const ctxThrowSpy = jest.spyOn(ctx, 'throw')
+
+      await expect(authenticatedTenantMiddleware(ctx, next)).rejects.toThrow()
+      expect(ctxThrowSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(ctx.tenantApiSignatureResult).toBeUndefined()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test('throws 401 when the tenant id is not included', async (): Promise<void> => {
+      const ctx = createTenantedContext({
+        signature: generateApiSignature(
+          tenant.apiSecret,
+          Config.adminApiSignatureVersion,
+          requestBody
+        )
+      })
+
+      const next = jest.fn()
+      const ctxThrowSpy = jest.spyOn(ctx, 'throw')
+
+      await expect(authenticatedTenantMiddleware(ctx, next)).rejects.toThrow()
+      expect(ctxThrowSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test('throws 401 when the signature is not included', async (): Promise<void> => {
+      const ctx = createTenantedContext({ 'tenant-id': tenant.id })
+
+      const next = jest.fn()
+      const ctxThrowSpy = jest.spyOn(ctx, 'throw')
+
+      await expect(authenticatedTenantMiddleware(ctx, next)).rejects.toThrow()
+      expect(ctxThrowSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test('throws 401 when the tenant does not exist', async (): Promise<void> => {
+      const ctx = createTenantedContext({
+        signature: generateApiSignature(
+          tenant.apiSecret,
+          Config.adminApiSignatureVersion,
+          requestBody
+        ),
+        'tenant-id': uuid()
+      })
+
+      const next = jest.fn()
+      const ctxThrowSpy = jest.spyOn(ctx, 'throw')
+
+      await expect(authenticatedTenantMiddleware(ctx, next)).rejects.toThrow()
+      expect(ctxThrowSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    test('throws 401 when the signature is replayed', async (): Promise<void> => {
+      const headers = {
+        signature: generateApiSignature(
+          tenant.apiSecret,
+          Config.adminApiSignatureVersion,
+          requestBody
+        ),
+        'tenant-id': tenant.id
+      }
+
+      await expect(
+        authenticatedTenantMiddleware(createTenantedContext(headers), jest.fn())
+      ).resolves.toBeUndefined()
+
+      const replayedCtx = createTenantedContext(headers)
+      const next = jest.fn()
+      const ctxThrowSpy = jest.spyOn(replayedCtx, 'throw')
+
+      await expect(
+        authenticatedTenantMiddleware(replayedCtx, next)
+      ).rejects.toThrow()
+      expect(ctxThrowSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unauthenticatedTenantMiddleware', (): void => {
+    test.each`
+      isOperator | description
+      ${false}   | ${'tenanted non-operator'}
+      ${true}    | ${'tenanted operator'}
+    `(
+      'stores the tenant on the request context for a $description request',
+      async ({ isOperator }): Promise<void> => {
+        const expectedTenant = isOperator ? operator : tenant
+        const ctx = createTenantedContext({
+          'tenant-id': expectedTenant.id
+        })
+
+        const next = jest.fn()
+
+        await expect(
+          unauthenticatedTenantMiddleware(ctx, next)
+        ).resolves.toBeUndefined()
+
+        expect(ctx.tenantApiSignatureResult).toEqual({
+          tenant: expectedTenant,
+          isOperator
+        })
+        expect(next).toHaveBeenCalled()
+      }
+    )
+
+    test('leaves the request untenanted when no tenant id is provided', async (): Promise<void> => {
+      const ctx = createTenantedContext({})
+
+      const next = jest.fn()
+      const tenantGetSpy = jest.spyOn(tenantService, 'get')
+
+      await expect(
+        unauthenticatedTenantMiddleware(ctx, next)
+      ).resolves.toBeUndefined()
+
+      expect(ctx.tenantApiSignatureResult).toBeUndefined()
+      expect(tenantGetSpy).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalled()
+    })
+
+    test('throws 401 when the tenant does not exist', async (): Promise<void> => {
+      const ctx = createTenantedContext({ 'tenant-id': uuid() })
+
+      const next = jest.fn()
+      const ctxThrowSpy = jest.spyOn(ctx, 'throw')
+
+      await expect(unauthenticatedTenantMiddleware(ctx, next)).rejects.toThrow()
+      expect(ctxThrowSpy).toHaveBeenCalledWith(401, 'Unauthorized')
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('createTenantedApolloContext', (): void => {
+    test.each`
+      isOperator | description
+      ${false}   | ${'tenanted non-operator'}
+      ${true}    | ${'tenanted operator'}
+    `(
+      'builds the Apollo context from a $description request',
+      async ({ isOperator }): Promise<void> => {
+        const expectedTenant = isOperator ? operator : tenant
+        const ctx = createTenantedContext({
+          'tenant-id': expectedTenant.id
+        })
+
+        await unauthenticatedTenantMiddleware(ctx, jest.fn())
+
+        expect(createTenantedApolloContext(ctx)).toEqual({
+          tenant: expectedTenant,
+          isOperator,
+          container: appContainer.container,
+          logger
+        })
+      }
+    )
+
+    test('throws an unauthenticated error when the request is untenanted', async (): Promise<void> => {
+      const ctx = createTenantedContext({})
+
+      await unauthenticatedTenantMiddleware(ctx, jest.fn())
+      expect(ctx.tenantApiSignatureResult).toBeUndefined()
+
+      let error: unknown
+      try {
+        createTenantedApolloContext(ctx)
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(GraphQLError)
+      expect(error).toMatchObject({
+        message: 'Unauthorized',
+        extensions: {
+          code: GraphQLErrorCode.Unauthenticated
+        }
+      })
+    })
+  })
+
+  describe('per-request tenant isolation', (): void => {
+    // Regression: the tenant was once held in one variable shared by every request
+    test('keeps concurrent requests tenanted to their own tenant', async (): Promise<void> => {
+      const otherTenant = await createTenant(
+        crypto.randomBytes(8).toString('base64')
+      )
+
+      const contexts = [tenant, otherTenant, operator].map((requestTenant) =>
+        createTenantedContext({
+          signature: generateApiSignature(
+            requestTenant.apiSecret,
+            Config.adminApiSignatureVersion,
+            requestBody
+          ),
+          'tenant-id': requestTenant.id
+        })
+      )
+
+      await Promise.all(
+        contexts.map((ctx) => authenticatedTenantMiddleware(ctx, jest.fn()))
+      )
+
+      const apolloContexts = contexts.map((ctx) =>
+        createTenantedApolloContext(ctx)
+      )
+
+      expect(
+        apolloContexts.map((apolloCtx) => ({
+          tenantId: apolloCtx.tenant.id,
+          isOperator: apolloCtx.isOperator
+        }))
+      ).toEqual([
+        { tenantId: tenant.id, isOperator: false },
+        { tenantId: otherTenant.id, isOperator: false },
+        { tenantId: operator.id, isOperator: true }
+      ])
+    })
+  })
+})

--- a/packages/backend/src/tenants/middleware.ts
+++ b/packages/backend/src/tenants/middleware.ts
@@ -1,0 +1,64 @@
+import Koa from 'koa'
+import { GraphQLError } from 'graphql'
+import { TenantedApolloContext, TenantedAppContext } from '../app'
+import { GraphQLErrorCode } from '../graphql/errors'
+import { getTenantFromApiSignature } from '../shared/utils'
+
+export async function authenticatedTenantMiddleware(
+  ctx: TenantedAppContext,
+  next: Koa.Next
+): Promise<void> {
+  const config = await ctx.container.use('config')
+  const result = await getTenantFromApiSignature(ctx, config)
+  if (!result) {
+    ctx.throw(401, 'Unauthorized')
+  } else {
+    ctx.tenantApiSignatureResult = {
+      tenant: result.tenant,
+      isOperator: result.isOperator
+    }
+  }
+  return next()
+}
+
+// Used in test environment only
+export async function unauthenticatedTenantMiddleware(
+  ctx: TenantedAppContext,
+  next: Koa.Next
+): Promise<void> {
+  if (ctx.headers['tenant-id']) {
+    const config = await ctx.container.use('config')
+    const tenantService = await ctx.container.use('tenantService')
+    const tenant = await tenantService.get(ctx.headers['tenant-id'] as string)
+
+    if (tenant) {
+      ctx.tenantApiSignatureResult = {
+        tenant,
+        isOperator: tenant.apiSecret === config.adminApiSecret
+      }
+    } else {
+      ctx.throw(401, 'Unauthorized')
+    }
+  }
+  return next()
+}
+
+// Tenant comes off the request ctx, so requests never share a tenant
+export function createTenantedApolloContext(
+  ctx: TenantedAppContext
+): TenantedApolloContext {
+  if (!ctx.tenantApiSignatureResult) {
+    // Test env only: authenticatedTenantMiddleware already throws 401
+    throw new GraphQLError('Unauthorized', {
+      extensions: {
+        code: GraphQLErrorCode.Unauthenticated
+      }
+    })
+  }
+
+  return {
+    ...ctx.tenantApiSignatureResult,
+    container: ctx.container,
+    logger: ctx.logger
+  }
+}


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
- Fix a race where Backend Admin GraphQL requests shared a single tenant auth result across concurrent requests
- Store tenant auth on the per-request Koa `ctx` and build Apollo context from that `ctx` (same pattern as the auth service)
- Add middleware/context unit tests, including a concurrent isolation regression
- Add `GraphQLErrorCode.Unauthenticated` for untenanted test-env requests
## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Under concurrent load (e.g. many parallel `createTenant` calls), some operator requests failed with GraphQL `permission denied`. Auth was held in a shared variable in `startAdminServer`, so one request could overwrite another’s `isOperator` / tenant before Apollo built its context.


## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
