### PR TITLE
fix(frontend/Snackbar): announce correctly, pause timer on interaction

### DIFF
--- a/packages/frontend/app/components/Snackbar.tsx
+++ b/packages/frontend/app/components/Snackbar.tsx
@@ -1,7 +1,7 @@
 import { Transition } from '@headlessui/react'
 import { cx } from 'class-variance-authority'
 import type { FC } from 'react'
-import { Fragment, useEffect } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 import { type Message } from '~/lib/message.server'
 import { CheckCircleSolid, XIcon, XCircleSolid } from './icons'
 
@@ -19,7 +19,30 @@ interface SnackbarProps {
   dismissAfter?: number
 }
 
-export const Snackbar: FC<SnackbarProps> = ({
+export const Snackbar: FC<SnackbarProps> = (props) => (
+  <>
+    <SnackbarAnnouncer message={props.message} show={props.show} />
+    <SnackbarToast {...props} />
+  </>
+)
+
+// Live regions are only reliably announced by screen readers when the browser
+// already has the node registered and then content its changes.
+const SnackbarAnnouncer: FC<Pick<SnackbarProps, 'message' | 'show'>> = ({
+  message,
+  show = false
+}) => (
+  <div
+    role={message?.type === 'error' ? 'alert' : 'status'}
+    aria-live={message?.type === 'error' ? 'assertive' : 'polite'}
+    aria-atomic='true'
+    className='sr-only'
+  >
+    {show ? message?.content : ''}
+  </div>
+)
+
+const SnackbarToast: FC<SnackbarProps> = ({
   id,
   message,
   onClose,
@@ -27,14 +50,19 @@ export const Snackbar: FC<SnackbarProps> = ({
   show = false,
   dismissAfter
 }) => {
-  useEffect(() => {
-    let timer: NodeJS.Timeout
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const startTimer = () => {
     if (dismissAfter && show) {
-      timer = setTimeout(() => {
-        onClose()
-      }, dismissAfter)
+      timerRef.current = setTimeout(onClose, dismissAfter)
     }
-    return () => clearTimeout(timer)
+  }
+
+  const clearTimer = () => clearTimeout(timerRef.current)
+
+  useEffect(() => {
+    startTimer()
+    return clearTimer
   }, [dismissAfter, onClose, show])
 
   if (!message) return null
@@ -61,6 +89,10 @@ export const Snackbar: FC<SnackbarProps> = ({
           leaveTo='opacity-0 scale-95'
         >
           <div
+            onMouseEnter={clearTimer}
+            onMouseLeave={startTimer}
+            onFocus={clearTimer}
+            onBlur={startTimer}
             className={cx(
               'relative mx-4 flex w-full transform items-center justify-between space-x-3 overflow-hidden rounded-xl py-3 px-4 text-left align-middle shadow-lg transition-all sm:max-w-[22rem]',
               message.type === 'success' ? 'bg-green-500' : 'bg-white'
@@ -73,7 +105,9 @@ export const Snackbar: FC<SnackbarProps> = ({
               {message.type === 'error' && (
                 <XCircleSolid className='w-4 h-4 text-red-400 flex-shrink-0' />
               )}
+              {/* hidden here to avoid double narration (announced via SnackbarAnnouncer already) */}
               <p
+                aria-hidden='true'
                 className={cx(
                   'text',
                   message.type === 'success' ? 'text-white' : 'text-tealish'
@@ -83,6 +117,7 @@ export const Snackbar: FC<SnackbarProps> = ({
               </p>
             </div>
             <button
+              type='button'
               className={cx(
                 '-mr-2',
                 message.type === 'success'

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -134,6 +134,13 @@ export default function App() {
           >
             Skip to main content
           </a>
+          <Snackbar
+            id='snackbar'
+            onClose={() => setSnackbarOpen(false)}
+            show={snackbarOpen}
+            message={message}
+            dismissAfter={200000}
+          />
           <div className='min-h-full relative z-10'>
             {displaySidebar && (
               <Sidebar
@@ -153,13 +160,6 @@ export default function App() {
               </main>
             </div>
           </div>
-          <Snackbar
-            id='snackbar'
-            onClose={() => setSnackbarOpen(false)}
-            show={snackbarOpen}
-            message={message}
-            dismissAfter={2000}
-          />
         </Theme>
         <ScrollRestoration />
         <PublicEnv env={publicEnv} />

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -139,7 +139,7 @@ export default function App() {
             onClose={() => setSnackbarOpen(false)}
             show={snackbarOpen}
             message={message}
-            dismissAfter={2000}
+            dismissAfter={5000}
           />
           <div className='min-h-full relative z-10'>
             {displaySidebar && (

--- a/packages/frontend/app/root.tsx
+++ b/packages/frontend/app/root.tsx
@@ -139,7 +139,7 @@ export default function App() {
             onClose={() => setSnackbarOpen(false)}
             show={snackbarOpen}
             message={message}
-            dismissAfter={200000}
+            dismissAfter={2000}
           />
           <div className='min-h-full relative z-10'>
             {displaySidebar && (


### PR DESCRIPTION
<!--- Pull request titles should follow conventional commit format. -->

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Changes proposed in this pull request
<!--
Provide a succinct description of what this pull request entails.
-->
Multiple a11y fixes to Snackbar:
- Add accessible role and make sure it's reliably announced
- Ensure hide timer could be paused if user hovers (or focuses) over notification (it should stay, not disappear immediately if user is interacting). Also, increase timeout from 2s to 5s.
- Move Snackbar to start in tab-order, so one doesn't have to tab till end to interact with it (by that time, notification goes away)

In future, we can get rid of `SnackbarAnnouncer` when `ariaNotify` is better supported.

## Context
<!--
What were you trying to do?
Provide further details about how the feature should be tested/reviewed if necessary.
Link issues here -  using `fixes #number`
-->
Follow up of https://github.com/interledger/rafiki/pull/3961

## Checklist
<!--
Checklist items become clickable check boxes once the pull request is created. There is no need to edit them now.
-->

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added/updated
- [ ] Make sure that all checks pass
- [ ] Bruno collection updated (if necessary)
- [ ] Documentation issue created with `user-docs` label (if necessary)
- [ ] OpenAPI specs updated (if necessary)
