### PR TITLE
fix: use constant-time compare for admin/webhook HMAC digests

### DIFF
--- a/packages/auth/src/signature/tenant.ts
+++ b/packages/auth/src/signature/tenant.ts
@@ -26,6 +26,20 @@ interface VerifyApiSignatureArgs {
   apiSignatureVersion: number
 }
 
+
+function hmacHexDigestsEqual(expectedHex: string, providedHex: string): boolean {
+  const expected = Buffer.from(expectedHex, 'hex')
+  const provided = Buffer.from(providedHex, 'hex')
+  if (
+    expected.length === 0 ||
+    expected.length !== provided.length ||
+    expectedHex.length !== providedHex.length
+  ) {
+    return false
+  }
+  return crypto.timingSafeEqual(expected, provided)
+}
+
 function verifyApiSignatureDigest(args: VerifyApiSignatureArgs): boolean {
   const { signature, request, tenantApiSecret, apiSignatureVersion } = args
   const { body } = request
@@ -44,7 +58,7 @@ function verifyApiSignatureDigest(args: VerifyApiSignatureArgs): boolean {
   hmac.update(payload)
   const digest = hmac.digest('hex')
 
-  return digest === signatureDigest
+  return hmacHexDigestsEqual(digest, signatureDigest)
 }
 
 async function canApiSignatureBeProcessed(

--- a/packages/backend/src/shared/utils.ts
+++ b/packages/backend/src/shared/utils.ts
@@ -1,6 +1,6 @@
 import { validate, version } from 'uuid'
 import { URL, type URL as URLType } from 'url'
-import { createCipheriv, createHmac, randomBytes } from 'crypto'
+import { createCipheriv, createHmac, randomBytes, timingSafeEqual } from 'crypto'
 import { canonicalize } from 'json-canonicalize'
 import { IAppConfig } from '../config/app'
 import { AppContext, AppServices } from '../app'
@@ -125,6 +125,20 @@ function getSignatureParts(signature: string) {
   return { timestamp, version, digest }
 }
 
+function hmacHexDigestsEqual(expectedHex: string, providedHex: string): boolean {
+  const expected = Buffer.from(expectedHex, 'hex')
+  const provided = Buffer.from(providedHex, 'hex')
+  // Reject non-hex / length mismatch before timingSafeEqual (throws on unequal length).
+  if (
+    expected.length === 0 ||
+    expected.length !== provided.length ||
+    expectedHex.length !== providedHex.length
+  ) {
+    return false
+  }
+  return timingSafeEqual(expected, provided)
+}
+
 function verifyApiSignatureDigest(
   signature: string,
   request: AppContext['request'],
@@ -147,7 +161,7 @@ function verifyApiSignatureDigest(
   hmac.update(payload)
   const digest = hmac.digest('hex')
 
-  return digest === signatureDigest
+  return hmacHexDigestsEqual(digest, signatureDigest)
 }
 
 async function canApiSignatureBeProcessed(

--- a/packages/documentation/src/content/docs/integration/requirements/webhook-events.mdx
+++ b/packages/documentation/src/content/docs/integration/requirements/webhook-events.mdx
@@ -190,7 +190,16 @@ function verifyWebhookSignature(request: Request): boolean {
   const hmac = createHmac('sha256', config['SIGNATURE_SECRET'])
   hmac.update(payload)
   const digest = hmac.digest('hex')
-  return digest === signatureDigest
+  const expected = Buffer.from(digest, 'hex')
+  const provided = Buffer.from(signatureDigest, 'hex')
+  if (
+    expected.length === 0 ||
+    expected.length !== provided.length ||
+    digest.length !== signatureDigest.length
+  ) {
+    return false
+  }
+  return require('crypto').timingSafeEqual(expected, provided)
 }
 ```
 

--- a/packages/documentation/src/content/docs/v1-beta/integration/requirements/webhook-events.mdx
+++ b/packages/documentation/src/content/docs/v1-beta/integration/requirements/webhook-events.mdx
@@ -194,7 +194,16 @@ function verifyWebhookSignature(request: Request): boolean {
   const hmac = createHmac('sha256', config['SIGNATURE_SECRET'])
   hmac.update(payload)
   const digest = hmac.digest('hex')
-  return digest === signatureDigest
+  const expected = Buffer.from(digest, 'hex')
+  const provided = Buffer.from(signatureDigest, 'hex')
+  if (
+    expected.length === 0 ||
+    expected.length !== provided.length ||
+    digest.length !== signatureDigest.length
+  ) {
+    return false
+  }
+  return require('crypto').timingSafeEqual(expected, provided)
 }
 ```
 

--- a/packages/point-of-sale/src/webhook-handlers/middleware.ts
+++ b/packages/point-of-sale/src/webhook-handlers/middleware.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto'
+import { createHmac, timingSafeEqual } from 'crypto'
 import { canonicalize } from 'json-canonicalize'
 import { AppContext } from '../app'
 
@@ -10,6 +10,20 @@ function getSignatureParts(signature: string) {
   const digest = signatureVersionAndDigest[1]
 
   return { timestamp, version, digest }
+}
+
+
+function hmacHexDigestsEqual(expectedHex: string, providedHex: string): boolean {
+  const expected = Buffer.from(expectedHex, 'hex')
+  const provided = Buffer.from(providedHex, 'hex')
+  if (
+    expected.length === 0 ||
+    expected.length !== provided.length ||
+    expectedHex.length !== providedHex.length
+  ) {
+    return false
+  }
+  return timingSafeEqual(expected, provided)
 }
 
 function verifyWebhookSignatureDigest(
@@ -34,7 +48,7 @@ function verifyWebhookSignatureDigest(
   hmac.update(payload)
   const digest = hmac.digest('hex')
 
-  return digest === signatureDigest
+  return hmacHexDigestsEqual(digest, signatureDigest)
 }
 
 export async function webhookHttpSigMiddleware(


### PR DESCRIPTION
## Summary
- Admin/tenant API HMAC verification (`verifyApiSignatureDigest`) and POS webhook HMAC used `digest === signatureDigest` (non-constant-time string compare).
- IdP secret checks already use `crypto.timingSafeEqual`; align HMAC digest compares the same way (equal-length hex Buffers, fail closed on length/non-hex mismatch).
- Update webhook docs examples that already recommend constant-time compare but showed `===`.

Sibling surface to open #3963 (same auth/signature files; EXPIRE units).

## Test plan
- [x] Helper semantics checked with Node (`timingSafeEqual` equal/unequal/short/non-hex)
- [ ] `pnpm exec jest src/shared/utils.test.ts` / `packages/auth` tenant signature tests (needs Docker/testcontainers; not available in this agent environment)
- [ ] Confirm docs examples render

Made with [Cursor](https://cursor.com)