### PR TITLE
fix(backend): require HTTP message signature on GET /outgoing-payment-grant

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -52,7 +52,8 @@ import {
 import { QuoteService } from './open_payments/quote/service'
 import {
   OutgoingPaymentRoutes,
-  CreateBody as OutgoingCreateBody
+  CreateBody as OutgoingCreateBody,
+  SignedGrantContext
 } from './open_payments/payment/outgoing/routes'
 import { OutgoingPaymentService } from './open_payments/payment/outgoing/service'
 import { IlpPlugin, IlpPluginOptions } from './payment-method/ilp/ilp_plugin'
@@ -725,10 +726,14 @@ export class App {
     // GET /outgoing-payment-grant
     // Get grant spent amounts (scoped to interval, if any) from grant
     // with outgoing payment create access
-    router.get(
+    router.get<DefaultState, SignedGrantContext>(
       '/:tenantId/outgoing-payment-grant',
       // Expects token used for outgoing payment payment creation
       createOutgoingPaymentGrantTokenIntrospectionMiddleware(),
+      // Every other token-protected Open Payments route pairs introspection
+      // with HTTP message signature verification; possession of the access
+      // token alone is not supposed to be sufficient to call this endpoint.
+      httpsigMiddleware,
       outgoingPaymentRoutes.getGrantSpentAmounts
     )
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -730,9 +730,6 @@ export class App {
       '/:tenantId/outgoing-payment-grant',
       // Expects token used for outgoing payment payment creation
       createOutgoingPaymentGrantTokenIntrospectionMiddleware(),
-      // Every other token-protected Open Payments route pairs introspection
-      // with HTTP message signature verification; possession of the access
-      // token alone is not supposed to be sufficient to call this endpoint.
       httpsigMiddleware,
       outgoingPaymentRoutes.getGrantSpentAmounts
     )

--- a/packages/backend/src/open_payments/auth/middleware.test.ts
+++ b/packages/backend/src/open_payments/auth/middleware.test.ts
@@ -1198,7 +1198,7 @@ describe('introspect', () => {
           ]
         })
         // httpsigMiddleware (applied on the route) resolves the caller's key
-        // from ctx.client, matching every sibling token-protected route.
+        // from ctx.client
         expect(ctx.client).toEqual(client)
         expect(next).toHaveBeenCalled()
       }

--- a/packages/backend/src/open_payments/auth/middleware.test.ts
+++ b/packages/backend/src/open_payments/auth/middleware.test.ts
@@ -1197,6 +1197,9 @@ describe('introspect', () => {
             }
           ]
         })
+        // httpsigMiddleware (applied on the route) resolves the caller's key
+        // from ctx.client, matching every sibling token-protected route.
+        expect(ctx.client).toEqual(client)
         expect(next).toHaveBeenCalled()
       }
     )

--- a/packages/backend/src/open_payments/auth/middleware.ts
+++ b/packages/backend/src/open_payments/auth/middleware.ts
@@ -147,6 +147,10 @@ export function createOutgoingPaymentGrantTokenIntrospectionMiddleware() {
 
       const access = tokenInfo.access[0]
 
+      // httpsigMiddleware resolves the caller's key from ctx.client; set it
+      // exactly as createTokenIntrospectionMiddleware does for every sibling
+      // route.
+      ctx.client = tokenInfo.client
       ctx.grant = {
         id: tokenInfo.grant,
         limits:

--- a/packages/backend/src/open_payments/auth/middleware.ts
+++ b/packages/backend/src/open_payments/auth/middleware.ts
@@ -147,9 +147,7 @@ export function createOutgoingPaymentGrantTokenIntrospectionMiddleware() {
 
       const access = tokenInfo.access[0]
 
-      // httpsigMiddleware resolves the caller's key from ctx.client; set it
-      // exactly as createTokenIntrospectionMiddleware does for every sibling
-      // route.
+      // httpsigMiddleware resolves the caller's key from ctx.client
       ctx.client = tokenInfo.client
       ctx.grant = {
         id: tokenInfo.grant,

--- a/packages/backend/src/open_payments/payment/outgoing/routes.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/routes.ts
@@ -3,7 +3,8 @@ import {
   ReadContext,
   CreateContext,
   ListContext,
-  IntrospectionContext
+  IntrospectionContext,
+  HttpSigContext
 } from '../../../app'
 import { IAppConfig } from '../../../config/app'
 import {
@@ -87,6 +88,8 @@ async function getOutgoingPayment(
 export interface GrantContext extends IntrospectionContext {
   grant: { id: string; limits?: Limits }
 }
+
+export type SignedGrantContext = GrantContext & HttpSigContext
 
 async function getOutgoingPaymentGrantSpentAmounts(
   deps: ServiceDependencies,


### PR DESCRIPTION
## Problem

`GET /:tenantId/outgoing-payment-grant` is wired with exactly two handlers , `createOutgoingPaymentGrantTokenIntrospectionMiddleware()` and `outgoingPaymentRoutes.getGrantSpentAmounts` , while **every** sibling token-protected Open Payments route in the same router (incoming-payments create/list/get/complete, outgoing-payments create/list/get, quotes create/get) pairs its introspection middleware with `httpsigMiddleware`.

Open Payments binds the access token to the client's key and requires each request to carry an HTTP Message Signature, so possession of the token alone is not supposed to be sufficient. On this endpoint it was: a leaked GNAP access token for outgoing-payment create access could be replayed bearer-style, with no `Signature`/`Signature-Input` headers, to read the grant's spent debit and receive amounts , and the endpoint doubles as an oracle confirming a stolen token is still active.

The intended contract is visible in the repo itself: `bruno/collections/Rafiki/Open Payments APIs/Outgoing Payment Grant/Get Outgoing Payment Grant.bru` calls `scripts.addSignatureHeaders()` in its pre-request script , clients sign; the server just never verified.

## Fix

- Add `httpsigMiddleware` to the route, matching every sibling route.
- Set `ctx.client` from the introspection result in `createOutgoingPaymentGrantTokenIntrospectionMiddleware` (as `createTokenIntrospectionMiddleware` already does), which `httpsigMiddleware` needs to resolve the caller's key.
- Introduce `SignedGrantContext` (`GrantContext & HttpSigContext`) and type the route with it, so the wiring is checked at compile time.
- Extend the middleware's success-path test to assert `ctx.client` is populated.

## Verification

`tsc --noEmit` on the backend package is at exact parity with the unpatched baseline (10 pre-existing errors, none in touched files). Jest suites require the Postgres/Redis testcontainers environment, which isn't available here; the middleware success-path test was extended to cover the new `ctx.client` assignment.

If the omission was deliberate (e.g. the endpoint is considered low-sensitivity), happy to close, but the asymmetry with every sibling route and the repo's own signed client request suggest it was an oversight when the endpoint was added.
