### PR TITLE
fix: pass seconds (not ms) to Redis EXPIRE for admin signature replay cache

### DIFF
--- a/packages/auth/src/signature/tenant.test.ts
+++ b/packages/auth/src/signature/tenant.test.ts
@@ -253,6 +253,11 @@ describe('Tenant Middlewares', (): void => {
         authenticatedTenantMiddleware(ctx, jest.fn())
       ).resolves.toBeUndefined()
 
+      // Redis EXPIRE is in seconds; a ms/seconds mixup would leave TTL ≈ ttlSeconds*1000.
+      const ttl = await redis.ttl(`signature:${signature}`)
+      expect(ttl).toBeGreaterThan(0)
+      expect(ttl).toBeLessThanOrEqual(config.adminApiSignatureTtlSeconds)
+
       const next = jest.fn()
       const ctxThrowSpy = jest.spyOn(ctx, 'throw')
 

--- a/packages/auth/src/signature/tenant.ts
+++ b/packages/auth/src/signature/tenant.ts
@@ -55,7 +55,8 @@ async function canApiSignatureBeProcessed(
   const { timestamp } = getSignatureParts(signature)
   const signatureTime = Number(timestamp)
   const currentTime = Date.now()
-  const ttlMilliseconds = config.adminApiSignatureTtlSeconds * 1000
+  const ttlSeconds = config.adminApiSignatureTtlSeconds
+  const ttlMilliseconds = ttlSeconds * 1000
 
   if (currentTime - signatureTime > ttlMilliseconds) return false
 
@@ -65,7 +66,8 @@ async function canApiSignatureBeProcessed(
 
   const op = redis.multi()
   op.set(key, signature)
-  op.expire(key, ttlMilliseconds)
+  // Redis EXPIRE takes seconds (not milliseconds).
+  op.expire(key, ttlSeconds)
   await op.exec()
 
   return true

--- a/packages/backend/src/shared/utils.test.ts
+++ b/packages/backend/src/shared/utils.test.ts
@@ -272,6 +272,11 @@ describe('utils', (): void => {
         })
       ).resolves.toBe(true)
 
+      // Redis EXPIRE is in seconds; a ms/seconds mixup would leave TTL ≈ ttlSeconds*1000.
+      const ttl = await redis.ttl(`signature:${signature}`)
+      expect(ttl).toBeGreaterThan(0)
+      expect(ttl).toBeLessThanOrEqual(Config.adminApiSignatureTtlSeconds)
+
       const verified = await verifyApiSignature(ctx, {
         ...Config,
         adminApiSecret: 'test-secret'

--- a/packages/backend/src/shared/utils.ts
+++ b/packages/backend/src/shared/utils.ts
@@ -158,7 +158,8 @@ async function canApiSignatureBeProcessed(
   const { timestamp } = getSignatureParts(signature)
   const signatureTime = Number(timestamp)
   const currentTime = Date.now()
-  const ttlMilliseconds = config.adminApiSignatureTtlSeconds * 1000
+  const ttlSeconds = config.adminApiSignatureTtlSeconds
+  const ttlMilliseconds = ttlSeconds * 1000
 
   if (currentTime - signatureTime > ttlMilliseconds) return false
 
@@ -168,7 +169,8 @@ async function canApiSignatureBeProcessed(
 
   const op = redis.multi()
   op.set(key, signature)
-  op.expire(key, ttlMilliseconds)
+  // Redis EXPIRE takes seconds (not milliseconds).
+  op.expire(key, ttlSeconds)
   await op.exec()
 
   return true


### PR DESCRIPTION
## Problem

`canApiSignatureBeProcessed` (backend and auth) computes `ttlMilliseconds = adminApiSignatureTtlSeconds * 1000` for the `Date.now()` signature-age check, then passes that same value to `redis.expire`.

Redis [`EXPIRE`](https://redis.io/commands/expire/) takes **seconds**. With the default `ADMIN_API_SIGNATURE_TTL_SECONDS=30`, replay-cache keys were retained for ~30000 seconds (~8.3 hours) instead of 30 seconds.

Direction is fail-safe for replay protection (keys live longer than intended), but it causes unnecessary Redis memory retention under admin traffic. The auth session store already converts correctly (`expireInSec = maxAgeMs / 1000 + 10` in `auth/src/app.ts`).

## Fix

- Keep milliseconds for the wall-clock age check.
- Pass `ttlSeconds` to `redis.expire` in both packages.
- Extend the existing "already processed" tests to assert `redis.ttl(signature:…)` is within the configured second window (a ms/seconds mixup would leave TTL ≈ `ttlSeconds * 1000`).

## Verification

Local unit-mismatch repro (no Redis required): default 30s config → code previously passed `30000` to EXPIRE → 8.33h TTL. Full Jest suites need the Postgres/Redis testcontainers environment.

Made with [Cursor](https://cursor.com)